### PR TITLE
Remove extra touch-callout and user-select from blocklyText

### DIFF
--- a/core/css.js
+++ b/core/css.js
@@ -355,8 +355,6 @@ Blockly.Css.CONTENT = [
     'font-family: sans-serif;',
     'font-size: 12pt;',
     'font-weight: 600;',
-    '-webkit-touch-callout: default;',
-    '-webkit-user-select: text;',
   '}',
 
   '.blocklyTextTruncated {',


### PR DESCRIPTION
These were intended for the htmlInput, not the SVG blocklyText. Adding these in was causing the blocklyText element to get selected sometimes in webkit browsers.

@drigz Should fix #294 
