### PR TITLE
SNAP_RADIUS = 72;

### DIFF
--- a/core/constants.js
+++ b/core/constants.js
@@ -35,7 +35,7 @@ Blockly.DRAG_RADIUS = 5;
 /**
  * Maximum misalignment between connections for them to snap together.
  */
-Blockly.SNAP_RADIUS = 20;
+Blockly.SNAP_RADIUS = 72;
 
 /**
  * Delay in ms between trigger and bumping unconnected block out of alignment.


### PR DESCRIPTION
This makes ghosts feel pretty great with a couple of remaining exceptions. I think it's also about the distance we would want blocks to snap at. Later we might want to make this dependent on the block size (for vertical)?
