### PR TITLE
Only create new blocks in flyout at certain angle #179

### DIFF
--- a/core/flyout.js
+++ b/core/flyout.js
@@ -788,7 +788,8 @@ Blockly.Flyout.prototype.onMouseMoveBlock_ = function(e) {
     }
   }
 
-  // Still dragging within the sticky DRAG_RADIUS.
+  // Don't create a block within the sticky drag radius,
+  // or if we failed the direction check.
   if (Math.sqrt(dx * dx + dy * dy) > Blockly.DRAG_RADIUS && directionCheck) {
     // Create the block.
     Blockly.Flyout.startFlyout_.createBlockFunc_(Blockly.Flyout.startBlock_)(

--- a/core/flyout.js
+++ b/core/flyout.js
@@ -153,7 +153,7 @@ Blockly.Flyout.prototype.verticalOffset_ = 0;
  * @type {number}
  * @private
 */
-Blockly.Flyout.prototype.dragTowardWorkspaceOrthogonalAngleRange_ = 70;
+Blockly.Flyout.prototype.dragAngleRange_ = 70;
 
 /**
  * Creates the flyout's DOM.  Only needs to be called once.
@@ -798,7 +798,7 @@ Blockly.Flyout.prototype.isDragTowardWorkspace_ = function(dx, dy) {
   var dragDirection = Math.atan2(dy, dx) / Math.PI * 180;
 
   var draggingTowardWorkspace = false;
-  var range = Blockly.Flyout.startFlyout_.dragTowardWorkspaceOrthogonalAngleRange_;
+  var range = Blockly.Flyout.startFlyout_.dragAngleRange_;
   if (Blockly.Flyout.startFlyout_.horizontalLayout_) {
     if (Blockly.Flyout.startFlyout_.toolboxPosition_ == Blockly.TOOLBOX_AT_TOP) {
       // Horizontal at top

--- a/core/flyout.js
+++ b/core/flyout.js
@@ -761,6 +761,7 @@ Blockly.Flyout.prototype.onMouseMoveBlock_ = function(e) {
   var dx = e.clientX - Blockly.Flyout.startDownEvent_.clientX;
   var dy = e.clientY - Blockly.Flyout.startDownEvent_.clientY;
 
+  // Direction goes from -180 to 180, with 0 toward the right and 90 on top.
   var direction = Math.atan2(dy, dx) / Math.PI * 180;
 
   // Do a direction check based on the flyout position

--- a/core/flyout.js
+++ b/core/flyout.js
@@ -141,6 +141,18 @@ Blockly.Flyout.prototype.height_ = 0;
 Blockly.Flyout.prototype.verticalOffset_ = 0;
 
 /**
+ * Minimum angle at which blocks are created from a fixed flyout.
+ * @type {number}
+*/
+Blockly.Flyout.prototype.directionRangeMin = 20;
+
+/**
+ * Maximum angle at which blocks are created from a fixed flyout.
+ * @type {number}
+*/
+Blockly.Flyout.prototype.directionRangeMax = 160;
+
+/**
  * Creates the flyout's DOM.  Only needs to be called once.
  * @return {!Element} The flyout's SVG group.
  */
@@ -671,6 +683,8 @@ Blockly.Flyout.prototype.blockMouseDown_ = function(block) {
       // Left-click (or middle click)
       Blockly.Css.setCursor(Blockly.Css.Cursor.CLOSED);
       // Record the current mouse position.
+      flyout.startDragMouseY_ = e.clientY;
+      flyout.startDragMouseX_ = e.clientX;
       Blockly.Flyout.startDownEvent_ = e;
       Blockly.Flyout.startBlock_ = block;
       Blockly.Flyout.startFlyout_ = flyout;
@@ -751,11 +765,19 @@ Blockly.Flyout.prototype.onMouseMoveBlock_ = function(e) {
   }
   var dx = e.clientX - Blockly.Flyout.startDownEvent_.clientX;
   var dy = e.clientY - Blockly.Flyout.startDownEvent_.clientY;
+
+  var direction = Math.atan2(dy, dx) / Math.PI * 180;
+
   // Still dragging within the sticky DRAG_RADIUS.
-  if (Math.sqrt(dx * dx + dy * dy) > Blockly.DRAG_RADIUS) {
+  if (Math.sqrt(dx * dx + dy * dy) > Blockly.DRAG_RADIUS &&
+      direction > Blockly.Flyout.startFlyout_.directionRangeMin &&
+      direction < Blockly.Flyout.startFlyout_.directionRangeMax) {
     // Create the block.
     Blockly.Flyout.startFlyout_.createBlockFunc_(Blockly.Flyout.startBlock_)(
         Blockly.Flyout.startDownEvent_);
+  } else {
+    // Do a scroll
+    Blockly.Flyout.startFlyout_.onMouseMove_(e);
   }
 };
 

--- a/core/flyout.js
+++ b/core/flyout.js
@@ -141,16 +141,11 @@ Blockly.Flyout.prototype.height_ = 0;
 Blockly.Flyout.prototype.verticalOffset_ = 0;
 
 /**
- * Minimum angle at which blocks are created from a fixed flyout.
+ * Angle size at which blocks are created from a fixed flyout on touch.
  * @type {number}
+ * @private
 */
-Blockly.Flyout.prototype.directionRangeMin = 20;
-
-/**
- * Maximum angle at which blocks are created from a fixed flyout.
- * @type {number}
-*/
-Blockly.Flyout.prototype.directionRangeMax = 160;
+Blockly.Flyout.prototype.directionRange_ = 140;
 
 /**
  * Creates the flyout's DOM.  Only needs to be called once.
@@ -313,7 +308,7 @@ Blockly.Flyout.prototype.setMetrics_ = function(xyRatio) {
 
 Blockly.Flyout.prototype.setVerticalOffset = function(verticalOffset) {
   this.verticalOffset_ = verticalOffset;
-}
+};
 
 /**
  * Move the toolbox to the edge of the workspace.
@@ -768,10 +763,33 @@ Blockly.Flyout.prototype.onMouseMoveBlock_ = function(e) {
 
   var direction = Math.atan2(dy, dx) / Math.PI * 180;
 
+  // Do a direction check based on the flyout position
+  var directionCheck = false;
+  var range = Blockly.Flyout.startFlyout_.directionRange_;
+  if (Blockly.Flyout.startFlyout_.horizontalLayout_) {
+    if (Blockly.Flyout.startFlyout_.toolboxPosition_ == Blockly.TOOLBOX_AT_TOP) {
+      if (direction < 90 + range / 2 && direction > 90 - range / 2) {
+        directionCheck = true;
+      }
+    } else {
+      if (direction > -90 - range / 2 && direction < -90 + range / 2) {
+        directionCheck = true;
+      }
+    }
+  } else {
+    if (Blockly.Flyout.startFlyout_.toolboxPosition_ == Blockly.TOOLBOX_AT_LEFT) {
+      if (direction < range / 2 && direction > -range / 2) {
+        directionCheck = true;
+      }
+    } else {
+      if (direction < -180 + range / 2 || direction > 180 - range / 2) {
+        directionCheck = true;
+      }
+    }
+  }
+
   // Still dragging within the sticky DRAG_RADIUS.
-  if (Math.sqrt(dx * dx + dy * dy) > Blockly.DRAG_RADIUS &&
-      direction > Blockly.Flyout.startFlyout_.directionRangeMin &&
-      direction < Blockly.Flyout.startFlyout_.directionRangeMax) {
+  if (Math.sqrt(dx * dx + dy * dy) > Blockly.DRAG_RADIUS && directionCheck) {
     // Create the block.
     Blockly.Flyout.startFlyout_.createBlockFunc_(Blockly.Flyout.startBlock_)(
         Blockly.Flyout.startDownEvent_);
@@ -779,6 +797,7 @@ Blockly.Flyout.prototype.onMouseMoveBlock_ = function(e) {
     // Do a scroll
     Blockly.Flyout.startFlyout_.onMouseMove_(e);
   }
+  e.stopPropagation();
 };
 
 /**

--- a/core/flyout.js
+++ b/core/flyout.js
@@ -141,11 +141,19 @@ Blockly.Flyout.prototype.height_ = 0;
 Blockly.Flyout.prototype.verticalOffset_ = 0;
 
 /**
- * Angle size at which blocks are created from a fixed flyout on touch.
+ * Range of a drag angle from a fixed flyout considered "dragging toward workspace."
+ * Drags that are within the bounds of this many degrees from the orthogonal
+ * line to the flyout edge are considered to be "drags toward the workspace."
+ * Example:
+ * Flyout                                                  Edge   Workspace
+ * [block] /  <-within this angle, drags "toward workspace" |
+ * [block] ---- orthogonal to flyout boundary ----          |
+ * [block] \                                                |
+ * The angle is given in degrees from the orthogonal.
  * @type {number}
  * @private
 */
-Blockly.Flyout.prototype.directionRange_ = 140;
+Blockly.Flyout.prototype.dragTowardWorkspaceOrthogonalAngleRange_ = 70;
 
 /**
  * Creates the flyout's DOM.  Only needs to be called once.
@@ -761,37 +769,11 @@ Blockly.Flyout.prototype.onMouseMoveBlock_ = function(e) {
   var dx = e.clientX - Blockly.Flyout.startDownEvent_.clientX;
   var dy = e.clientY - Blockly.Flyout.startDownEvent_.clientY;
 
-  // Direction goes from -180 to 180, with 0 toward the right and 90 on top.
-  var direction = Math.atan2(dy, dx) / Math.PI * 180;
-
-  // Do a direction check based on the flyout position
-  var directionCheck = false;
-  var range = Blockly.Flyout.startFlyout_.directionRange_;
-  if (Blockly.Flyout.startFlyout_.horizontalLayout_) {
-    if (Blockly.Flyout.startFlyout_.toolboxPosition_ == Blockly.TOOLBOX_AT_TOP) {
-      if (direction < 90 + range / 2 && direction > 90 - range / 2) {
-        directionCheck = true;
-      }
-    } else {
-      if (direction > -90 - range / 2 && direction < -90 + range / 2) {
-        directionCheck = true;
-      }
-    }
-  } else {
-    if (Blockly.Flyout.startFlyout_.toolboxPosition_ == Blockly.TOOLBOX_AT_LEFT) {
-      if (direction < range / 2 && direction > -range / 2) {
-        directionCheck = true;
-      }
-    } else {
-      if (direction < -180 + range / 2 || direction > 180 - range / 2) {
-        directionCheck = true;
-      }
-    }
-  }
-
-  // Don't create a block within the sticky drag radius,
-  // or if we failed the direction check.
-  if (Math.sqrt(dx * dx + dy * dy) > Blockly.DRAG_RADIUS && directionCheck) {
+  // Only create a block if the user is dragging toward the workspace,
+  // Otherwise the drag might be the start of a scroll in the flyout.
+  // Don't create a block within the sticky drag radius.
+  if (this.isDragTowardWorkspace_(dx, dy) &&
+      Math.sqrt(dx * dx + dy * dy) > Blockly.DRAG_RADIUS) {
     // Create the block.
     Blockly.Flyout.startFlyout_.createBlockFunc_(Blockly.Flyout.startBlock_)(
         Blockly.Flyout.startDownEvent_);
@@ -800,6 +782,49 @@ Blockly.Flyout.prototype.onMouseMoveBlock_ = function(e) {
     Blockly.Flyout.startFlyout_.onMouseMove_(e);
   }
   e.stopPropagation();
+};
+
+/**
+ * Determine if a drag delta is toward the workspace, based on the position
+ * and orientation of the flyout. This is used in onMouseMoveBlock_ to determine
+ * if a new block should be created or if the flyout should scroll.
+ * @param {number} dx X delta of the drag
+ * @param {number} dy Y delta of the drag
+ * @return {boolean} true if the drag is toward the workspace.
+ * @private
+ */
+Blockly.Flyout.prototype.isDragTowardWorkspace_ = function(dx, dy) {
+  // Direction goes from -180 to 180, with 0 toward the right and 90 on top.
+  var dragDirection = Math.atan2(dy, dx) / Math.PI * 180;
+
+  var draggingTowardWorkspace = false;
+  var range = Blockly.Flyout.startFlyout_.dragTowardWorkspaceOrthogonalAngleRange_;
+  if (Blockly.Flyout.startFlyout_.horizontalLayout_) {
+    if (Blockly.Flyout.startFlyout_.toolboxPosition_ == Blockly.TOOLBOX_AT_TOP) {
+      // Horizontal at top
+      if (dragDirection < 90 + range && dragDirection > 90 - range ) {
+        draggingTowardWorkspace = true;
+      }
+    } else {
+      // Horizontal at bottom
+      if (dragDirection > -90 - range && dragDirection < -90 + range) {
+        draggingTowardWorkspace = true;
+      }
+    }
+  } else {
+    if (Blockly.Flyout.startFlyout_.toolboxPosition_ == Blockly.TOOLBOX_AT_LEFT) {
+      // Vertical at left
+      if (dragDirection < range && dragDirection > -range) {
+        draggingTowardWorkspace = true;
+      }
+    } else {
+      // Vertical at right
+      if (dragDirection < -180 + range || dragDirection > 180 - range) {
+        draggingTowardWorkspace = true;
+      }
+    }
+  }
+  return draggingTowardWorkspace;
 };
 
 /**


### PR DESCRIPTION
This is especially important on touch - it's hard to scroll the flyout without this.

I explicitly spelled out the logic for when to initiate a drag per position. If you think of a clever way to encapsulate all of that, it would be great to replace it :)

@thisandagain 
