### PR TITLE
Fix width of input rows to stretch for all inputs; add rounded corner to extra row for statement

### DIFF
--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -688,8 +688,9 @@ Blockly.BlockSvg.prototype.renderDrawRight_ = function(steps,
           inputRows[y + 1].type == Blockly.NEXT_STATEMENT) {
         // If the final input is a statement stack, add a small row underneath.
         // Consecutive statement stacks are also separated by a small divider.
-        steps.push('v', Blockly.BlockSvg.SEP_SPACE_Y);
-        cursorY += Blockly.BlockSvg.SEP_SPACE_Y;
+        steps.push(Blockly.BlockSvg.TOP_RIGHT_CORNER);
+        steps.push('v', Blockly.BlockSvg.SEP_SPACE_Y - Blockly.BlockSvg.CORNER_RADIUS);
+        cursorY += Blockly.BlockSvg.SEP_SPACE_Y + Blockly.BlockSvg.CORNER_RADIUS;
       }
     }
     cursorY += row.height;

--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -622,7 +622,10 @@ Blockly.BlockSvg.prototype.renderDrawRight_ = function(steps,
           }
         }
       }
-
+      // Update right edge for all inputs, such that all rows
+      // stretch to be at least the size of all previous rows.
+      inputRows.rightEdge = Math.max(cursorX, inputRows.rightEdge);
+      // Move to the right edge
       cursorX = Math.max(cursorX, inputRows.rightEdge);
       this.width = Math.max(this.width, cursorX);
       steps.push('H', cursorX);


### PR DESCRIPTION
Before:
<img width="283" alt="screen shot 2016-05-23 at 5 57 31 pm" src="https://cloud.githubusercontent.com/assets/120403/15485962/6dcca50c-2110-11e6-81c3-8186ec89821f.png">

After:
<img width="289" alt="screen shot 2016-05-23 at 6 04 35 pm" src="https://cloud.githubusercontent.com/assets/120403/15486045/d699cb1e-2110-11e6-9b7f-4217f2833d5e.png">
