### PR TITLE
Add Apache 2.0 license header to new files

### DIFF
--- a/blocks_horizontal/control.js
+++ b/blocks_horizontal/control.js
@@ -1,4 +1,24 @@
 /**
+ * @license
+ * Visual Blocks Editor
+ *
+ * Copyright 2016 Massachusetts Institute of Technology
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
  * @fileoverview Control blocks for Scratch (Horizontal)
  * @author ascii@media.mit.edu <Andrew Sliwinski>
  */

--- a/blocks_horizontal/event.js
+++ b/blocks_horizontal/event.js
@@ -1,4 +1,24 @@
 /**
+ * @license
+ * Visual Blocks Editor
+ *
+ * Copyright 2016 Massachusetts Institute of Technology
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
  * @fileoverview Control blocks for Scratch (Horizontal)
  * @author ascii@media.mit.edu <Andrew Sliwinski>
  */

--- a/blocks_horizontal/wedo.js
+++ b/blocks_horizontal/wedo.js
@@ -1,4 +1,24 @@
 /**
+ * @license
+ * Visual Blocks Editor
+ *
+ * Copyright 2016 Massachusetts Institute of Technology
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
  * @fileoverview Wedo blocks for Scratch (Horizontal)
  * @author ascii@media.mit.edu <Andrew Sliwinski>
  */

--- a/core/colours.js
+++ b/core/colours.js
@@ -1,3 +1,23 @@
+/**
+ * @license
+ * Visual Blocks Editor
+ *
+ * Copyright 2016 Massachusetts Institute of Technology
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 'use strict';
 
 goog.provide('Blockly.Colours');

--- a/core/dragsurface_svg.js
+++ b/core/dragsurface_svg.js
@@ -1,4 +1,24 @@
 /**
+ * @license
+ * Visual Blocks Editor
+ *
+ * Copyright 2016 Massachusetts Institute of Technology
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
  * @fileoverview An SVG that floats on top of the workspace.
  * Blocks are moved into this SVG during a drag, improving performance.
  * The entire SVG is translated, so the blocks are never repainted during drag.

--- a/core/dropdowndiv.js
+++ b/core/dropdowndiv.js
@@ -1,11 +1,21 @@
 /**
  * @license
- * Scratch Blocks
+ * Visual Blocks Editor
  *
- * Copyright (c) 2016, Massachusetts Institute of Technology
+ * Copyright 2016 Massachusetts Institute of Technology
  * All rights reserved.
  *
- * Licensed under BSD-3-clause (see LICENSE).
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 /**

--- a/core/field_iconmenu.js
+++ b/core/field_iconmenu.js
@@ -1,4 +1,24 @@
 /**
+ * @license
+ * Visual Blocks Editor
+ *
+ * Copyright 2016 Massachusetts Institute of Technology
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
  * @fileoverview Icon picker input field.
  * This is primarily for use in Scratch Horizontal blocks.
  * Pops open a drop-down with icons; when an icon is selected, it replaces


### PR DESCRIPTION
Files that were forked off Blockly (eg block_render_svg_horizontal.js)
remain marked as Copyright Google, whereas new files are Copyright MIT.

I'm adding these headers at Andrew's suggestion. Let me know if you prefer any adjustments - in particular I stuck with Blocky's use of "Visual Block Editor". The difference in headers between files should just be the Copyright line and replacing the Blockly URL with "All rights reserved." as in the BSD-3-Clause text.
