### PR TITLE
Some RTL fixes #34

### DIFF
--- a/blocks_horizontal/control.js
+++ b/blocks_horizontal/control.js
@@ -50,7 +50,8 @@ Blockly.Blocks['control_repeat'] = {
           "src": Blockly.mainWorkspace.options.pathToMedia + "icons/control_forever.svg",
           "width": 40,
           "height": 40,
-          "alt": "*"
+          "alt": "*",
+          "flip_rtl": true
         },
         {
           "type": "input_value",
@@ -94,7 +95,8 @@ Blockly.Blocks['control_forever'] = {
           "src": Blockly.mainWorkspace.options.pathToMedia + "icons/control_forever.svg",
           "width": 40,
           "height": 40,
-          "alt": "*"
+          "alt": "*",
+          "flip_rtl": true
         }
       ],
       "inputsInline": true,

--- a/blocks_horizontal/event.js
+++ b/blocks_horizontal/event.js
@@ -45,7 +45,8 @@ Blockly.Blocks['event_whenflagclicked'] = {
           "src": Blockly.mainWorkspace.options.pathToMedia + "icons/event_whenflagclicked.svg",
           "width": 40,
           "height": 40,
-          "alt": "flag"
+          "alt": "flag",
+          "flip_rtl": true
         }
       ],
       "inputsInline": true,

--- a/core/block.js
+++ b/core/block.js
@@ -1171,7 +1171,8 @@ Blockly.Block.prototype.interpolate_ = function(message, args, lastDummyAlign) {
             break;
           case 'field_image':
             field = new Blockly.FieldImage(element['src'],
-                element['width'], element['height'], element['alt']);
+                element['width'], element['height'], element['alt'],
+                element['flip_rtl']);
             break;
           case 'field_date':
             if (Blockly.FieldDate) {

--- a/core/block_render_svg_horizontal.js
+++ b/core/block_render_svg_horizontal.js
@@ -518,9 +518,10 @@ Blockly.BlockSvg.prototype.renderDrawBottom_ = function(steps,
                Blockly.BlockSvg.CORNER_RADIUS);
 
     // Create statement connection.
-    // @todo RTL
-    // var connectionX = connectionsXY.x + (this.RTL ? -cursorX : cursorX + 1);
     var connectionX = connectionsXY.x + Blockly.BlockSvg.CORNER_RADIUS * 2 + 4 * Blockly.BlockSvg.GRID_UNIT;
+    if (this.RTL) {
+      connectionX = connectionsXY.x - Blockly.BlockSvg.CORNER_RADIUS * 2 - 4 * Blockly.BlockSvg.GRID_UNIT;
+    }
     var connectionY = connectionsXY.y + metrics.height - Blockly.BlockSvg.CORNER_RADIUS * 2;
     metrics.statement.connection.moveTo(connectionX, connectionY);
     if (metrics.statement.connection.targetConnection) {
@@ -565,7 +566,7 @@ Blockly.BlockSvg.prototype.renderDrawRight_ =
     // Create next block connection.
     var connectionX;
     if (this.RTL) {
-      connectionX = connectionsXY.x + metrics.width;
+      connectionX = connectionsXY.x - metrics.width;
     } else {
       connectionX = connectionsXY.x + metrics.width;
     }

--- a/core/block_render_svg_horizontal.js
+++ b/core/block_render_svg_horizontal.js
@@ -400,11 +400,14 @@ Blockly.BlockSvg.prototype.renderDraw_ = function(metrics) {
   if (metrics.valueInput) {
     var input = metrics.valueInput.getSvgRoot();
     var inputBBox = input.getBBox();
-    var transformation = 'translate(' +
-      (Blockly.BlockSvg.NOTCH_WIDTH +
-        (metrics.bayWidth ? 2 * Blockly.BlockSvg.GRID_UNIT +
-          Blockly.BlockSvg.NOTCH_WIDTH*2 : 0) + metrics.bayWidth) + ',' +
-      (metrics.height - 2 * Blockly.BlockSvg.GRID_UNIT) + ')';
+    var valueX = (Blockly.BlockSvg.NOTCH_WIDTH +
+      (metrics.bayWidth ? 2 * Blockly.BlockSvg.GRID_UNIT +
+        Blockly.BlockSvg.NOTCH_WIDTH*2 : 0) + metrics.bayWidth);
+    if (this.RTL) {
+      valueX = -valueX;
+    }
+    var valueY = (metrics.height - 2 * Blockly.BlockSvg.GRID_UNIT);
+    var transformation = 'translate(' + valueX + ',' + valueY + ')';
     input.setAttribute('transform', transformation);
   }
 };

--- a/core/block_render_svg_horizontal.js
+++ b/core/block_render_svg_horizontal.js
@@ -380,10 +380,20 @@ Blockly.BlockSvg.prototype.renderDraw_ = function(metrics) {
     var icon = metrics.icon.getSvgRoot();
     var iconSize = metrics.icon.getSize();
     var iconX = metrics.width - iconSize.width - Blockly.BlockSvg.SEP_SPACE_X / 1.5;
+    var iconY = metrics.height - iconSize.height - Blockly.BlockSvg.SEP_SPACE_Y;
+    var iconScale = "scale(1 1)";
+    if (this.RTL) {
+      // Do we want to mirror the icon left-to-right?
+      if (metrics.icon.getFlipRTL()) {
+        iconScale = "scale(-1 1)";
+        iconX = -metrics.width + iconSize.width + Blockly.BlockSvg.SEP_SPACE_X / 1.5;
+      } else {
+        // If not, don't offset by iconSize.width
+        iconX = -metrics.width + Blockly.BlockSvg.SEP_SPACE_X / 1.5;
+      }
+    }
     icon.setAttribute('transform',
-      'translate(' + (iconX) + ',' +
-      (metrics.height - iconSize.height - Blockly.BlockSvg.SEP_SPACE_Y) + ')');
-    // @todo RTL
+      'translate(' + iconX + ',' + iconY + ') ' + iconScale);
   }
 
   // Position value input

--- a/core/block_render_svg_horizontal.js
+++ b/core/block_render_svg_horizontal.js
@@ -379,6 +379,7 @@ Blockly.BlockSvg.prototype.renderDraw_ = function(metrics) {
   if (!this.isGhost() && metrics.icon) {
     var icon = metrics.icon.getSvgRoot();
     var iconSize = metrics.icon.getSize();
+    // Icon's position is calculated relative to the "end" edge of the block.
     var iconX = metrics.width - iconSize.width - Blockly.BlockSvg.SEP_SPACE_X / 1.5;
     var iconY = metrics.height - iconSize.height - Blockly.BlockSvg.SEP_SPACE_Y;
     var iconScale = "scale(1 1)";

--- a/core/field_image.js
+++ b/core/field_image.js
@@ -38,16 +38,18 @@ goog.require('goog.userAgent');
  * @param {number} width Width of the image.
  * @param {number} height Height of the image.
  * @param {string=} opt_alt Optional alt text for when block is collapsed.
+ * @param {boolean} flip_rtl Whether to flip the icon in RTL
  * @extends {Blockly.Field}
  * @constructor
  */
-Blockly.FieldImage = function(src, width, height, opt_alt) {
+Blockly.FieldImage = function(src, width, height, opt_alt, flip_rtl) {
   this.sourceBlock_ = null;
   // Ensure height and width are numbers.  Strings are bad at math.
   this.height_ = Number(height);
   this.width_ = Number(width);
   this.size_ = new goog.math.Size(this.width_, this.height_);
   this.text_ = opt_alt || '';
+  this.flipRTL_ = flip_rtl;
   this.setValue(src);
 };
 goog.inherits(Blockly.FieldImage, Blockly.Field);
@@ -148,6 +150,14 @@ Blockly.FieldImage.prototype.setValue = function(src) {
     this.imageElement_.setAttributeNS('http://www.w3.org/1999/xlink',
         'xlink:href', goog.isString(src) ? src : '');
   }
+};
+
+/**
+ * Get whether to flip this image in RTL
+ * @return {boolean} True if we should flip in RTL.
+ */
+Blockly.FieldImage.prototype.getFlipRTL = function() {
+  return this.flipRTL_;
 };
 
 /**

--- a/core/flyout.js
+++ b/core/flyout.js
@@ -581,7 +581,7 @@ Blockly.Flyout.prototype.show = function(xmlList) {
     block.render();
     var root = block.getSvgRoot();
     var blockHW = block.getHeightWidth();
-    block.moveBy((this.horizontalLayout_ && this.RTL) ? this.width_ - cursorX : cursorX, cursorY);
+    block.moveBy((this.horizontalLayout_ && this.RTL) ? -cursorX : cursorX, cursorY);
     if (this.horizontalLayout_) {
       cursorX += blockHW.width + gaps[i];
     } else {


### PR DESCRIPTION
This is a partial implementation of correct positioning in RTL.

-Fixes a bug with the horizontal workspace positioning of blocks
-Add property to image fields to indicate we should flip the icon
-Positioning of icons correctly
-Positioning of connections correctly

Still to do:
-Positioning of the inner input/field text in the shadow block seems off...not sure what's up with that yet. 
<img width="506" alt="screen shot 2016-03-03 at 5 49 41 pm" src="https://cloud.githubusercontent.com/assets/120403/13512395/563a1af6-e168-11e5-90ff-ff3c9b626d63.png">
