### PR TITLE
Allow WidgetDiv to hide immediately, no animation

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -375,6 +375,7 @@ Blockly.BlockSvg.prototype.moveBy = function(dx, dy) {
   this.moveConnections_(dx, dy);
   event.recordNew();
   Blockly.Events.fire(event);
+  Blockly.WidgetDiv.hide(true);
 };
 
 /**
@@ -923,6 +924,8 @@ Blockly.BlockSvg.prototype.onMouseMove_ = function(e) {
       // drag surface. By moving to the drag surface before unplug, connection
       // positions will be calculated correctly.
       this.moveToDragSurface_();
+      // Clear all WidgetDivs without animating, in case blocks are moved around
+      Blockly.WidgetDiv.hide(true);
       if (this.parentBlock_) {
         // Push this block to the very top of the stack.
         this.unplug();
@@ -1415,7 +1418,6 @@ Blockly.BlockSvg.prototype.removeSelect = function() {
 
 /**
  * Adds the dragging class to this block.
- * Also disables the highlights/shadows to improve performance.
  */
 Blockly.BlockSvg.prototype.addDragging = function() {
   Blockly.addClass_(/** @type {!Element} */ (this.svgGroup_),

--- a/core/scrollbar.js
+++ b/core/scrollbar.js
@@ -424,6 +424,9 @@ Blockly.Scrollbar.prototype.onMouseDownBar_ = function(e) {
   }
   this.svgKnob_.setAttribute(this.horizontal_ ? 'x' : 'y',
                              this.constrainKnob_(knobValue));
+  // When the scrollbars are clicked, hide the WidgetDiv without animation
+  // in anticipation of a workspace move.
+  Blockly.WidgetDiv.hide(true);
   this.onScroll_();
   e.stopPropagation();
 };
@@ -452,6 +455,9 @@ Blockly.Scrollbar.prototype.onMouseDownKnob_ = function(e) {
       'mouseup', this, this.onMouseUpKnob_);
   Blockly.Scrollbar.onMouseMoveWrapper_ = Blockly.bindEvent_(document,
       'mousemove', this, this.onMouseMoveKnob_);
+  // When the scrollbars are clicked, hide the WidgetDiv without animation
+  // in anticipation of a workspace move.
+  Blockly.WidgetDiv.hide(true);
   e.stopPropagation();
 };
 

--- a/core/widgetdiv.js
+++ b/core/widgetdiv.js
@@ -127,7 +127,7 @@ Blockly.WidgetDiv.hide = function(opt_noAnimate) {
     // This happens when a previous widget was animating out,
     // but Blockly is hiding the widget to create a new one.
     // So, short-circuit the animation and clear the timer.
-    Blockly.WidgetDiv.disposeAnimationTimer_ && window.clearTimeout(Blockly.WidgetDiv.disposeAnimationTimer_);
+    window.clearTimeout(Blockly.WidgetDiv.disposeAnimationTimer_);
     Blockly.WidgetDiv.disposeAnimationFinished_ && Blockly.WidgetDiv.disposeAnimationFinished_();
     Blockly.WidgetDiv.disposeAnimationFinished_ = null;
     Blockly.WidgetDiv.disposeAnimationTimer_ = null;

--- a/core/widgetdiv.js
+++ b/core/widgetdiv.js
@@ -119,14 +119,15 @@ Blockly.WidgetDiv.show = function(newOwner, rtl, opt_dispose,
 
 /**
  * Destroy the widget and hide the div.
+ * @param {boolean=} opt_noAnimate If set, animation will not be run for the hide.
  */
-Blockly.WidgetDiv.hide = function() {
+Blockly.WidgetDiv.hide = function(opt_noAnimate) {
   if (Blockly.WidgetDiv.disposeAnimationTimer_) {
     // An animation timer is set already.
     // This happens when a previous widget was animating out,
     // but Blockly is hiding the widget to create a new one.
     // So, short-circuit the animation and clear the timer.
-    window.clearTimeout(Blockly.WidgetDiv.disposeAnimationTimer_);
+    Blockly.WidgetDiv.disposeAnimationTimer_ && window.clearTimeout(Blockly.WidgetDiv.disposeAnimationTimer_);
     Blockly.WidgetDiv.disposeAnimationFinished_ && Blockly.WidgetDiv.disposeAnimationFinished_();
     Blockly.WidgetDiv.disposeAnimationFinished_ = null;
     Blockly.WidgetDiv.disposeAnimationTimer_ = null;
@@ -138,13 +139,15 @@ Blockly.WidgetDiv.hide = function() {
     Blockly.WidgetDiv.dispose_ && Blockly.WidgetDiv.dispose_();
     Blockly.WidgetDiv.dispose_ = null;
     // If we want to animate out, set the appropriate timer for final dispose.
-    if (Blockly.WidgetDiv.disposeAnimationFinished_) {
+    if (Blockly.WidgetDiv.disposeAnimationFinished_ && !opt_noAnimate) {
       Blockly.WidgetDiv.disposeAnimationTimer_ = window.setTimeout(
         Blockly.WidgetDiv.hide, // Come back to hide and take the first branch.
         Blockly.WidgetDiv.disposeAnimationTimerLength_ * 1000
       );
     } else {
-      // No timer provided - auto-hide the DOM now.
+      // No timer provided (or no animation desired) - auto-hide the DOM now.
+      Blockly.WidgetDiv.disposeAnimationFinished_ && Blockly.WidgetDiv.disposeAnimationFinished_();
+      Blockly.WidgetDiv.disposeAnimationFinished_ = null;
       Blockly.WidgetDiv.owner_ = null;
       Blockly.WidgetDiv.hideAndClearDom_();
     }

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -690,6 +690,9 @@ Blockly.WorkspaceSvg.prototype.onMouseWheel_ = function(e) {
     this.zoom(position.x, position.y, delta);
   } else {
     // This is a regular mouse wheel event - scroll the workspace
+    // First hide the WidgetDiv without animation
+    // (mouse scroll makes field out of place with div)
+    Blockly.WidgetDiv.hide(true);
     var x = this.scrollX - e.deltaX;
     var y = this.scrollY - e.deltaY;
     this.startDragMetrics = this.getMetrics();
@@ -991,6 +994,8 @@ Blockly.WorkspaceSvg.prototype.zoom = function(x, y, type) {
   } else {
     this.translate(0, 0);
   }
+  // Hide the WidgetDiv without animation (zoom makes field out of place with div)
+  Blockly.WidgetDiv.hide(true);
   Blockly.hideChaff(false);
   if (this.flyout_) {
     // No toolbox, resize flyout.
@@ -1038,6 +1043,8 @@ Blockly.WorkspaceSvg.prototype.zoomToFit = function() {
   this.scale = newScale;
   this.updateGridPattern_();
   this.scrollbar.resize();
+  // Hide the WidgetDiv without animation (zoom makes field out of place with div)
+  Blockly.WidgetDiv.hide(true);
   Blockly.hideChaff(false);
   if (this.flyout_) {
     // No toolbox, resize flyout.
@@ -1056,6 +1063,8 @@ Blockly.WorkspaceSvg.prototype.zoomToFit = function() {
 Blockly.WorkspaceSvg.prototype.zoomReset = function(e) {
   this.scale = 1;
   this.updateGridPattern_();
+  // Hide the WidgetDiv without animation (zoom makes field out of place with div)
+  Blockly.WidgetDiv.hide(true);
   Blockly.hideChaff(false);
   if (this.flyout_) {
     // No toolbox, resize flyout.
@@ -1091,7 +1100,9 @@ Blockly.WorkspaceSvg.prototype.scroll = function(x, y) {
                metrics.contentWidth);
   y = Math.max(y, metrics.viewHeight - metrics.contentTop -
                metrics.contentHeight);
-
+   // When the workspace starts scrolling, hide the WidgetDiv without animation.
+   // This is to prevent a dispoal animation from happening in the wrong location.
+   Blockly.WidgetDiv.hide(true);
   // Move the scrollbars and the page will scroll automatically.
   this.scrollbar.set(-x - metrics.contentLeft,
                      -y - metrics.contentTop);


### PR DESCRIPTION
And add calls to this where the div animation may become out of sync with the field itself.

When hide() is normally called by hideChaff, the animate-out was being triggered. This was bad, because often hideChaff was called before the block itself was being moved. Then the WidgetDiv was animating out, but the field was visible in a different location - just generally looking weird.

A bit of a spaghetti fix but unfortunately since hideChaff is used for so many things in so many places, trying to fix it there seemed even more of a spaghetti fix.
