### PR TITLE
Add basic .eslintrc

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,25 @@
+{
+    "rules": {
+        "curly": [2, "multi-line"],
+        "eol-last": [2],
+        "indent": [2, 2], # Blockly/Google use 2-space indents
+        "linebreak-style": [2, "unix"],
+        "max-len": [2, 120, 4],
+        "no-trailing-spaces": [2, { "skipBlankLines": true }],
+        "no-unused-vars": [2, {"args": "after-used", "varsIgnorePattern": "^_"}],
+        "quotes": [0], # Blockly mixes single and double quotes
+        "semi": [2, "always"],
+        "space-before-function-paren": [2, "never"], # Blockly doesn't have space before function paren
+        "strict": [0], # Blockly uses 'use strict' in files
+        "no-cond-assign": [0], # Blockly often uses cond-assignment in loops
+        "no-redeclare": [0] # XXX: should fix
+    },
+    "env": {
+        "browser": true
+    },
+    "globals": {
+        "Blockly": true, # Blockly global
+        "goog": true # goog closure libraries/includes
+    },
+    "extends": "eslint:recommended"
+}

--- a/package.json
+++ b/package.json
@@ -2,9 +2,11 @@
   "name": "blockly",
   "version": "1.0.0",
   "description": "Blockly is a library for building visual programming editors.",
-  "keywords": ["blockly"],
+  "keywords": [
+    "blockly"
+  ],
   "scripts": {
-    "lint": "jshint ."
+    "lint": "eslint ."
   },
   "repository": {
     "type": "git",
@@ -20,11 +22,19 @@
   "license": "Apache-2.0",
   "private": true,
   "devDependencies": {
+    "eslint": "^2.7.0",
     "jshint": "latest"
   },
   "jshintConfig": {
     "globalstrict": true,
-    "predef": ["Blockly", "goog", "window", "document", "soy", "XMLHttpRequest"],
+    "predef": [
+      "Blockly",
+      "goog",
+      "window",
+      "document",
+      "soy",
+      "XMLHttpRequest"
+    ],
     "sub": true,
     "undef": true,
     "unused": true


### PR DESCRIPTION
Our projects generally use .eslintrc. Eslint gives many, many lint warnings at this point (even though I've adjusted things to be more like Blockly). Eventually it would be good to pass through and fix things up and see if there are any conflicts with closure lint. In the meantime this will help us write correct code.
