### PR TITLE
Remove obsolete "tap listeners".

### DIFF
--- a/core/workspace.js
+++ b/core/workspace.js
@@ -302,40 +302,6 @@ Blockly.Workspace.prototype.fireChangeListener = function(event) {
 };
 
 /**
- * When a block in the workspace is tapped, call a function with the
- *  blockId and root blockId.
- * @param {!Function} func Function to call.
- * @return {!Function} Function that can be passed to
- *     removeTapListener.
- */
-Blockly.Workspace.prototype.addTapListener = function(func) {
-  this.tapListeners_.push(func);
-  return func;
-};
-
-/**
- * Stop listening for this workspace's taps.
- * @param {Function} func Function to stop calling.
- */
-Blockly.Workspace.prototype.removeTapListener = function(func) {
-  var i = this.tapListeners_.indexOf(func);
-  if (i != -1) {
-    this.tapListeners_.splice(i, 1);
-  }
-};
-
-/**
- * Fire a tap event.
- * @param {string} blockId ID of block that was tapped
- * @param {string} rootBlockId ID of root block in tree that was tapped
- */
-Blockly.Workspace.prototype.fireTapListener = function(blockId, rootBlockId) {
-  for (var i = 0, func; func = this.tapListeners_[i]; i++) {
-    func(blockId, rootBlockId);
-  }
-};
-
-/**
  * Find the block on this workspace with the specified ID.
  * @param {string} id ID of block to find.
  * @return {Blockly.Block} The sought after block or null if not found.


### PR DESCRIPTION
These were put in before Blockly had UI events; they're no longer needed or used.
