### PR TITLE
Allow moving an insertion marker leftwards

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -998,7 +998,7 @@ Blockly.BlockSvg.prototype.updatePreviews = function(closestConnection,
   // Remove an insertion marker if needed.  For Scratch-Blockly we are using
   // grayed-out blocks instead of highlighting the connection; for compatibility
   // with Web Blockly the name "highlightedConnection" will still be used.
-  if (Blockly.highlightedConnection_ &&
+  if (Blockly.highlightedConnection_ && blockly.localConnection_ &&
       (Blockly.highlightedConnection_ != closestConnection ||
        Blockly.localConnection_ != localConnection)) {
     if (Blockly.insertionMarker_ && Blockly.insertionMarkerConnection_) {

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -999,7 +999,8 @@ Blockly.BlockSvg.prototype.updatePreviews = function(closestConnection,
   // grayed-out blocks instead of highlighting the connection; for compatibility
   // with Web Blockly the name "highlightedConnection" will still be used.
   if (Blockly.highlightedConnection_ &&
-      Blockly.highlightedConnection_ != closestConnection) {
+      (Blockly.highlightedConnection_ != closestConnection ||
+       Blockly.localConnection_ != localConnection)) {
     if (Blockly.insertionMarker_ && Blockly.insertionMarkerConnection_) {
       Blockly.BlockSvg.disconnectInsertionMarker();
     }


### PR DESCRIPTION
If you drag a pants block over another block, then try to drag it left so that it's before the other block, the insertion marker won't move until you drag away and return. This is nothing severe but slightly clunky.

![drag left broken](https://cloud.githubusercontent.com/assets/632207/14635160/6f0f0320-0625-11e6-84d0-dd7b062a85bc.gif)
_dragging left before the fix_

The expected behaviour can be achieved by patching updatePreviews to recognise an insertion marker as invalid if localConnection has changed, not just if highlightedConnection has changed.

![drag left fixed](https://cloud.githubusercontent.com/assets/632207/14635189/8d2c2c16-0625-11e6-9637-98be388c5959.gif)
_dragging left after the fix_

(the gifs were captured after rebasing onto bugfix/232 for clarity)
