### PR TITLE
Glows on running blocks and (partially) stacks

### DIFF
--- a/core/block_render_svg_horizontal.js
+++ b/core/block_render_svg_horizontal.js
@@ -201,7 +201,8 @@ Blockly.BlockSvg.prototype.updateColour = function() {
   this.svgPath_.setAttribute('stroke', strokeColour);
 
   // Render block fill
-  this.svgPath_.setAttribute('fill', this.getColour());
+  var fillColour = (this.isGlowing_) ? this.getColourSecondary() : this.getColour();
+  this.svgPath_.setAttribute('fill', fillColour);
 
   // Bump every dropdown to change its colour.
   for (var x = 0, input; input = this.inputList[x]; x++) {

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -77,6 +77,13 @@ Blockly.BlockSvg.prototype.width = 0;
 Blockly.BlockSvg.prototype.dragStartXY_ = null;
 
 /**
+ * Whether the block glows as if running.
+ * @type {boolean}
+ * @private
+ */
+Blockly.BlockSvg.prototype.isGlowing_ = false;
+
+/**
  * Constant for identifying rows that are to be rendered inline.
  * Don't collide with Blockly.INPUT_VALUE and friends.
  * @const
@@ -132,6 +139,15 @@ Blockly.BlockSvg.prototype.unselect = function() {
   Blockly.selected = null;
   this.removeSelect();
   Blockly.fireUiEvent(this.workspace.getCanvas(), 'blocklySelectChange');
+};
+
+/**
+ * Glow this block.  Highlight it visually as if it's running.
+ * @param {boolean} isGlowing Whether the block should glow.
+ */
+Blockly.BlockSvg.prototype.setGlow = function(isGlowing) {
+  this.isGlowing_ = isGlowing;
+  this.updateColour();
 };
 
 /**

--- a/core/inject.js
+++ b/core/inject.js
@@ -279,6 +279,19 @@ Blockly.createDom_ = function(container, options) {
        'k1': 0, 'k2': 1, 'k3': 1, 'k4': 0}, embossFilter);
   options.embossFilterId = embossFilter.id;
 
+  var stackGlowFilter = Blockly.createSvgElement('filter',
+      {'id': 'blocklyStackGlowFilter' + rnd}, defs);
+  Blockly.createSvgElement('feMorphology',
+      {'in': 'SourceAlpha', 'operator': 'dilate', 'radius': 4, 'result': 'outBlur'}, stackGlowFilter);
+  Blockly.createSvgElement('feFlood',
+      {'flood-color': '#05f', 'flood-opacity': '0.9', 'result': 'outColor'}, stackGlowFilter);
+  Blockly.createSvgElement('feComposite',
+      {'in': 'outColor', 'in2': 'outBlur',
+       'operator': 'in', 'result': 'outGlow'}, stackGlowFilter);
+  Blockly.createSvgElement('feComposite',
+      {'in': 'SourceGraphic', 'in2': 'outGlow', 'operator': 'over'}, stackGlowFilter);
+  options.stackGlowFilterId = stackGlowFilter.id;
+
   var disabledPattern = Blockly.createSvgElement('pattern',
       {'id': 'blocklyDisabledPattern' + rnd,
        'patternUnits': 'userSpaceOnUse',

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -464,12 +464,10 @@ Blockly.WorkspaceSvg.prototype.glowBlock = function(id, isGlowing) {
   if (id) {
     block = Blockly.Block.getById(id);
     if (!block) {
-      return;
+      throw 'Tried to glow block that does not exist.';
     }
   }
-  if (block) {
-    block.setGlow(isGlowing);
-  }
+  block.setGlow(isGlowing);
 };
 
 /**

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -455,6 +455,24 @@ Blockly.WorkspaceSvg.prototype.highlightBlock = function(id) {
 };
 
 /**
+ * Glow/unglow a block in the workspace.
+ * @param {?string} id ID of block to find.
+ * @param {boolean} isGlowing Whether to glow the block.
+ */
+Blockly.WorkspaceSvg.prototype.glowBlock = function(id, isGlowing) {
+  var block = null;
+  if (id) {
+    block = Blockly.Block.getById(id);
+    if (!block) {
+      return;
+    }
+  }
+  if (block) {
+    block.setGlow(isGlowing);
+  }
+};
+
+/**
  * Paste the provided block onto the workspace.
  * @param {!Element} xmlBlock XML block element.
  */


### PR DESCRIPTION
This adds a property to the Block SVG to track "glow" state (since "highlight" is already used in the Blockly codebase). Blocks switch their fill color to the secondary color when the state is set by the workspace. Should allow us to easily implement block-by-block glowing (as in ScratchJr).

I've also added a new SVG filter for "stack glow" more like Scratch.
<img width="510" alt="screen shot 2016-03-04 at 12 24 54 pm" src="https://cloud.githubusercontent.com/assets/120403/13534699/81082d1c-e204-11e5-8f9e-577892ee4b22.png">
It works if applied manually to the dragging group of the stack. I didn't add setters for this yet as I think we need to consider where the filter might actually be applied (and if we can use it).
For example, because of the way we're likely doing ghosts, when we apply the filter to the dragging group, the filter is also applied to the ghost :( so the insertion ghosts appear highlighted if they're dragged in from the right to a "running" stack. It makes Carl pretty sad, but maybe it's actually consistent/reasonable behavior anyway.

Anyway this PR should get us mostly there.
