### PR TITLE
Remove extra 1px padding on vertical statement connections

### DIFF
--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -673,7 +673,7 @@ Blockly.BlockSvg.prototype.renderDrawRight_ = function(steps,
       steps.push('H', inputRows.rightEdge);
 
       // Create statement connection.
-      connectionX = connectionsXY.x + (this.RTL ? -cursorX : cursorX + 1);
+      connectionX = connectionsXY.x + (this.RTL ? -cursorX : cursorX);
       connectionY = connectionsXY.y + cursorY + 1;
       input.connection.moveTo(connectionX, connectionY);
       if (input.connection.isConnected()) {


### PR DESCRIPTION
Before:
<img width="144" alt="screen shot 2016-05-23 at 3 52 26 pm" src="https://cloud.githubusercontent.com/assets/120403/15482645/c61b1642-20fe-11e6-987b-8463e4082c19.png">
After:
<img width="160" alt="screen shot 2016-05-23 at 3 52 49 pm" src="https://cloud.githubusercontent.com/assets/120403/15482649/c97e9e08-20fe-11e6-8ff0-2832baf9f6ac.png">
