### PR TITLE
Slight refactor of colour handling; add additional properties

### DIFF
--- a/core/block.js
+++ b/core/block.js
@@ -27,6 +27,7 @@
 goog.provide('Blockly.Block');
 
 goog.require('Blockly.Blocks');
+goog.require('Blockly.Colours');
 goog.require('Blockly.Comment');
 goog.require('Blockly.Connection');
 goog.require('Blockly.Input');

--- a/core/block.js
+++ b/core/block.js
@@ -564,7 +564,8 @@ Blockly.Block.prototype.setInsertionMarker = function(insertionMarker) {
   }
   this.isInsertionMarker_ = insertionMarker;
   if (this.isInsertionMarker_) {
-    this.setColour("#949494");
+    this.setColour(Blockly.Colours.insertionMarker);
+    this.setOpacity(Blockly.Colours.insertionMarkerOpacity);
   }
 };
 

--- a/core/block_render_svg_horizontal.js
+++ b/core/block_render_svg_horizontal.js
@@ -211,6 +211,9 @@ Blockly.BlockSvg.prototype.updateColour = function() {
   var fillColour = (this.isGlowing_) ? this.getColourSecondary() : this.getColour();
   this.svgPath_.setAttribute('fill', fillColour);
 
+  // Render opacity
+  this.svgPath_.setAttribute('fill-opacity', this.getOpacity());
+
   // Bump every dropdown to change its colour.
   for (var x = 0, input; input = this.inputList[x]; x++) {
     for (var y = 0, field; field = input.fieldRow[y]; y++) {

--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -170,6 +170,9 @@ Blockly.BlockSvg.prototype.updateColour = function() {
   }
   this.svgPath_.setAttribute('fill', hexColour);
 
+  // Render opacity
+  this.svgPath_.setAttribute('fill-opacity', this.getOpacity());
+
   // Render block stroke
   var colorShift = goog.color.darken(rgb, 0.1);
   var strokeColor = goog.color.rgbArrayToHex(colorShift);

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -66,12 +66,22 @@ goog.inherits(Blockly.BlockSvg, Blockly.Block);
 
 /**
  * Height of this block, not including any statement blocks above or below.
+ * @type {number}
  */
 Blockly.BlockSvg.prototype.height = 0;
+
 /**
  * Width of this block, including any connected value blocks.
+ * @type {number}
  */
 Blockly.BlockSvg.prototype.width = 0;
+
+/**
+ * Opacity of this block between 0 and 1.
+ * @type {number}
+ * @private
+ */
+Blockly.BlockSvg.prototype.opacity_ = 1;
 
 /**
  * Original location of block being dragged.
@@ -464,6 +474,25 @@ Blockly.BlockSvg.prototype.getBoundingRectangle = function() {
         blockXY.y + blockBounds.height);
   }
   return {topLeft: topLeft, bottomRight: bottomRight};
+};
+
+/**
+ * Set block opacity for SVG rendering.
+ * @param {number} opacity Intended opacity, betweeen 0 and 1
+ */
+Blockly.BlockSvg.prototype.setOpacity = function(opacity) {
+  this.opacity_ = opacity;
+  if (this.rendered) {
+    this.updateColour();
+  }
+};
+
+/**
+ * Get block opacity for SVG rendering.
+ * @return {number} Intended opacity, betweeen 0 and 1
+ */
+Blockly.BlockSvg.prototype.getOpacity = function() {
+  return this.opacity_;
 };
 
 /**

--- a/core/colours.js
+++ b/core/colours.js
@@ -32,6 +32,11 @@ Blockly.Colours = {
   },
   "text": "#575E75",
   "workspace": "#F5F8FF",
+  "toolbox": "#DDDDDD",
+  "toolboxText": "#000000",
+  "flyout": "#DDDDDD",
+  "scrollbar": "#CCCCCC",
+  "scrollbarHover": '#BBBBBB',
   "textField": "#FFFFFF",
   "insertionMarker": "#949494",
   "insertionMarkerOpacity": 0.6

--- a/core/colours.js
+++ b/core/colours.js
@@ -3,6 +3,8 @@
 goog.provide('Blockly.Colours');
 
 Blockly.Colours = {
+  // SVG colours: these must be specificed in #RRGGBB style
+  // To add an opacity, this must be specified as a separate property (for SVG fill-opacity)
   "motion": {
     "primary": "#4C97FF",
     "secondary": "#4280D7",
@@ -30,5 +32,7 @@ Blockly.Colours = {
   },
   "text": "#575E75",
   "workspace": "#F5F8FF",
-  "textField": "#FFFFFF"
+  "textField": "#FFFFFF",
+  "insertionMarker": "#949494",
+  "insertionMarkerOpacity": 0.6
 };

--- a/core/css.js
+++ b/core/css.js
@@ -87,6 +87,12 @@ Blockly.Css.inject = function(hasCss, pathToMedia) {
   // Strip off any trailing slash (either Unix or Windows).
   Blockly.Css.mediaPath_ = pathToMedia.replace(/[\\\/]$/, '');
   text = text.replace(/<<<PATH>>>/g, Blockly.Css.mediaPath_);
+  // Dynamically replace colours in the CSS text, in case they have
+  // been set at run-time injection.
+  for (var colourProperty in Blockly.Colours) {
+    if (!Blockly.Colours.hasOwnProperty(colourProperty)) continue;
+    text = text.replace('$colour_' + colourProperty, Blockly.Colours[colourProperty]);
+  }
   // Inject CSS tag.
   var cssNode = document.createElement('style');
   document.head.appendChild(cssNode);
@@ -140,7 +146,7 @@ Blockly.Css.setCursor = function(cursor) {
  */
 Blockly.Css.CONTENT = [
   '.blocklySvg {',
-    'background-color: ' + Blockly.Colours.workspace + ';',
+    'background-color: $colour_workspace;',
     'outline: none;',
     'overflow: hidden;',  /* IE overflows by default. */
   '}',
@@ -261,7 +267,7 @@ Blockly.Css.CONTENT = [
 
   '.blocklyNonEditableText>text,',
   '.blocklyEditableText>text {',
-    'fill: ' +  Blockly.Colours.text + ';',
+    'fill: $colour_text;',
   '}',
 
   '.blocklyEditableText:hover>rect {',
@@ -270,7 +276,7 @@ Blockly.Css.CONTENT = [
   '}',
 
   '.blocklyBubbleText {',
-    'fill:' + Blockly.Colours.text +';',
+    'fill: $colour_text;',
   '}',
 
   /*
@@ -333,7 +339,7 @@ Blockly.Css.CONTENT = [
     'padding: 2px 0;',
     'width: 100%;',
     'text-align: center;',
-    'color: ' + Blockly.Colours.text + ';',
+    'color: $colour_text;',
   '}',
 
   '.blocklyMainBackground {',

--- a/core/css.js
+++ b/core/css.js
@@ -354,7 +354,7 @@ Blockly.Css.CONTENT = [
   '}',
 
   '.blocklyFlyoutBackground {',
-    'fill: #ddd;',
+    'fill: $colour_flyout;',
     'fill-opacity: .8;',
   '}',
 
@@ -363,12 +363,12 @@ Blockly.Css.CONTENT = [
   '}',
 
   '.blocklyScrollbarKnob {',
-    'fill: #ccc;',
+    'fill: $colour_scrollbar;',
   '}',
 
   '.blocklyScrollbarBackground:hover+.blocklyScrollbarKnob,',
   '.blocklyScrollbarKnob:hover {',
-    'fill: #bbb;',
+    'fill: $colour_scrollbarHover;',
   '}',
 
   '.blocklyZoom>image {',
@@ -437,7 +437,8 @@ Blockly.Css.CONTENT = [
 
   /* Category tree in Toolbox. */
   '.blocklyToolboxDiv {',
-    'background-color: #ddd;',
+    'background-color: $colour_toolbox;',
+    'color: $colour_toolboxText;',
     'overflow-x: visible;',
     'overflow-y: auto;',
     'position: absolute;',

--- a/core/css.js
+++ b/core/css.js
@@ -90,8 +90,9 @@ Blockly.Css.inject = function(hasCss, pathToMedia) {
   // Dynamically replace colours in the CSS text, in case they have
   // been set at run-time injection.
   for (var colourProperty in Blockly.Colours) {
-    if (!Blockly.Colours.hasOwnProperty(colourProperty)) continue;
-    text = text.replace('$colour_' + colourProperty, Blockly.Colours[colourProperty]);
+    if (Blockly.Colours.hasOwnProperty(colourProperty)) {
+      text = text.replace('$colour_' + colourProperty, Blockly.Colours[colourProperty]);
+    }
   }
   // Inject CSS tag.
   var cssNode = document.createElement('style');

--- a/core/css.js
+++ b/core/css.js
@@ -333,6 +333,7 @@ Blockly.Css.CONTENT = [
     'padding: 2px 0;',
     'width: 100%;',
     'text-align: center;',
+    'color: ' + Blockly.Colours.text + ';',
   '}',
 
   '.blocklyMainBackground {',

--- a/core/options.js
+++ b/core/options.js
@@ -111,11 +111,12 @@ Blockly.Options = function(options) {
   var colours = options['colours'];
   if (colours) {
     for (var colourProperty in colours) {
-      if (!colours.hasOwnProperty(colourProperty)) continue;
-      if (!Blockly.Colours.hasOwnProperty(colourProperty)) continue;
-      // If a property is in both colours option and Blockly.Colours,
-      // set the Blockly.Colours value to the override.
-      Blockly.Colours[colourProperty] = colours[colourProperty];
+      if (colours.hasOwnProperty(colourProperty) &&
+          Blockly.Colours.hasOwnProperty(colourProperty)) {
+        // If a property is in both colours option and Blockly.Colours,
+        // set the Blockly.Colours value to the override.
+        Blockly.Colours[colourProperty] = colours[colourProperty];
+      }
     }
   }
 

--- a/core/options.js
+++ b/core/options.js
@@ -25,6 +25,7 @@
 'use strict';
 
 goog.provide('Blockly.Options');
+goog.require('Blockly.Colours');
 
 
 /**
@@ -105,6 +106,18 @@ Blockly.Options = function(options) {
 
   var enableRealtime = !!options['realtime'];
   var realtimeOptions = enableRealtime ? options['realtimeOptions'] : undefined;
+
+  // Colour overrides provided by the injection
+  var colours = options['colours'];
+  if (colours) {
+    for (var colourProperty in colours) {
+      if (!colours.hasOwnProperty(colourProperty)) continue;
+      if (!Blockly.Colours.hasOwnProperty(colourProperty)) continue;
+      // If a property is in both colours option and Blockly.Colours,
+      // set the Blockly.Colours value to the override.
+      Blockly.Colours[colourProperty] = colours[colourProperty];
+    }
+  }
 
   this.RTL = !!options['rtl'];
   this.collapse = hasCollapse;

--- a/tests/horizontal_playground.html
+++ b/tests/horizontal_playground.html
@@ -37,6 +37,11 @@ function start() {
     trashcan: true,
     horizontalLayout: true,
     toolboxPosition: 'start',
+    grid: {spacing: 16,
+      length: 1,
+      colour: '#2C344A',
+      snap: false
+    },
     zoom: {
       controls: true,
       wheel: true,
@@ -45,6 +50,14 @@ function start() {
       minScale: 0.25,
       scaleSpeed: 1.1
     },
+    colours: {
+      workspace: '#334771',
+      flyout: '#283856',
+      scrollbar: '#24324D',
+      scrollbarHover: '#0C111A',
+      insertionMarker: '#FFFFFF',
+      insertionMarkerOpacity: 0.3,
+    }
   });
   // Restore previously displayed text.
   var text = sessionStorage.getItem('textarea');


### PR DESCRIPTION
This allows us to override colour properties at injection-time. This is nice because it means we can override things like insertion marker colour on a per-workspace basis.

Also adds a bunch of properties to our colour library (toolbox, flyout, scrollbars, insertion markers), provides a per-block opacity property (set on insertion markers). Also made our horizontal workspace in "dark mode" for fun.

@thisandagain 
