### PR TITLE
Update size of statement block space on top #169

### DIFF
--- a/core/block_render_svg_horizontal.js
+++ b/core/block_render_svg_horizontal.js
@@ -51,7 +51,7 @@ Blockly.BlockSvg.SEP_SPACE_Y = 3 * Blockly.BlockSvg.GRID_UNIT;
  * Vertical space above blocks with statements.
  * @const
  */
-Blockly.BlockSvg.STATEMENT_BLOCK_SPACE = 4 * Blockly.BlockSvg.GRID_UNIT;
+Blockly.BlockSvg.STATEMENT_BLOCK_SPACE = 3 * Blockly.BlockSvg.GRID_UNIT;
 
 /**
  * Height of user inputs


### PR DESCRIPTION
@carljbowman 
It turns out this is actually something we made very easy to change - a single variable. So let's adjust it all we want :P

<img width="607" alt="screen shot 2016-04-06 at 9 12 04 pm" src="https://cloud.githubusercontent.com/assets/120403/14337492/6ceebb78-fc3c-11e5-94c2-42ded5ce5508.png">

Does this look ok to you?
