### PR TITLE
Allow text fields to skip truncation mid-render

### DIFF
--- a/core/field.js
+++ b/core/field.js
@@ -321,19 +321,16 @@ Blockly.Field.prototype.getText = function() {
 /**
  * Set the text in this field.  Trigger a rerender of the source block.
  * @param {*} text New text.
+ * @param {boolean=} opt_skipTruncation If true, skip truncation of text (for mid-renders).
  */
-Blockly.Field.prototype.setText = function(text) {
+Blockly.Field.prototype.setText = function(text, opt_skipTruncation) {
   if (text === null) {
     // No change if null.
     return;
   }
   text = String(text);
-  if (text === this.text_) {
-    // No change.
-    return;
-  }
   this.text_ = text;
-  this.updateTextNode_();
+  this.updateTextNode_(opt_skipTruncation);
 
   if (this.sourceBlock_ && this.sourceBlock_.rendered) {
     this.sourceBlock_.render();
@@ -343,15 +340,16 @@ Blockly.Field.prototype.setText = function(text) {
 
 /**
  * Update the text node of this field to display the current text.
+ * @param {boolean=} opt_skipTruncation If true, skip truncation of text (for mid-renders).
  * @private
  */
-Blockly.Field.prototype.updateTextNode_ = function() {
+Blockly.Field.prototype.updateTextNode_ = function(opt_skipTruncation) {
   if (!this.textElement_) {
     // Not rendered yet.
     return;
   }
   var text = this.text_;
-  if (text.length > this.maxDisplayLength) {
+  if (!opt_skipTruncation && text.length > this.maxDisplayLength) {
     // Truncate displayed string and add an ellipsis ('...').
     text = text.substring(0, this.maxDisplayLength - 2) + '\u2026';
   }
@@ -387,21 +385,19 @@ Blockly.Field.prototype.getValue = function() {
  * By default there is no difference between the human-readable text and
  * the language-neutral values.  Subclasses (such as dropdown) may define this.
  * @param {string} newText New text.
+ * @param {boolean=} opt_skipTruncation If true, skip truncation of text (for mid-renders).
  */
-Blockly.Field.prototype.setValue = function(newText) {
+Blockly.Field.prototype.setValue = function(newText, opt_skipTruncation) {
   if (newText === null) {
     // No change if null.
     return;
   }
   var oldText = this.getValue();
-  if (oldText == newText) {
-    return;
-  }
-  if (this.sourceBlock_ && Blockly.Events.isEnabled()) {
+  if (oldText != newText && this.sourceBlock_ && Blockly.Events.isEnabled()) {
     Blockly.Events.fire(new Blockly.Events.Change(
         this.sourceBlock_, 'field', this.name, oldText, newText));
   }
-  this.setText(newText);
+  this.setText(newText, opt_skipTruncation);
 };
 
 /**

--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -77,9 +77,10 @@ Blockly.FieldTextInput.prototype.dispose = function() {
 /**
  * Set the text in this field.
  * @param {?string} text New text.
+ * @param {boolean=} opt_skipTruncation If true, skip truncation of text (for mid-renders).
  * @override
  */
-Blockly.FieldTextInput.prototype.setValue = function(text) {
+Blockly.FieldTextInput.prototype.setValue = function(text, opt_skipTruncation) {
   if (text === null) {
     return;  // No change if null.
   }
@@ -91,7 +92,7 @@ Blockly.FieldTextInput.prototype.setValue = function(text) {
       text = validated;
     }
   }
-  Blockly.Field.prototype.setValue.call(this, text);
+  Blockly.Field.prototype.setValue.call(this, text, opt_skipTruncation);
 };
 
 /**
@@ -193,7 +194,7 @@ Blockly.FieldTextInput.prototype.onHtmlInputChange_ = function(e) {
   var text = htmlInput.value;
   if (text !== htmlInput.oldValue_) {
     htmlInput.oldValue_ = text;
-    this.setValue(text);
+    this.setValue(text, true);
     this.validate_();
   } else if (goog.userAgent.WEBKIT) {
     // Cursor key.  Render the source block to show the caret moving.


### PR DESCRIPTION
Here is another mess for your review :)

Blockly.Field truncates text that gets too long.

The size of the field is calculated (getSize, getBBox, actually in render) by actually inserting the text into the SVG and then measuring the box size . But the underlying field previously always displayed using the truncated version of the text. So, when you are editing a field and don't want the full truncation, the sizing was wrong.

With this update, the underlying field always displays the current version of the text, even if in the final render it might be truncated. It keeps the underlying field in sync with the edited version more closely.

Another way to do this might be to always truncate for the field render. But then we need a way to measure the size of the text during editing (involves rendering to a canvas or something unpleasant).

Let me know if that doesn't make sense...
