### PR TITLE
Keep text-input widget div options to CSS class

### DIFF
--- a/core/css.js
+++ b/core/css.js
@@ -143,6 +143,9 @@ Blockly.Css.CONTENT = [
     'display: none;',
     'position: absolute;',
     'z-index: 999;',
+  '}',
+
+  '.blocklyWidgetDiv.fieldTextInput {',
     'overflow: hidden;',
     'border: 1px solid;',
     'box-sizing: border-box;',

--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -127,6 +127,8 @@ Blockly.FieldTextInput.prototype.showEditor_ = function(opt_quietInput) {
 
   Blockly.WidgetDiv.show(this, this.sourceBlock_.RTL, this.widgetDispose_());
   var div = Blockly.WidgetDiv.DIV;
+  // Apply text-input-specific fixed CSS
+  div.className += ' fieldTextInput';
   // Create the input.
   var htmlInput = goog.dom.createDom('input', 'blocklyHtmlInput');
   htmlInput.setAttribute('spellcheck', this.spellcheck_);
@@ -317,6 +319,8 @@ Blockly.FieldTextInput.prototype.widgetDispose_ = function() {
     style.width = 'auto';
     style.height = 'auto';
     style.fontSize = '';
+    // Reset class
+    Blockly.WidgetDiv.DIV.className = 'blocklyWidgetDiv';
   };
 };
 


### PR DESCRIPTION
My field changes broke the right-click menu because it uses the Widget Div, and I was applying a bunch of incompatible styles to it. Instead, I only apply those styles when we're actually rendering a text input by keeping those in a class. Fixes the right-click menu!
