### PR TITLE
Add additional "stack click" event for toggling stacks

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -691,7 +691,7 @@ Blockly.BlockSvg.prototype.onMouseUp_ = function(e) {
     // This is used to toggle the stack when any block in the stack is clicked.
     var rootBlock = this.workspace.getBlockById(this.id).getRootBlock();
     Blockly.Events.fire(
-      new Blockly.Events.Ui(rootBlock, 'stackClick', undefined, undefined));
+      new Blockly.Events.Ui(rootBlock, 'stackclick', undefined, undefined));
   }
   Blockly.terminateDrag_();
   if (Blockly.selected && Blockly.highlightedConnection_) {

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -687,6 +687,11 @@ Blockly.BlockSvg.prototype.onMouseUp_ = function(e) {
   if (Blockly.dragMode_ != Blockly.DRAG_FREE && !Blockly.WidgetDiv.isVisible() && isNotShadowBlock) {
     Blockly.Events.fire(
         new Blockly.Events.Ui(this, 'click', undefined, undefined));
+    // Scratch-specific: also fire a "stack click" event for this stack.
+    // This is used to toggle the stack when any block in the stack is clicked.
+    var rootBlock = this.workspace.getBlockById(this.id).getRootBlock();
+    Blockly.Events.fire(
+      new Blockly.Events.Ui(rootBlock, 'stackClick', undefined, undefined));
   }
   Blockly.terminateDrag_();
   if (Blockly.selected && Blockly.highlightedConnection_) {


### PR DESCRIPTION
This is the best way I could think of doing this - using an additional event.

Previously, we were reading the click event and then having to re-query Blockly to get the block that starts the stack. Another alternative I considered was attaching the root block ID to the event, but there's not a clean way to do that without changing the model of the UI event entirely. This way, we get the info we need without changing the model very much.
