### PR TITLE
Hide dropdowns when scrolling the flyout

### DIFF
--- a/core/flyout.js
+++ b/core/flyout.js
@@ -741,6 +741,8 @@ Blockly.Flyout.prototype.blockMouseDown_ = function(block) {
   return function(e) {
     flyout.dragMode_ = Blockly.DRAG_NONE;
     Blockly.terminateDrag_();
+    Blockly.WidgetDiv.hide(true);
+    Blockly.DropDownDiv.hideWithoutAnimation();
     Blockly.hideChaff();
     if (Blockly.isRightButton(e)) {
       // Right-click.
@@ -774,6 +776,8 @@ Blockly.Flyout.prototype.onMouseDown_ = function(e) {
   if (Blockly.isRightButton(e)) {
     return;
   }
+  Blockly.WidgetDiv.hide(true);
+  Blockly.DropDownDiv.hideWithoutAnimation();
   Blockly.hideChaff(true);
   Blockly.Flyout.terminateDrag_();
   this.startDragMouseY_ = e.clientY;


### PR DESCRIPTION
Fixes #302. This hides both WidgetDiv and DropDownDiv without animation,
otherwise they can float over other blocks as they're animating out.
