### PR TITLE
Implementation of grow on drag

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -32,6 +32,7 @@ goog.require('goog.Timer');
 goog.require('goog.asserts');
 goog.require('goog.dom');
 goog.require('goog.math.Coordinate');
+goog.require('goog.style');
 goog.require('goog.userAgent');
 
 
@@ -851,9 +852,15 @@ Blockly.BlockSvg.prototype.setDragging_ = function(adding) {
 /**
  * Move this block to its workspace's drag surface, accounting for positioning.
  * Generally should be called at the same time as setDragging_(true).
+ * @param {Event} e Mouse or touch event triggering this move
  * @private
  */
-Blockly.BlockSvg.prototype.moveToDragSurface_ = function() {
+Blockly.BlockSvg.prototype.moveToDragSurface_ = function(e) {
+  // Transform origin for scaling the blocks will be the difference
+  // between the block's absolute position and the click position.
+  var blockPosition = goog.style.getClientPosition(this.getSvgRoot());
+  var originX = e.clientX - blockPosition.x;
+  var originY = e.clientY - blockPosition.y;
   // The translation for drag surface blocks,
   // is equal to the current relative-to-surface position,
   // to keep the position in sync as it move on/off the surface.
@@ -861,7 +868,7 @@ Blockly.BlockSvg.prototype.moveToDragSurface_ = function() {
   this.clearTransformAttributes_();
   this.workspace.dragSurface.translateSurface(xy.x, xy.y);
   // Execute the move on the top-level SVG component
-  this.workspace.dragSurface.setBlocksAndShow(this.getSvgRoot());
+  this.workspace.dragSurface.setBlocksAndShow(this.getSvgRoot(), originX, originY);
 };
 
 /**
@@ -923,7 +930,7 @@ Blockly.BlockSvg.prototype.onMouseMove_ = function(e) {
       // in tighten_(). Then blocks connected to this block move around on the
       // drag surface. By moving to the drag surface before unplug, connection
       // positions will be calculated correctly.
-      this.moveToDragSurface_();
+      this.moveToDragSurface_(e);
       // Clear all WidgetDivs without animating, in case blocks are moved around
       Blockly.WidgetDiv.hide(true);
       if (this.parentBlock_) {

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -864,6 +864,11 @@ Blockly.BlockSvg.prototype.moveToDragSurface_ = function(e) {
   var blockPosition = goog.style.getClientPosition(this.getSvgRoot());
   var originX = e.clientX - blockPosition.x;
   var originY = e.clientY - blockPosition.y;
+  if (this.workspace.RTL) {
+    // Offset scale point by width of stack in RTL
+    var heightWidth = this.getHeightWidth();
+    originX -= heightWidth.width * this.workspace.scale;
+  }
   // The translation for drag surface blocks,
   // is equal to the current relative-to-surface position,
   // to keep the position in sync as it move on/off the surface.

--- a/core/css.js
+++ b/core/css.js
@@ -215,6 +215,15 @@ Blockly.Css.CONTENT = [
     'perspective: 1000;',
   '}',
 
+  '.blocklyDragSurfaceSvg {',
+    'position: absolute;',
+    'top: 0;',
+    'left: 0;',
+    'right: 0;',
+    'bottom: 0;',
+    'overflow: visible !important;',
+  '}',
+
   '.blocklyResizeSE {',
     'cursor: se-resize;',
     'fill: #aaa;',

--- a/core/dragsurface_svg.js
+++ b/core/dragsurface_svg.js
@@ -82,6 +82,22 @@ Blockly.DragSurfaceSvg.prototype.scaleWrapper_ = null;
 Blockly.DragSurfaceSvg.prototype.scale_ = 1;
 
 /**
+ * Cached X value for the translation of the drag surface.
+ * Used to set the correct scale origin point.
+ * @type {Number}
+ * @private
+ */
+Blockly.DragSurfaceSvg.prototype.translateX_ = 0;
+
+/**
+ * Cached Y value for the translation of the drag surface.
+ * Used to set the correct scale origin point.
+ * @type {Number}
+ * @private
+ */
+Blockly.DragSurfaceSvg.prototype.translateY_ = 0;
+
+/**
  * Stored X value for the transform origin of the drag surface.
  * Used to adjust the origin as we drag.
  * @type {Number}
@@ -154,6 +170,8 @@ Blockly.DragSurfaceSvg.prototype.setBlocksAndShow = function (blocks, transformO
  */
 Blockly.DragSurfaceSvg.prototype.translateAndScaleGroup = function (x, y, scale) {
   var transform;
+  this.translateX_ = x;
+  this.translateY_ = y;
   this.scale_ = scale;
   if (Blockly.is3dSupported()) {
     transform = 'transform: translate3d(' + x + 'px, ' + y + 'px, 0px)' +
@@ -174,14 +192,12 @@ Blockly.DragSurfaceSvg.prototype.translateAndScaleGroup = function (x, y, scale)
  * @param {Number} y Y translation for the entire surface
  */
 Blockly.DragSurfaceSvg.prototype.translateSurface = function(x, y) {
-  var transform;
+  var originX = (this.transformOriginX_ + x) * this.scale_ + this.translateX_;
+  var originY = (this.transformOriginY_ + y) * this.scale_ + this.translateY_;
+  this.scaleWrapper_.style.transformOrigin = originX + 'px ' + originY + 'px 0px';
   x *= this.scale_;
   y *= this.scale_;
-
-  var originX = this.transformOriginX_ + x;
-  var originY = this.transformOriginY_ + y;
-  this.scaleWrapper_.style.transformOrigin = originX + 'px ' + originY + 'px 0px';
-
+  var transform;
   if (Blockly.is3dSupported()) {
     transform = 'transform: translate3d(' + x + 'px, ' + y + 'px, 0px); display: block;';
     this.SVG_.setAttribute('style', transform);

--- a/core/flyout.js
+++ b/core/flyout.js
@@ -896,7 +896,7 @@ Blockly.Flyout.prototype.createBlockFunc_ = function(originBlock) {
     block.onMouseDown_(e);
     Blockly.dragMode_ = Blockly.DRAG_FREE;
     block.setDragging_(true);
-    block.moveToDragSurface_();
+    block.moveToDragSurface_(e);
   };
 };
 


### PR DESCRIPTION
Here is a partial implementation of grow-on-drag.

Essentially it adds another wrapper to the drag layer - this one that gets a scale factor. It has to be separate from the translating drag layer itself, because that has its own `transform` property so we can't transition it.

I suspect we'll want one more thing - to "ungrow" when we're dropping on the workspace (but not dropping into a stack). That might be harder to pull off...
