### PR TITLE
Remove width/height from blocklyDragSurface

### DIFF
--- a/core/css.js
+++ b/core/css.js
@@ -196,8 +196,6 @@ Blockly.Css.CONTENT = [
     'left: 0;',
     'right: 0;',
     'bottom: 0;',
-    'width: 100%;',
-    'height: 100%;',
     'overflow: visible !important;',
     'z-index: 5000;', /* Always display on top */
     '-webkit-backface-visibility: hidden;',


### PR DESCRIPTION
This was causing issue on iOS Safari when the SVG was exceeding the size of the window
