### PR TITLE
Consistent naming of input_statements for substacks 

### DIFF
--- a/blocks_horizontal/control.js
+++ b/blocks_horizontal/control.js
@@ -41,7 +41,7 @@ Blockly.Blocks['control_repeat'] = {
       "args0": [
         {
           "type": "input_statement",
-          "name": "DO"
+          "name": "SUBSTACK"
         },
         {
           "type": "field_image",
@@ -83,7 +83,7 @@ Blockly.Blocks['control_forever'] = {
       "args0": [
         {
           "type": "input_statement",
-          "name": "NAME"
+          "name": "SUBSTACK"
         },
         {
           "type": "field_image",


### PR DESCRIPTION
Fixes #77.

This is helpful for shaping the interpreter to handle statement inputs in a consistent way.
