### PR TITLE
Fix #292 by using page offset instead of client position

### DIFF
--- a/core/dropdowndiv.js
+++ b/core/dropdowndiv.js
@@ -224,7 +224,7 @@ Blockly.DropDownDiv.show = function(owner, primaryX, primaryY, secondaryX, secon
  */
 Blockly.DropDownDiv.getPositionMetrics = function(primaryX, primaryY, secondaryX, secondaryY) {
   var div = Blockly.DropDownDiv.DIV_;
-  var boundPosition = goog.style.getClientPosition(Blockly.DropDownDiv.boundsElement_);
+  var boundPosition = goog.style.getPageOffset(Blockly.DropDownDiv.boundsElement_);
   var boundSize = goog.style.getSize(Blockly.DropDownDiv.boundsElement_);
   var divSize = goog.style.getSize(div);
 


### PR DESCRIPTION
The drop-down bounds were being calculated relative to the client viewport (i.e. not including the page scroll). Using the page offset instead accounts for scroll, so the drop-down displays in the right position even on scrolled pages.
