### PR TITLE
Revert "Allow moving an insertion marker leftwards, take 2"

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -984,9 +984,8 @@ Blockly.BlockSvg.prototype.updatePreviews = function(closestConnection,
   // Remove an insertion marker if needed.  For Scratch-Blockly we are using
   // grayed-out blocks instead of highlighting the connection; for compatibility
   // with Web Blockly the name "highlightedConnection" will still be used.
-  if (Blockly.highlightedConnection_ && Blockly.localConnection_ &&
-      (Blockly.highlightedConnection_ != closestConnection ||
-       Blockly.localConnection_ != localConnection)) {
+  if (Blockly.highlightedConnection_ &&
+      Blockly.highlightedConnection_ != closestConnection) {
     if (Blockly.insertionMarker_ && Blockly.insertionMarkerConnection_) {
       Blockly.BlockSvg.disconnectInsertionMarker();
     }


### PR DESCRIPTION
Reverts LLK/scratch-blockly#252 as it introduced #263
