### PR TITLE
Allow moving an insertion marker leftwards, take 2

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -998,8 +998,9 @@ Blockly.BlockSvg.prototype.updatePreviews = function(closestConnection,
   // Remove an insertion marker if needed.  For Scratch-Blockly we are using
   // grayed-out blocks instead of highlighting the connection; for compatibility
   // with Web Blockly the name "highlightedConnection" will still be used.
-  if (Blockly.highlightedConnection_ &&
-      Blockly.highlightedConnection_ != closestConnection) {
+  if (Blockly.highlightedConnection_ && Blockly.localConnection_ &&
+      (Blockly.highlightedConnection_ != closestConnection ||
+       Blockly.localConnection_ != localConnection)) {
     if (Blockly.insertionMarker_ && Blockly.insertionMarkerConnection_) {
       Blockly.BlockSvg.disconnectInsertionMarker();
     }


### PR DESCRIPTION
By recognising an insertion marker as invalid if localConnection has changed, not just if highlightedConnection has changed.

This is sort of a duplicate review of #236, which I merged, then realised I'd hadn't actually tested it and a typo broke the insertion markers. I reverted it, and thought I'd err on the side of caution in sending for review again. Sorry for the mess!
