### PR TITLE
Don't let blocks scroll over fixed flyout

### DIFF
--- a/core/blockly.js
+++ b/core/blockly.js
@@ -433,8 +433,19 @@ Blockly.hideChaff = function(opt_allowToolbox) {
 Blockly.getMainWorkspaceMetrics_ = function() {
   var svgSize = Blockly.svgSize(this.getParentSvg());
   if (this.toolbox_) {
-    svgSize.width -= this.toolbox_.width;
+    if (this.horizontalLayout) {
+      svgSize.height -= this.toolbox_.height;
+    } else {
+      svgSize.width -= this.toolbox_.width;
+    }
+  } else if (this.flyout_) {
+    if (this.horizontalLayout) {
+      svgSize.height -= this.flyout_.height_;
+    } else {
+      svgSize.width -= this.flyout_.width_;
+    }
   }
+
   // Set the margin to match the flyout's margin so that the workspace does
   // not jump as blocks are added.
   var MARGIN = Blockly.Flyout.prototype.CORNER_RADIUS - 1;
@@ -464,9 +475,19 @@ Blockly.getMainWorkspaceMetrics_ = function() {
     var topEdge = blockBox.y;
     var bottomEdge = topEdge + blockBox.height;
   }
-  var absoluteLeft = 0;
-  if (this.toolbox_ && this.toolbox_.toolboxPosition == Blockly.TOOLBOX_AT_LEFT) {
-    absoluteLeft = this.toolbox_.width;
+  var absoluteLeft = 0, absoluteTop = 0;
+  if (this.toolbox_) {
+    if (this.toolbox_.toolboxPosition == Blockly.TOOLBOX_AT_LEFT) {
+      absoluteLeft = this.toolbox_.width;
+    } else if (this.flyout_.toolboxPosition == Blockly.TOOLBOX_AT_TOP) {
+      absoluteTop = this.toolbox_.height;
+    }
+  } else if (this.flyout_) {
+    if (this.flyout_.toolboxPosition_ == Blockly.TOOLBOX_AT_LEFT) {
+      absoluteLeft = this.flyout_.width_;
+    } else if (this.flyout_.toolboxPosition_ == Blockly.TOOLBOX_AT_TOP) {
+      absoluteTop = this.flyout_.height_;
+    }
   }
   var metrics = {
     viewHeight: svgSize.height,
@@ -477,7 +498,7 @@ Blockly.getMainWorkspaceMetrics_ = function() {
     viewLeft: -this.scrollX,
     contentTop: topEdge,
     contentLeft: leftEdge,
-    absoluteTop: 0,
+    absoluteTop: absoluteTop,
     absoluteLeft: absoluteLeft
   };
   return metrics;

--- a/core/flyout.js
+++ b/core/flyout.js
@@ -360,15 +360,16 @@ Blockly.Flyout.prototype.position = function() {
   this.setBackgroundPath_(edgeWidth,
     this.horizontalLayout_ ? this.height_ + this.verticalOffset_ : metrics.viewHeight);
 
-  var x = metrics.absoluteLeft;
+  var x = 0;
+  var svgSize = Blockly.svgSize(this.workspace_.getParentSvg());
   if (this.toolboxPosition_ == Blockly.TOOLBOX_AT_RIGHT) {
-    x += metrics.viewWidth;
+    x += svgSize.width;
     x -= this.width_;
   }
 
-  var y = metrics.absoluteTop;
+  var y = 0;
   if (this.toolboxPosition_ == Blockly.TOOLBOX_AT_BOTTOM) {
-    y += metrics.viewHeight;
+    y += svgSize.height_;
     y -= this.height_;
   }
 

--- a/core/inject.js
+++ b/core/inject.js
@@ -261,12 +261,6 @@ Blockly.init_ = function(mainWorkspace) {
       // Build a fixed flyout with the root blocks.
       mainWorkspace.flyout_.init(mainWorkspace);
       mainWorkspace.flyout_.show(options.languageTree.childNodes);
-      // Translate the workspace sideways to avoid the fixed flyout.
-      mainWorkspace.scrollX = mainWorkspace.flyout_.width_;
-      if (options.toolboxPosition == Blockly.TOOLBOX_AT_RIGHT) {
-        mainWorkspace.scrollX *= -1;
-      }
-      mainWorkspace.translate(mainWorkspace.scrollX, 0);
     }
   }
 


### PR DESCRIPTION
To do this, I draw the flyout relative to the SVG (instead of relative
to the workspace view) and then resize the workspace view
(absoluteLeft/Top and viewWidth/Height) to not include the flyout area.

Fixes #275.
