### PR TITLE
Implement translation of entire drag surface SVG to prevent repaint.

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -903,7 +903,7 @@ Blockly.BlockSvg.prototype.onMouseMove_ = function(e) {
   if (Blockly.dragMode_ == Blockly.DRAG_FREE) {
     var dx = oldXY.x - this.dragStartXY_.x;
     var dy = oldXY.y - this.dragStartXY_.y;
-    this.workspace.dragSurface.translateSurface(newXY.x, newXY.y, Blockly.is3dSupported());
+    this.workspace.dragSurface.translateSurface(newXY.x, newXY.y);
     // Drag all the nested bubbles.
     for (var i = 0; i < this.draggedBubbles_.length; i++) {
       var commentData = this.draggedBubbles_[i];

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -253,7 +253,6 @@ Blockly.BlockSvg.terminateDrag_ = function() {
       event.oldCoordinate = selected.dragStartXY_;
       event.recordNew();
       Blockly.Events.fire(event);
-
       selected.moveConnections_(dxy.x, dxy.y);
       delete selected.draggedBubbles_;
       selected.setDragging_(false);
@@ -336,6 +335,14 @@ Blockly.BlockSvg.prototype.getRelativeToSurfaceXY = function() {
       var xy = Blockly.getRelativeXY_(element);
       x += xy.x;
       y += xy.y;
+      // If this element is the current element on the drag surface, include
+      // the translation of the drag surface itself.
+      if (this.workspace.dragSurface &&
+          this.workspace.dragSurface.getCurrentBlock() == element) {
+        var surfaceTranslation = this.workspace.dragSurface.getSurfaceTranslation();
+        x += surfaceTranslation.x;
+        y += surfaceTranslation.y;
+      }
       element = element.parentNode;
     } while (element && element != this.workspace.getCanvas() &&
              element != dragSurfaceGroup);
@@ -820,7 +827,7 @@ Blockly.BlockSvg.prototype.moveToDragSurface_ = function() {
   // to keep the position in sync as it move on/off the surface.
   var xy = this.getRelativeToSurfaceXY();
   this.clearTransformAttributes_();
-  this.translate(xy.x, xy.y, Blockly.is3dSupported());
+  this.workspace.dragSurface.translateSurface(xy.x, xy.y);
   // Execute the move on the top-level SVG component
   this.workspace.dragSurface.setBlocksAndShow(this.getSvgRoot());
 };
@@ -830,12 +837,12 @@ Blockly.BlockSvg.prototype.moveToDragSurface_ = function() {
  * Generally should be called at the same time as setDragging_(false).
  * @private
  */
-Blockly.BlockSvg.prototype.moveOffDragSurface_ = function() {
-  this.workspace.dragSurface.clearAndHide(this.workspace.getCanvas());
+ Blockly.BlockSvg.prototype.moveOffDragSurface_ = function() {
   // Translate to current position, turning off 3d.
   var xy = this.getRelativeToSurfaceXY();
   this.clearTransformAttributes_();
   this.translate(xy.x, xy.y, false);
+  this.workspace.dragSurface.clearAndHide(this.workspace.getCanvas());
 };
 
 /**
@@ -896,7 +903,7 @@ Blockly.BlockSvg.prototype.onMouseMove_ = function(e) {
   if (Blockly.dragMode_ == Blockly.DRAG_FREE) {
     var dx = oldXY.x - this.dragStartXY_.x;
     var dy = oldXY.y - this.dragStartXY_.y;
-    this.translate(newXY.x, newXY.y, Blockly.is3dSupported());
+    this.workspace.dragSurface.translateSurface(newXY.x, newXY.y, Blockly.is3dSupported());
     // Drag all the nested bubbles.
     for (var i = 0; i < this.draggedBubbles_.length; i++) {
       var commentData = this.draggedBubbles_[i];
@@ -978,7 +985,6 @@ Blockly.BlockSvg.prototype.updatePreviews = function(closestConnection,
   if (closestConnection &&
       closestConnection != Blockly.highlightedConnection_ &&
       !closestConnection.sourceBlock_.isInsertionMarker()) {
-
     Blockly.highlightedConnection_ = closestConnection;
     Blockly.localConnection_ = localConnection;
     if (!Blockly.insertionMarker_) {

--- a/core/dragsurface_svg.js
+++ b/core/dragsurface_svg.js
@@ -1,6 +1,7 @@
 /**
  * @fileoverview An SVG that floats on top of the workspace.
  * Blocks are moved into this SVG during a drag, improving performance.
+ * The entire SVG is translated, so the blocks are never repainted during drag.
  * @author tmickel@mit.edu (Tim Mickel)
  */
 
@@ -12,6 +13,7 @@
  goog.require('Blockly.constants');
 
  goog.require('goog.asserts');
+ goog.require('goog.math.Coordinate');
 
  /**
   * Class for a Drag Surface SVG.
@@ -42,6 +44,14 @@ Blockly.DragSurfaceSvg.prototype.dragGroup_ = null;
   * @private
   */
 Blockly.DragSurfaceSvg.prototype.container_ = null;
+
+/**
+ * Cached value for the scale of the drag surface.
+ * Used to set/get the correct translation during and after a drag.
+ * @type {Number}
+ * @private
+ */
+Blockly.DragSurfaceSvg.prototype.scale_ = 1;
 
  /**
   * Create the drag surface and inject it into the container.
@@ -80,14 +90,47 @@ Blockly.DragSurfaceSvg.prototype.setBlocksAndShow = function (blocks) {
  * @param {Number} scale Scale of the group
  */
 Blockly.DragSurfaceSvg.prototype.translateAndScaleGroup = function (x, y, scale) {
+  var transform;
+  this.scale_ = scale;
   if (Blockly.is3dSupported()) {
-    var transform = 'transform: translate3d(' + x + 'px, ' + y + 'px, 0px)' +
+    transform = 'transform: translate3d(' + x + 'px, ' + y + 'px, 0px)' +
       'scale3d(' + scale + ',' + scale + ',' + scale + ')';
     this.dragGroup_.setAttribute('style', transform);
   } else {
-    var transform = 'translate(' + x + ', ' + y + ') scale(' + scale + ')';
+    transform = 'translate(' + x + ', ' + y + ') scale(' + scale + ')';
     this.dragGroup_.setAttribute('transform', transform);
   }
+};
+
+/**
+ * Translate the entire drag surface during a drag.
+ * We translate the drag surface instead of the blocks inside the surface
+ * so that the browser avoids repainting the SVG.
+ * Because of this, the drag coordinates must be adjusted by scale.
+ * @param {Number} x X translation for the entire surface
+ * @param {Number} y Y translation for the entire surface
+ */
+Blockly.DragSurfaceSvg.prototype.translateSurface = function(x, y) {
+  var transform;
+  x *= this.scale_;
+  y *= this.scale_;
+  if (Blockly.is3dSupported()) {
+    transform = 'transform: translate3d(' + x + 'px, ' + y + 'px, 0px); display: block;';
+    this.SVG_.setAttribute('style', transform);
+  } else {
+    transform = 'translate(' + x + ', ' + y + ')';
+    this.SVG_.setAttribute('transform', transform);
+  }
+};
+
+/**
+ * Reports the surface translation in scaled workspace coordinates.
+ * Use this when finishing a drag to return blocks to the correct position.
+ * @return {goog.math.Coordinate} Current translation of the surface
+ */
+Blockly.DragSurfaceSvg.prototype.getSurfaceTranslation = function() {
+  var xy = Blockly.getRelativeXY_(this.SVG_);
+  return new goog.math.Coordinate(xy.x / this.scale_, xy.y / this.scale_);
 };
 
 /**
@@ -98,13 +141,21 @@ Blockly.DragSurfaceSvg.prototype.getGroup = function () {
   return this.dragGroup_;
 };
 
+/**
+ * Get the current blocks on the drag surface, if any (primarily for BlockSvg.getRelativeToSurfaceXY).
+ * @return {Element} Drag surface block DOM element
+ */
+Blockly.DragSurfaceSvg.prototype.getCurrentBlock = function () {
+  return this.dragGroup_.childNodes[0];
+};
+
  /**
   * Clear the group and hide the surface; move the blocks off onto the provided element.
   * @param {!Element} newSurface Surface the dragging blocks should be moved to
   */
 Blockly.DragSurfaceSvg.prototype.clearAndHide = function (newSurface) {
   // appendChild removes the node from this.dragGroup_
-  newSurface.appendChild(this.dragGroup_.childNodes[0]);
+  newSurface.appendChild(this.getCurrentBlock());
   this.SVG_.style.display = 'none';
   goog.asserts.assert(this.dragGroup_.childNodes.length == 0, 'Drag group was not cleared.');
 };


### PR DESCRIPTION
-Extend DragSurfaceSvg so that the entire SVG surface can be translated.
-Update getRelativeXY_ to include the drag surface translation when the block is on that surface.
-Translate the surface on the call to moveToDragSurface_ and during the mousemove event.

@picklesrus 
