### PR TITLE
Remove special rounding for endHats #96

### DIFF
--- a/core/block_render_svg_horizontal.js
+++ b/core/block_render_svg_horizontal.js
@@ -275,7 +275,7 @@ Blockly.BlockSvg.prototype.renderCompute_ = function() {
     fieldWidth: 0,
     fieldHeight: 0,
     fieldRadius: 0,
-    startHat: false,
+    startHat: false
   };
 
   if (this.nextConnection && !this.previousConnection) {
@@ -515,7 +515,7 @@ Blockly.BlockSvg.prototype.renderDrawBottom_ = function(steps,
     }
   }
 
-  if (this.nextConnection) {
+  if (!this.isShadow()) {
     steps.push('H', metrics.width - Blockly.BlockSvg.CORNER_RADIUS);
   } else {
     // input
@@ -532,7 +532,7 @@ Blockly.BlockSvg.prototype.renderDrawBottom_ = function(steps,
  */
 Blockly.BlockSvg.prototype.renderDrawRight_ =
     function(steps, connectionsXY, metrics) {
-  if (this.nextConnection) {
+  if (!this.isShadow()) {
     steps.push('a', Blockly.BlockSvg.CORNER_RADIUS + ',' +
                Blockly.BlockSvg.CORNER_RADIUS + ' 0 0,0 ' +
                Blockly.BlockSvg.CORNER_RADIUS + ',-' +
@@ -562,6 +562,8 @@ Blockly.BlockSvg.prototype.renderDrawRight_ =
       this.nextConnection.tighten_();
     }
     steps.push('V', Blockly.BlockSvg.CORNER_RADIUS);
+  } else if (!this.isShadow()) {
+    steps.push('V', Blockly.BlockSvg.CORNER_RADIUS);
   }
 };
 
@@ -574,7 +576,7 @@ Blockly.BlockSvg.prototype.renderDrawRight_ =
  */
 Blockly.BlockSvg.prototype.renderDrawTop_ =
     function(steps, connectionsXY, metrics) {
-  if (this.nextConnection) {
+  if (!this.isShadow()) {
     steps.push('a', Blockly.BlockSvg.CORNER_RADIUS + ',' +
                Blockly.BlockSvg.CORNER_RADIUS + ' 0 0,0 -' +
                Blockly.BlockSvg.CORNER_RADIUS + ',-' +


### PR DESCRIPTION
This fixes our forever-in-repeat problem and brings us to spec with #96.
<img width="383" alt="screen shot 2016-03-02 at 8 52 01 pm" src="https://cloud.githubusercontent.com/assets/120403/13482136/c74b7bc8-e0b8-11e5-8e64-8135b999f65a.png">

I removed the endHat handling entirely, because to my understanding, this is no longer part of the spec. Any blocks with previousConnection && !nextconnection should be squared off, as the forever. If we change this in the future, we can restore the endHat behavior then.

@carljbowman 
