### PR TITLE
Freeze connections during drags

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -226,6 +226,7 @@ Blockly.BlockSvg.terminateDrag_ = function() {
         selected.ghostBlock_ = null;
         Blockly.Events.enable();
       }
+      Blockly.connectionsFrozen = false;
       // Update the connection locations.
       var xy = selected.getRelativeToSurfaceXY();
       var dxy = goog.math.Coordinate.difference(xy, selected.dragStartXY_);
@@ -779,6 +780,7 @@ Blockly.BlockSvg.prototype.onMouseMove_ = function(e) {
         this.disconnectUiEffect();
       }
       this.setDragging_(true);
+      Blockly.connectionsFrozen = true;
     }
   }
   if (Blockly.dragMode_ == 2) {

--- a/core/blockly.js
+++ b/core/blockly.js
@@ -263,6 +263,15 @@ Blockly.clipboardSource_ = null;
 Blockly.dragMode_ = 0;
 
 /**
+ * Whether to update the database when moving connections.
+ * Update this at your own risk!  If the database gets out of sync with reality
+ * it won't be possible to find connecitons in this.  This is only intended to
+ * be used when rendering insertion markers causes spurious moves.
+ * @type {boolean}
+ */
+Blockly.connectionsFrozen = false;
+
+/**
  * Wrapper function called when a touch mouseUp occurs during a drag operation.
  * @type {Array.<!Array>}
  * @private

--- a/core/connection.js
+++ b/core/connection.js
@@ -728,13 +728,13 @@ Blockly.Connection.prototype.bumpAwayFrom_ = function(staticConnection) {
  */
 Blockly.Connection.prototype.moveTo = function(x, y) {
   // Remove it from its old location in the database (if already present)
-  if (this.inDB_) {
+  if (this.inDB_ && !Blockly.connectionsFrozen) {
     this.db_.removeConnection_(this);
   }
   this.x_ = x;
   this.y_ = y;
   // Insert it into its new location in the database.
-  if (!this.hidden_) {
+  if (!this.hidden_ && !Blockly.connectionsFrozen) {
     this.db_.addConnection(this);
   }
 };

--- a/core/connection_db.js
+++ b/core/connection_db.js
@@ -39,6 +39,7 @@ Blockly.ConnectionDB = function() {
 };
 
 Blockly.ConnectionDB.prototype = new Array();
+
 /**
  * Don't inherit the constructor from Array.
  * @type {!Function}


### PR DESCRIPTION
This should get rid of some of the jumpiness in https://github.com/LLK/scratch-blockly/issues/139.  It won't make it all disappear, because there are still two distinct render passes happening.

@tmickel please play with this and let me know if it helps.
