### PR TITLE
Colour spec implementation, #98

### DIFF
--- a/blocks/math.js
+++ b/blocks/math.js
@@ -32,7 +32,7 @@ goog.require('Blockly.Blocks');
 /**
  * Common HSV hue for all blocks in this category.
  */
-Blockly.Blocks.math.HUE = 230;
+Blockly.Blocks.math.HUE = '#ffffff';
 
 Blockly.Blocks['math_number'] = {
   /**

--- a/blocks/math.js
+++ b/blocks/math.js
@@ -34,7 +34,7 @@ goog.require('Blockly.Colours');
 /**
  * Common HSV hue for all blocks in this category.
  */
-Blockly.Blocks.math.HUE = Blockly.Colours.text_field;
+Blockly.Blocks.math.HUE = Blockly.Colours.textField;
 
 Blockly.Blocks['math_number'] = {
   /**

--- a/blocks/math.js
+++ b/blocks/math.js
@@ -28,11 +28,13 @@ goog.provide('Blockly.Blocks.math');
 
 goog.require('Blockly.Blocks');
 
+goog.require('Blockly.Colours');
+
 
 /**
  * Common HSV hue for all blocks in this category.
  */
-Blockly.Blocks.math.HUE = '#ffffff';
+Blockly.Blocks.math.HUE = Blockly.Colours.text_field;
 
 Blockly.Blocks['math_number'] = {
   /**

--- a/blocks/text.js
+++ b/blocks/text.js
@@ -32,7 +32,7 @@ goog.require('Blockly.Blocks');
 /**
  * Common HSV hue for all blocks in this category.
  */
-Blockly.Blocks.texts.HUE = 160;
+Blockly.Blocks.texts.HUE = '#ffffff';
 
 Blockly.Blocks['text'] = {
   /**

--- a/blocks/text.js
+++ b/blocks/text.js
@@ -28,11 +28,13 @@ goog.provide('Blockly.Blocks.texts');
 
 goog.require('Blockly.Blocks');
 
+goog.require('Blockly.Colours');
+
 
 /**
  * Common HSV hue for all blocks in this category.
  */
-Blockly.Blocks.texts.HUE = '#ffffff';
+Blockly.Blocks.texts.HUE = Blockly.Colours.text_field;
 
 Blockly.Blocks['text'] = {
   /**

--- a/blocks/text.js
+++ b/blocks/text.js
@@ -34,7 +34,7 @@ goog.require('Blockly.Colours');
 /**
  * Common HSV hue for all blocks in this category.
  */
-Blockly.Blocks.texts.HUE = Blockly.Colours.text_field;
+Blockly.Blocks.texts.HUE = Blockly.Colours.textField;
 
 Blockly.Blocks['text'] = {
   /**

--- a/blocks_horizontal/control.js
+++ b/blocks_horizontal/control.js
@@ -62,6 +62,8 @@ Blockly.Blocks['control_repeat'] = {
       "previousStatement": null,
       "nextStatement": null,
       "colour": Blockly.Colours.control.primary,
+      "colourSecondary": Blockly.Colours.control.secondary,
+      "colourTertiary": Blockly.Colours.control.tertiary,
       "tooltip": "",
       "helpUrl": "http://www.example.com/"
     });
@@ -98,6 +100,8 @@ Blockly.Blocks['control_forever'] = {
       "inputsInline": true,
       "previousStatement": null,
       "colour": Blockly.Colours.control.primary,
+      "colourSecondary": Blockly.Colours.control.secondary,
+      "colourTertiary": Blockly.Colours.control.tertiary,
       "tooltip": ""
     });
 

--- a/blocks_horizontal/control.js
+++ b/blocks_horizontal/control.js
@@ -28,6 +28,8 @@ goog.provide('Blockly.Blocks.control');
 
 goog.require('Blockly.Blocks');
 
+goog.require('Blockly.Colours');
+
 Blockly.Blocks['control_repeat'] = {
   /**
    * Block for repeat n times (external number).
@@ -59,7 +61,7 @@ Blockly.Blocks['control_repeat'] = {
       "inputsInline": true,
       "previousStatement": null,
       "nextStatement": null,
-      "colour": '#F2B827',
+      "colour": Blockly.Colours.control.primary,
       "tooltip": "",
       "helpUrl": "http://www.example.com/"
     });
@@ -95,7 +97,7 @@ Blockly.Blocks['control_forever'] = {
       ],
       "inputsInline": true,
       "previousStatement": null,
-      "colour": '#F2B827',
+      "colour": Blockly.Colours.control.primary,
       "tooltip": ""
     });
 

--- a/blocks_horizontal/event.js
+++ b/blocks_horizontal/event.js
@@ -51,6 +51,8 @@ Blockly.Blocks['event_whenflagclicked'] = {
       "inputsInline": true,
       "nextStatement": null,
       "colour": Blockly.Colours.event.primary,
+      "colourSecondary": Blockly.Colours.event.secondary,
+      "colourTertiary": Blockly.Colours.event.tertiary,
       "tooltip": "Do stuff!"
     });
 

--- a/blocks_horizontal/event.js
+++ b/blocks_horizontal/event.js
@@ -28,6 +28,8 @@ goog.provide('Blockly.Blocks.event');
 
 goog.require('Blockly.Blocks');
 
+goog.require('Blockly.Colours');
+
 Blockly.Blocks['event_whenflagclicked'] = {
   /**
    * Block for repeat n times (external number).
@@ -48,7 +50,7 @@ Blockly.Blocks['event_whenflagclicked'] = {
       ],
       "inputsInline": true,
       "nextStatement": null,
-      "colour": '#F2EC27',
+      "colour": Blockly.Colours.event.primary,
       "tooltip": "Do stuff!"
     });
 

--- a/blocks_horizontal/looks.js
+++ b/blocks_horizontal/looks.js
@@ -57,6 +57,8 @@ Blockly.Blocks['looks_say'] = {
       "previousStatement": null,
       "nextStatement": null,
       "colour": Blockly.Colours.looks.primary,
+      "colourSecondary": Blockly.Colours.looks.secondary,
+      "colourTertiary": Blockly.Colours.looks.tertiary,
       "tooltip": ""
     });
 

--- a/blocks_horizontal/looks.js
+++ b/blocks_horizontal/looks.js
@@ -28,6 +28,8 @@ goog.provide('Blockly.Blocks.looks');
 
 goog.require('Blockly.Blocks');
 
+goog.require('Blockly.Colours');
+
 Blockly.Blocks['looks_say'] = {
   /**
    * Block to say something.
@@ -54,7 +56,7 @@ Blockly.Blocks['looks_say'] = {
       "inputsInline": true,
       "previousStatement": null,
       "nextStatement": null,
-      "colour": '#6971E7',
+      "colour": Blockly.Colours.looks.primary,
       "tooltip": ""
     });
 

--- a/blocks_horizontal/motion.js
+++ b/blocks_horizontal/motion.js
@@ -52,6 +52,8 @@ Blockly.Blocks['motion_moveright'] = {
       "previousStatement": null,
       "nextStatement": null,
       "colour": Blockly.Colours.motion.primary,
+      "colourSecondary": Blockly.Colours.motion.secondary,
+      "colourTertiary": Blockly.Colours.motion.tertiary,
       "tooltip": ""
     });
 

--- a/blocks_horizontal/motion.js
+++ b/blocks_horizontal/motion.js
@@ -28,6 +28,8 @@ goog.provide('Blockly.Blocks.motion');
 
 goog.require('Blockly.Blocks');
 
+goog.require('Blockly.Colours');
+
 Blockly.Blocks['motion_moveright'] = {
   /**
    * Block for move right (external number)
@@ -49,7 +51,7 @@ Blockly.Blocks['motion_moveright'] = {
       ],
       "previousStatement": null,
       "nextStatement": null,
-      "colour": '#25AFF4',
+      "colour": Blockly.Colours.motion.primary,
       "tooltip": ""
     });
 

--- a/core/block.js
+++ b/core/block.js
@@ -160,6 +160,20 @@ Blockly.Block.prototype.data = null;
 Blockly.Block.prototype.colour_ = '#000000';
 
 /**
+ * Secondary colour of the block in '#RRGGBB' format.
+ * @type {string}
+ * @private
+ */
+Blockly.Block.prototype.colourSecondary_ = '#000000';
+
+/**
+ * Tertiary colour of the block in '#RRGGBB' format.
+ * @type {string}
+ * @private
+ */
+Blockly.Block.prototype.colourTertiary_ = '#000000';
+
+/**
  * Dispose of this block.
  * @param {boolean} healStack If true, then try to heal any gap by connecting
  *     the next statement with the previous statement.  Otherwise, dispose of
@@ -606,17 +620,56 @@ Blockly.Block.prototype.getColour = function() {
 };
 
 /**
- * Change the colour of a block.
- * @param {number|string} colour HSV hue value, or #RRGGBB string.
+ * Get the secondary colour of a block.
+ * @return {string} #RRGGBB string.
  */
-Blockly.Block.prototype.setColour = function(colour) {
+Blockly.Block.prototype.getColourSecondary = function() {
+  return this.colourSecondary_;
+};
+
+/**
+ * Get the tertiary colour of a block.
+ * @return {string} #RRGGBB string.
+ */
+Blockly.Block.prototype.getColourTertiary = function() {
+  return this.colourTertiary_;
+};
+
+
+/**
+* Create an #RRGGBB string colour from a colour HSV hue value or #RRGGBB string.
+* @param {number|string} colour HSV hue value, or #RRGGBB string.
+* @return {string} #RRGGBB string.
+* @private
+*/
+Blockly.Block.prototype.makeColour_ = function(colour) {
   var hue = parseFloat(colour);
   if (!isNaN(hue)) {
-    this.colour_ = Blockly.hueToRgb(hue);
+    return Blockly.hueToRgb(hue);
   } else if (goog.isString(colour) && colour.match(/^#[0-9a-fA-F]{6}$/)) {
-    this.colour_ = colour;
+    return colour;
   } else {
     throw 'Invalid colour: ' + colour;
+  }
+}
+
+/**
+ * Change the colour of a block, and optional secondary/teriarty colours.
+ * @param {number|string} colour HSV hue value, or #RRGGBB string.
+ * @param {number|string} colourSecondary HSV hue value, or #RRGGBB string.
+ * @param {number|string} colourTertiary HSV hue value, or #RRGGBB string.
+ */
+Blockly.Block.prototype.setColour = function(colour, colourSecondary, colourTertiary) {
+  this.colour_ = this.makeColour_(colour);
+  if (colourSecondary !== undefined) {
+    this.colourSecondary_ = this.makeColour_(colourSecondary);
+  } else {
+    this.colourSecondary_ = goog.color.darken(colour, 0.1);
+  }
+  if (colourTertiary !== undefined) {
+    this.colourTertiary_ = this.makeColour_(colourTertiary);
+  } else {
+    this.colourTertiary_ = goog.color.darken(colour, 0.2);
   }
   if (this.rendered) {
     this.updateColour();
@@ -941,7 +994,7 @@ Blockly.Block.prototype.jsonInit = function(json) {
 
   // Set basic properties of block.
   if (json['colour'] !== undefined) {
-    this.setColour(json['colour']);
+    this.setColour(json['colour'], json['colourSecondary'], json['colourTertiary']);
   }
 
   // Interpolate the message blocks.

--- a/core/block_render_svg_horizontal.js
+++ b/core/block_render_svg_horizontal.js
@@ -201,8 +201,7 @@ Blockly.BlockSvg.prototype.updateColour = function() {
   }
 
   // Render block stroke
-  var colorShift = goog.color.darken(rgb, 0.1);
-  var strokeColor = goog.color.rgbArrayToHex(colorShift);
+  var strokeColor = this.getColourTertiary();
   this.svgPath_.setAttribute('stroke', strokeColor);
 
   // Bump every dropdown to change its colour.

--- a/core/block_render_svg_horizontal.js
+++ b/core/block_render_svg_horizontal.js
@@ -191,11 +191,17 @@ Blockly.BlockSvg.prototype.connectionUiEffect = function() {
  * Change the colour of a block.
  */
 Blockly.BlockSvg.prototype.updateColour = function() {
-  // Render block fill
-  this.svgPath_.setAttribute('fill', this.getColour());
+  var strokeColour = this.getColourTertiary();
+  if (this.isShadow() && this.parentBlock_) {
+    // Pull shadow block stroke colour from parent block's tertiary if possible.
+    strokeColour = this.parentBlock_.getColourTertiary();
+  }
 
   // Render block stroke
-  this.svgPath_.setAttribute('stroke', this.getColourTertiary());
+  this.svgPath_.setAttribute('stroke', strokeColour);
+
+  // Render block fill
+  this.svgPath_.setAttribute('fill', this.getColour());
 
   // Bump every dropdown to change its colour.
   for (var x = 0, input; input = this.inputList[x]; x++) {

--- a/core/block_render_svg_horizontal.js
+++ b/core/block_render_svg_horizontal.js
@@ -192,17 +192,10 @@ Blockly.BlockSvg.prototype.connectionUiEffect = function() {
  */
 Blockly.BlockSvg.prototype.updateColour = function() {
   // Render block fill
-  var hexColour = this.parentBlock_ ? this.parentBlock_.getColour() : this.getColour();
-  var rgb = goog.color.hexToRgb(hexColour);
-  if (this.isShadow()) {
-    this.svgPath_.setAttribute('fill', '#ffffff');
-  } else {
-    this.svgPath_.setAttribute('fill', hexColour);
-  }
+  this.svgPath_.setAttribute('fill', this.getColour());
 
   // Render block stroke
-  var strokeColor = this.getColourTertiary();
-  this.svgPath_.setAttribute('stroke', strokeColor);
+  this.svgPath_.setAttribute('stroke', this.getColourTertiary());
 
   // Bump every dropdown to change its colour.
   for (var x = 0, input; input = this.inputList[x]; x++) {

--- a/core/colours.js
+++ b/core/colours.js
@@ -29,5 +29,6 @@ Blockly.Colours = {
     "tertiary": "#CCAA00"
   },
   "text": "#575E75",
-  "workspace": "#F5F8FF"
+  "workspace": "#F5F8FF",
+  "text_field": "#FFFFFF"
 };

--- a/core/colours.js
+++ b/core/colours.js
@@ -1,0 +1,33 @@
+'use strict';
+
+goog.provide('Blockly.Colours');
+
+Blockly.Colours = {
+  "motion": {
+    "primary": "#4C97FF",
+    "secondary": "#4280D7",
+    "tertiary": "#3373CC"
+  },
+  "looks": {
+    "primary": "#9966FF",
+    "secondary": "#855CD6",
+    "tertiary": "#774DCB"
+  },
+  "sounds": {
+    "primary": "#D65CD6",
+    "secondary": "#BF40BF",
+    "tertiary": "#A63FA6"
+  },
+  "control": {
+    "primary": "#FFAB19",
+    "secondary": "#EC9C13",
+    "tertiary": "#CF8B17"
+  },
+  "event": {
+    "primary": "#FFD500",
+    "secondary": "#DBC200",
+    "tertiary": "#CCAA00"
+  },
+  "text": "#575E75",
+  "workspace": "#F5F8FF"
+};

--- a/core/colours.js
+++ b/core/colours.js
@@ -30,5 +30,5 @@ Blockly.Colours = {
   },
   "text": "#575E75",
   "workspace": "#F5F8FF",
-  "text_field": "#FFFFFF"
+  "textField": "#FFFFFF"
 };

--- a/core/css.js
+++ b/core/css.js
@@ -216,7 +216,7 @@ Blockly.Css.CONTENT = [
 
   '.blocklyNonEditableText>text,',
   '.blocklyEditableText>text {',
-    'fill: #000;',
+    'fill: ' +  Blockly.Colours.text + ';',
   '}',
 
   '.blocklyEditableText:hover>rect {',
@@ -225,7 +225,7 @@ Blockly.Css.CONTENT = [
   '}',
 
   '.blocklyBubbleText {',
-    'fill: #000;',
+    'fill:' + Blockly.Colours.text +';',
   '}',
 
   /*

--- a/core/css.js
+++ b/core/css.js
@@ -26,6 +26,8 @@
 
 goog.provide('Blockly.Css');
 
+goog.require('Blockly.Colours');
+
 
 /**
  * List of cursors.
@@ -132,7 +134,7 @@ Blockly.Css.setCursor = function(cursor) {
  */
 Blockly.Css.CONTENT = [
   '.blocklySvg {',
-    'background-color: #fff;',
+    'background-color: ' + Blockly.Colours.workspace + ';',
     'outline: none;',
     'overflow: hidden;',  /* IE overflows by default. */
   '}',


### PR DESCRIPTION
Creates a centralized place for our colours to live, Blockly.colours. Pull all colours for blocks and interface elements from here.

Extends block colours to include getters and setters for secondary and tertiary colours.

Updates updateColour and css.js to use the new colours.
