### PR TITLE
Distinguish mouse wheel/zoom and implement scrolling

### DIFF
--- a/core/blockly.js
+++ b/core/blockly.js
@@ -343,19 +343,9 @@ Blockly.onMouseMove_ = function(e) {
     Blockly.removeAllRanges();
     var dx = e.clientX - workspace.startDragMouseX;
     var dy = e.clientY - workspace.startDragMouseY;
-    var metrics = workspace.startDragMetrics;
     var x = workspace.startScrollX + dx;
     var y = workspace.startScrollY + dy;
-    x = Math.min(x, -metrics.contentLeft);
-    y = Math.min(y, -metrics.contentTop);
-    x = Math.max(x, metrics.viewWidth - metrics.contentLeft -
-                 metrics.contentWidth);
-    y = Math.max(y, metrics.viewHeight - metrics.contentTop -
-                 metrics.contentHeight);
-
-    // Move the scrollbars and the page will scroll automatically.
-    workspace.scrollbar.set(-x - metrics.contentLeft,
-                            -y - metrics.contentTop);
+    Blockly.scrollWorkspace(workspace, workspace.startDragMetrics, x, y);
     // Cancel the long-press if the drag has moved too far.
     if (Math.sqrt(dx * dx + dy * dy) > Blockly.DRAG_RADIUS) {
       Blockly.longStop_();
@@ -363,6 +353,26 @@ Blockly.onMouseMove_ = function(e) {
     e.stopPropagation();
   }
 };
+
+/**
+ * Scroll a workspace by a specified amount, keeping in the workspace bounds
+ * @param {!Blockly.WorkspaceSvg} workspace Which workspace to scroll
+ * @param {!Object} metrics Workspace metrics from the start of scroll
+ * @param {number} x Target X to scroll to
+ * @param {number} y Target Y to scroll to
+ */
+Blockly.scrollWorkspace = function(workspace, metrics, x, y) {
+  x = Math.min(x, -metrics.contentLeft);
+  y = Math.min(y, -metrics.contentTop);
+  x = Math.max(x, metrics.viewWidth - metrics.contentLeft -
+               metrics.contentWidth);
+  y = Math.max(y, metrics.viewHeight - metrics.contentTop -
+               metrics.contentHeight);
+
+  // Move the scrollbars and the page will scroll automatically.
+  workspace.scrollbar.set(-x - metrics.contentLeft,
+                          -y - metrics.contentTop);
+}
 
 /**
  * Handle a key-down on SVG drawing surface.

--- a/core/blockly.js
+++ b/core/blockly.js
@@ -345,7 +345,7 @@ Blockly.onMouseMove_ = function(e) {
     var dy = e.clientY - workspace.startDragMouseY;
     var x = workspace.startScrollX + dx;
     var y = workspace.startScrollY + dy;
-    Blockly.scrollWorkspace(workspace, workspace.startDragMetrics, x, y);
+    workspace.scroll(x, y);
     // Cancel the long-press if the drag has moved too far.
     if (Math.sqrt(dx * dx + dy * dy) > Blockly.DRAG_RADIUS) {
       Blockly.longStop_();
@@ -353,26 +353,6 @@ Blockly.onMouseMove_ = function(e) {
     e.stopPropagation();
   }
 };
-
-/**
- * Scroll a workspace by a specified amount, keeping in the workspace bounds
- * @param {!Blockly.WorkspaceSvg} workspace Which workspace to scroll
- * @param {!Object} metrics Workspace metrics from the start of scroll
- * @param {number} x Target X to scroll to
- * @param {number} y Target Y to scroll to
- */
-Blockly.scrollWorkspace = function(workspace, metrics, x, y) {
-  x = Math.min(x, -metrics.contentLeft);
-  y = Math.min(y, -metrics.contentTop);
-  x = Math.max(x, metrics.viewWidth - metrics.contentLeft -
-               metrics.contentWidth);
-  y = Math.max(y, metrics.viewHeight - metrics.contentTop -
-               metrics.contentHeight);
-
-  // Move the scrollbars and the page will scroll automatically.
-  workspace.scrollbar.set(-x - metrics.contentLeft,
-                          -y - metrics.contentTop);
-}
 
 /**
  * Handle a key-down on SVG drawing surface.

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -676,18 +676,9 @@ Blockly.WorkspaceSvg.prototype.onMouseWheel_ = function(e) {
     this.zoom(position.x, position.y, delta);
   } else {
     // This is a regular mouse wheel event - scroll the workspace
-    var metrics = this.getMetrics();
     var x = this.scrollX - e.deltaX;
     var y = this.scrollY - e.deltaY;
-    x = Math.min(x, -metrics.contentLeft);
-    y = Math.min(y, -metrics.contentTop);
-    x = Math.max(x, metrics.viewWidth - metrics.contentLeft -
-                 metrics.contentWidth);
-    y = Math.max(y, metrics.viewHeight - metrics.contentTop -
-                 metrics.contentHeight);
-    // Move the scrollbars and the page will scroll automatically.
-    this.scrollbar.set(-x - metrics.contentLeft,
-                       -y - metrics.contentTop);
+    Blockly.scrollWorkspace(this, this.getMetrics(), x, y);
   }
   e.preventDefault();
 };

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -678,7 +678,8 @@ Blockly.WorkspaceSvg.prototype.onMouseWheel_ = function(e) {
     // This is a regular mouse wheel event - scroll the workspace
     var x = this.scrollX - e.deltaX;
     var y = this.scrollY - e.deltaY;
-    Blockly.scrollWorkspace(this, this.getMetrics(), x, y);
+    this.startDragMetrics = this.getMetrics();
+    this.scroll(x, y);
   }
   e.preventDefault();
 };
@@ -1043,6 +1044,26 @@ Blockly.WorkspaceSvg.prototype.zoomReset = function(e) {
   // This event has been handled.  Don't start a workspace drag.
   e.stopPropagation();
 };
+
+/**
+ * Scroll the workspace by a specified amount, keeping in the bounds
+ * @param {number} x Target X to scroll to
+ * @param {number} y Target Y to scroll to
+ */
+Blockly.WorkspaceSvg.prototype.scroll = function(x, y) {
+  var metrics = this.startDragMetrics;
+  x = Math.min(x, -metrics.contentLeft);
+  y = Math.min(y, -metrics.contentTop);
+  x = Math.max(x, metrics.viewWidth - metrics.contentLeft -
+               metrics.contentWidth);
+  y = Math.max(y, metrics.viewHeight - metrics.contentTop -
+               metrics.contentHeight);
+
+  // Move the scrollbars and the page will scroll automatically.
+  this.scrollbar.set(-x - metrics.contentLeft,
+                     -y - metrics.contentTop);
+}
+
 
 /**
  * Updates the grid pattern.

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1046,12 +1046,13 @@ Blockly.WorkspaceSvg.prototype.zoomReset = function(e) {
 };
 
 /**
- * Scroll the workspace by a specified amount, keeping in the bounds
+ * Scroll the workspace by a specified amount, keeping in the bounds.
+ * Be sure to set this.startDragMetrics with cached metrics before calling.
  * @param {number} x Target X to scroll to
  * @param {number} y Target Y to scroll to
  */
 Blockly.WorkspaceSvg.prototype.scroll = function(x, y) {
-  var metrics = this.startDragMetrics;
+  var metrics = this.startDragMetrics; // Cached values
   x = Math.min(x, -metrics.contentLeft);
   y = Math.min(y, -metrics.contentTop);
   x = Math.max(x, metrics.viewWidth - metrics.contentLeft -
@@ -1062,8 +1063,7 @@ Blockly.WorkspaceSvg.prototype.scroll = function(x, y) {
   // Move the scrollbars and the page will scroll automatically.
   this.scrollbar.set(-x - metrics.contentLeft,
                      -y - metrics.contentTop);
-}
-
+};
 
 /**
  * Updates the grid pattern.

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -668,10 +668,27 @@ Blockly.WorkspaceSvg.prototype.moveDrag = function(e) {
  */
 Blockly.WorkspaceSvg.prototype.onMouseWheel_ = function(e) {
   // TODO: Remove terminateDrag and compensate for coordinate skew during zoom.
-  Blockly.terminateDrag_();
-  var delta = e.deltaY > 0 ? -1 : 1;
-  var position = Blockly.mouseToSvg(e, this.getParentSvg());
-  this.zoom(position.x, position.y, delta);
+  if (e.ctrlKey) {
+    // Pinch-to-zoom in Chrome only
+    Blockly.terminateDrag_();
+    var delta = e.deltaY > 0 ? -1 : 1;
+    var position = Blockly.mouseToSvg(e, this.getParentSvg());
+    this.zoom(position.x, position.y, delta);
+  } else {
+    // This is a regular mouse wheel event - scroll the workspace
+    var metrics = this.getMetrics();
+    var x = this.scrollX - e.deltaX;
+    var y = this.scrollY - e.deltaY;
+    x = Math.min(x, -metrics.contentLeft);
+    y = Math.min(y, -metrics.contentTop);
+    x = Math.max(x, metrics.viewWidth - metrics.contentLeft -
+                 metrics.contentWidth);
+    y = Math.max(y, metrics.viewHeight - metrics.contentTop -
+                 metrics.contentHeight);
+    // Move the scrollbars and the page will scroll automatically.
+    this.scrollbar.set(-x - metrics.contentLeft,
+                       -y - metrics.contentTop);
+  }
   e.preventDefault();
 };
 

--- a/tests/horizontal_playground.html
+++ b/tests/horizontal_playground.html
@@ -40,7 +40,7 @@ function start() {
     toolboxPosition: 'start',
     zoom: {
       controls: true,
-      wheel: false,
+      wheel: true,
       startScale: 1.0,
       maxScale: 4,
       minScale: 0.25,

--- a/tests/multi_playground.html
+++ b/tests/multi_playground.html
@@ -44,7 +44,7 @@ function startBlocklyInstance(suffix, rtl, horizontalLayout, position) {
     toolboxPosition: position,
     zoom: {
       controls: true,
-      wheel: false,
+      wheel: true,
       startScale: 1.0,
       maxScale: 4,
       minScale: 0.25,

--- a/tests/spectool.html
+++ b/tests/spectool.html
@@ -40,7 +40,7 @@ function start() {
     toolboxPosition: 'start',
     zoom: {
       controls: true,
-      wheel: false,
+      wheel: true,
       startScale: 8.0,
       maxScale: 10,
       minScale: 0.25,

--- a/tests/vertical_playground.html
+++ b/tests/vertical_playground.html
@@ -36,7 +36,7 @@ function start() {
     trashcan: true,
     zoom: {
       controls: true,
-      wheel: false,
+      wheel: true,
       startScale: 1.0,
       maxScale: 4,
       minScale: 0.25,


### PR DESCRIPTION
With this change, the mouse wheel scrolls the workspace by default. If it's a Chrome pinch-zoom event, the wheel event zooms the workspace instead.
