### PR TITLE
Split the block-positioning logic out of block_svg

### DIFF
--- a/core/block_render_svg_horizontal.js
+++ b/core/block_render_svg_horizontal.js
@@ -654,8 +654,9 @@ Blockly.BlockSvg.prototype.getFieldShadowBlock_ = function() {
  * @param {!Blockly.Block} newBlock The block to position - either the first
  *     block in a dragged stack or an insertion marker.
  * @param {!Blockly.Connection} newConnection The connection on the new block's
- *     stack - either a connection on newBlock, or the NEXT_STATEMENT connection
- *     on the stack if the stack's being dropped before another block.
+ *     stack - either a connection on newBlock, or the last NEXT_STATEMENT
+ *     connection on the stack if the stack's being dropped before another
+ *     block.
  * @param {!Blockly.Connection} existingConnection The connection on the
  *     existing block, which newBlock should line up with.
  */

--- a/core/block_render_svg_horizontal.js
+++ b/core/block_render_svg_horizontal.js
@@ -647,3 +647,32 @@ Blockly.BlockSvg.prototype.getFieldShadowBlock_ = function() {
 
   return null;
 };
+
+/**
+ * Position an new block correctly, so that it doesn't move the existing block
+ * when connected to it.
+ * @param {Blockly.Connection} newConnection The connection on the new block.
+ * @param {Blockly.Connection} existingConnection The connection on the existing
+ *     block.
+ */
+Blockly.BlockSvg.prototype.positionNewBlock =
+    function(newConnection, existingConnection) {
+  var newBlock = newConnection.sourceBlock_;
+
+  // We only need to position the new block if it's before the existing one,
+  // otherwise its position is set by the previous block.
+  if (newConnection.type == Blockly.NEXT_STATEMENT) {
+    var dx = existingConnection.x_ - newConnection.x_;
+    var dy = existingConnection.y_ - newConnection.y_;
+
+    // When putting a c-block around another c-block, the outer block must
+    // positioned above the inner block, as its connection point will stretch
+    // downwards when connected.
+    if (newConnection != newBlock.nextConnection) {
+      dy -= existingConnection.sourceBlock_.getHeightWidth(true).height -
+          Blockly.BlockSvg.MIN_BLOCK_Y;
+    }
+
+    newBlock.moveBy(dx, dy);
+  }
+}

--- a/core/block_render_svg_horizontal.js
+++ b/core/block_render_svg_horizontal.js
@@ -651,14 +651,14 @@ Blockly.BlockSvg.prototype.getFieldShadowBlock_ = function() {
 /**
  * Position an new block correctly, so that it doesn't move the existing block
  * when connected to it.
- * @param {Blockly.Connection} newConnection The connection on the new block.
+ * @param {Blockly.Block} newBlock The connection on the new block.
+ * @param {Blockly.Connection} newConnection The connection on the new block's
+ *     stack.
  * @param {Blockly.Connection} existingConnection The connection on the existing
  *     block.
  */
 Blockly.BlockSvg.prototype.positionNewBlock =
-    function(newConnection, existingConnection) {
-  var newBlock = newConnection.sourceBlock_;
-
+    function(newBlock, newConnection, existingConnection) {
   // We only need to position the new block if it's before the existing one,
   // otherwise its position is set by the previous block.
   if (newConnection.type == Blockly.NEXT_STATEMENT) {
@@ -668,7 +668,7 @@ Blockly.BlockSvg.prototype.positionNewBlock =
     // When putting a c-block around another c-block, the outer block must
     // positioned above the inner block, as its connection point will stretch
     // downwards when connected.
-    if (newConnection != newBlock.nextConnection) {
+    if (newConnection == newBlock.getFirstStatementConnection()) {
       dy -= existingConnection.sourceBlock_.getHeightWidth(true).height -
           Blockly.BlockSvg.MIN_BLOCK_Y;
     }

--- a/core/block_render_svg_horizontal.js
+++ b/core/block_render_svg_horizontal.js
@@ -651,11 +651,13 @@ Blockly.BlockSvg.prototype.getFieldShadowBlock_ = function() {
 /**
  * Position an new block correctly, so that it doesn't move the existing block
  * when connected to it.
- * @param {Blockly.Block} newBlock The connection on the new block.
- * @param {Blockly.Connection} newConnection The connection on the new block's
- *     stack.
- * @param {Blockly.Connection} existingConnection The connection on the existing
- *     block.
+ * @param {!Blockly.Block} newBlock The block to position - either the first
+ *     block in a dragged stack or an insertion marker.
+ * @param {!Blockly.Connection} newConnection The connection on the new block's
+ *     stack - either a connection on newBlock, or the NEXT_STATEMENT connection
+ *     on the stack if the stack's being dropped before another block.
+ * @param {!Blockly.Connection} existingConnection The connection on the
+ *     existing block, which newBlock should line up with.
  */
 Blockly.BlockSvg.prototype.positionNewBlock =
     function(newBlock, newConnection, existingConnection) {

--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -749,11 +749,13 @@ Blockly.BlockSvg.prototype.renderDrawLeft_ =
 /**
  * Position an new block correctly, so that it doesn't move the existing block
  * when connected to it.
- * @param {Blockly.Block} newBlock The connection on the new block.
- * @param {Blockly.Connection} newConnection The connection on the new block's
- *     stack.
- * @param {Blockly.Connection} existingConnection The connection on the existing
- *     block.
+ * @param {!Blockly.Block} newBlock The block to position - either the first
+ *     block in a dragged stack or an insertion marker.
+ * @param {!Blockly.Connection} newConnection The connection on the new block's
+ *     stack - either a connection on newBlock, or the NEXT_STATEMENT connection
+ *     on the stack if the stack's being dropped before another block.
+ * @param {!Blockly.Connection} existingConnection The connection on the
+ *     existing block, which newBlock should line up with.
  */
 Blockly.BlockSvg.prototype.positionNewBlock =
     function(newBlock, newConnection, existingConnection) {

--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -749,18 +749,20 @@ Blockly.BlockSvg.prototype.renderDrawLeft_ =
 /**
  * Position an new block correctly, so that it doesn't move the existing block
  * when connected to it.
- * @param {Blockly.Connection} newConnection The connection on the new block.
+ * @param {Blockly.Block} newBlock The connection on the new block.
+ * @param {Blockly.Connection} newConnection The connection on the new block's
+ *     stack.
  * @param {Blockly.Connection} existingConnection The connection on the existing
  *     block.
  */
 Blockly.BlockSvg.prototype.positionNewBlock =
-    function(newConnection, existingConnection) {
+    function(newBlock, newConnection, existingConnection) {
   // We only need to position the new block if it's before the existing one,
   // otherwise its position is set by the previous block.
   if (newConnection.type == Blockly.NEXT_STATEMENT) {
     var dx = existingConnection.x_ - newConnection.x_;
     var dy = existingConnection.y_ - newConnection.y_;
 
-    newConnection.sourceBlock_.moveBy(dx, dy);
+    newBlock.moveBy(dx, dy);
   }
 }

--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -752,8 +752,9 @@ Blockly.BlockSvg.prototype.renderDrawLeft_ =
  * @param {!Blockly.Block} newBlock The block to position - either the first
  *     block in a dragged stack or an insertion marker.
  * @param {!Blockly.Connection} newConnection The connection on the new block's
- *     stack - either a connection on newBlock, or the NEXT_STATEMENT connection
- *     on the stack if the stack's being dropped before another block.
+ *     stack - either a connection on newBlock, or the last NEXT_STATEMENT
+ *     connection on the stack if the stack's being dropped before another
+ *     block.
  * @param {!Blockly.Connection} existingConnection The connection on the
  *     existing block, which newBlock should line up with.
  */

--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -745,3 +745,22 @@ Blockly.BlockSvg.prototype.renderDrawLeft_ =
   }
   steps.push('z');
 };
+
+/**
+ * Position an new block correctly, so that it doesn't move the existing block
+ * when connected to it.
+ * @param {Blockly.Connection} newConnection The connection on the new block.
+ * @param {Blockly.Connection} existingConnection The connection on the existing
+ *     block.
+ */
+Blockly.BlockSvg.prototype.positionNewBlock =
+    function(newConnection, existingConnection) {
+  // We only need to position the new block if it's before the existing one,
+  // otherwise its position is set by the previous block.
+  if (newConnection.type == Blockly.NEXT_STATEMENT) {
+    var dx = existingConnection.x_ - newConnection.x_;
+    var dy = existingConnection.y_ - newConnection.y_;
+
+    newConnection.sourceBlock_.moveBy(dx, dy);
+  }
+}

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -657,7 +657,7 @@ Blockly.BlockSvg.prototype.onMouseUp_ = function(e) {
   Blockly.setPageSelectable(true);
   Blockly.terminateDrag_();
   if (Blockly.selected && Blockly.highlightedConnection_) {
-    this.positionNewBlock(
+    this.positionNewBlock(Blockly.selected,
         Blockly.localConnection_, Blockly.highlightedConnection_);
     // Connect two blocks together.
     Blockly.localConnection_.connect(Blockly.highlightedConnection_);
@@ -992,8 +992,8 @@ Blockly.BlockSvg.prototype.updatePreviews = function(closestConnection,
     // If there's already an insertion marker but it's representing the wrong
     // block, delete it so we can create the correct one.
     if (Blockly.insertionMarker_ &&
-        (candidateIsLast && Blockly.localConnection_.sourceBlock_ == this) ||
-        (!candidateIsLast && Blockly.localConnection_.sourceBlock_ != this)) {
+        ((candidateIsLast && Blockly.localConnection_.sourceBlock_ == this) ||
+         (!candidateIsLast && Blockly.localConnection_.sourceBlock_ != this))) {
       Blockly.insertionMarker_.dispose();
       Blockly.insertionMarker_ = null;
     }
@@ -1024,7 +1024,8 @@ Blockly.BlockSvg.prototype.updatePreviews = function(closestConnection,
       insertionMarker.render();
       insertionMarker.getSvgRoot().setAttribute('visibility', 'visible');
 
-      this.positionNewBlock(insertionMarkerConnection, closestConnection);
+      this.positionNewBlock(insertionMarker,
+          insertionMarkerConnection, closestConnection);
 
       if (insertionMarkerConnection.type == Blockly.PREVIOUS_STATEMENT &&
           !insertionMarker.nextConnection) {

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -1055,9 +1055,8 @@ Blockly.BlockSvg.prototype.updatePreviews = function(closestConnection,
           !insertionMarker.nextConnection) {
         Blockly.bumpedConnection_ = closestConnection.targetConnection;
       }
-      // Renders insertin marker.
+      // Renders insertion marker.
       insertionMarkerConnection.connect(closestConnection);
-      // Render dragging block so it appears on top.
       Blockly.insertionMarkerConnection_ = insertionMarkerConnection;
     }
   }

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -657,22 +657,8 @@ Blockly.BlockSvg.prototype.onMouseUp_ = function(e) {
   Blockly.setPageSelectable(true);
   Blockly.terminateDrag_();
   if (Blockly.selected && Blockly.highlightedConnection_) {
-    if (Blockly.localConnection_ ==
-        Blockly.selected.getFirstStatementConnection()) {
-      // Snap to match the position of the pre-existing stack.  Since this is a
-      // C-block, shift to take into account how the block will stretch as it
-      // surrounds the internal blocks.
-      Blockly.selected.moveBy(
-          Blockly.highlightedConnection_.x_ - Blockly.localConnection_.x_,
-          Blockly.highlightedConnection_.y_ - Blockly.localConnection_.y_ -
-          (Blockly.highlightedConnection_.sourceBlock_.getHeightWidth().height -
-          Blockly.BlockSvg.MIN_BLOCK_Y));
-    } else if (Blockly.localConnection_.type == Blockly.NEXT_STATEMENT) {
-      // Snap to match the position of the pre-existing stack.
-      Blockly.selected.moveBy(
-          Blockly.highlightedConnection_.x_ - Blockly.localConnection_.x_,
-          Blockly.highlightedConnection_.y_ - Blockly.localConnection_.y_);
-    }
+    this.positionNewBlock(
+        Blockly.localConnection_, Blockly.highlightedConnection_);
     // Connect two blocks together.
     Blockly.localConnection_.connect(Blockly.highlightedConnection_);
     if (this.rendered) {
@@ -1037,20 +1023,9 @@ Blockly.BlockSvg.prototype.updatePreviews = function(closestConnection,
       // connection location.
       insertionMarker.render();
       insertionMarker.getSvgRoot().setAttribute('visibility', 'visible');
-      // Move the preview to the correct location before the existing block.
-      if (insertionMarkerConnection.type == Blockly.NEXT_STATEMENT) {
-        var newX = closestConnection.x_ - insertionMarkerConnection.x_;
-        var newY = closestConnection.y_ - insertionMarkerConnection.y_;
-        // If it's the first statement connection of a c-block, this block is
-        // going to get taller as soon as render() is called below.
-        if (insertionMarkerConnection != insertionMarker.nextConnection) {
-          newY -= closestConnection.sourceBlock_.getHeightWidth().height -
-              Blockly.BlockSvg.MIN_BLOCK_Y;
-        }
 
-        insertionMarker.moveBy(newX, newY);
+      this.positionNewBlock(insertionMarkerConnection, closestConnection);
 
-      }
       if (insertionMarkerConnection.type == Blockly.PREVIOUS_STATEMENT &&
           !insertionMarker.nextConnection) {
         Blockly.bumpedConnection_ = closestConnection.targetConnection;


### PR DESCRIPTION
This allows the horizontal renderer to position its blocks differently, to cope with the fact that the tabs on its repeat blocks move to line up. This commit also makes the preview and new block positioning use the same code.

Fixes #232.
