### PR TITLE
Add width and height to drag layer

### DIFF
--- a/core/css.js
+++ b/core/css.js
@@ -190,6 +190,8 @@ Blockly.Css.CONTENT = [
     'left: 0;',
     'right: 0;',
     'bottom: 0;',
+    'width: 100%;',
+    'height: 100%;',
     'overflow: visible !important;',
     'z-index: 5000;', /* Always display on top */
     '-webkit-backface-visibility: hidden;',


### PR DESCRIPTION
Requiring overflow was causing unnecessary repaints.
