### PR TITLE
Vertical shapes pass

### DIFF
--- a/blocks_vertical/control.js
+++ b/blocks_vertical/control.js
@@ -122,6 +122,9 @@ Blockly.Blocks['control_if_else'] = {
       "message0": "if %1 %2 else %3 %4",
       "args0": [
         {
+          "type": "input_dummy"
+        },
+        {
           "type": "input_value",
           "name": "CONDITION",
           "check": "Boolean"

--- a/blocks_vertical/control.js
+++ b/blocks_vertical/control.js
@@ -122,9 +122,6 @@ Blockly.Blocks['control_if_else'] = {
       "message0": "if %1 %2 else %3 %4",
       "args0": [
         {
-          "type": "input_dummy"
-        },
-        {
           "type": "input_value",
           "name": "CONDITION",
           "check": "Boolean"

--- a/blocks_vertical/event.js
+++ b/blocks_vertical/event.js
@@ -23,8 +23,8 @@ Blockly.Blocks['event_whenflagclicked'] = {
         {
           "type": "field_image",
           "src": Blockly.mainWorkspace.options.pathToMedia + "icons/event_whenflagclicked.svg",
-          "width": 20,
-          "height": 20,
+          "width": 24,
+          "height": 24,
           "alt": "flag",
           "flip_rtl": true
         }

--- a/core/block_render_svg_horizontal.js
+++ b/core/block_render_svg_horizontal.js
@@ -41,6 +41,7 @@ Blockly.BlockSvg.GRID_UNIT = 4;
  * @const
  */
 Blockly.BlockSvg.SEP_SPACE_X = 3 * Blockly.BlockSvg.GRID_UNIT;
+
 /**
  * Vertical space between elements.
  * @const
@@ -124,32 +125,36 @@ Blockly.BlockSvg.MIN_BLOCK_Y = 16 * Blockly.BlockSvg.GRID_UNIT;
  * @const
  */
 Blockly.BlockSvg.TAB_WIDTH = 2 * Blockly.BlockSvg.GRID_UNIT;
+
 /**
  * Rounded corner radius.
  * @const
  */
 Blockly.BlockSvg.CORNER_RADIUS = 1 * Blockly.BlockSvg.GRID_UNIT;
+
 /**
  * Rounded corner radius.
  * @const
  */
 Blockly.BlockSvg.HAT_CORNER_RADIUS = 8 * Blockly.BlockSvg.GRID_UNIT;
+
 /**
  * Full height of connector notch including rounded corner.
  * @const
  */
 Blockly.BlockSvg.NOTCH_HEIGHT = 8 * Blockly.BlockSvg.GRID_UNIT + 2;
+
 /**
  * Width of connector notch
  * @const
  */
 Blockly.BlockSvg.NOTCH_WIDTH = 2 * Blockly.BlockSvg.GRID_UNIT;
+
 /**
  * SVG path for drawing next/previous notch from top to bottom.
  * Drawn in pixel units since Bezier control points are off the grid.
  * @const
  */
-
 Blockly.BlockSvg.NOTCH_PATH_DOWN =
   'c 0,2 1,3 2,4 ' +
   'l 4,4 ' +
@@ -158,6 +163,7 @@ Blockly.BlockSvg.NOTCH_PATH_DOWN =
   'c 0,2 -1,3 -2,4 ' +
   'l -4,4 ' +
   'c -1,1 -2,2 -2,4';
+
 /**
  * SVG path for drawing next/previous notch from bottom to top.
  * Drawn in pixel units since Bezier control points are off the grid.
@@ -196,6 +202,7 @@ Blockly.BlockSvg.FIELD_Y_OFFSET = -2 * Blockly.BlockSvg.GRID_UNIT;
  */
 Blockly.BlockSvg.TOP_LEFT_CORNER_START =
     'm ' + Blockly.BlockSvg.CORNER_RADIUS + ',0';
+
 /**
  * SVG path for drawing the rounded top-left corner.
  * @const
@@ -204,6 +211,7 @@ Blockly.BlockSvg.TOP_LEFT_CORNER =
     'A ' + Blockly.BlockSvg.CORNER_RADIUS + ',' +
     Blockly.BlockSvg.CORNER_RADIUS + ' 0 0,0 ' +
     '0,' + Blockly.BlockSvg.CORNER_RADIUS;
+
 /**
  * SVG start point for drawing the top-left corner.
  * @const

--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -738,8 +738,12 @@ Blockly.BlockSvg.prototype.renderDrawBottom_ = function(steps, connectionsXY,
     if (this.nextConnection.isConnected()) {
       this.nextConnection.tighten_();
     }
-    this.height += Blockly.BlockSvg.NOTCH_HEIGHT;
   }
+  // Always pretend height is extended by NOTCH_HEIGHT, even if there's no next.
+  // This is so blocks with no next connection stretch statement inputs to the
+  // correct size, as if there was a notch. Otherwise the height of a block
+  // with no next doesn't really matter anyway....
+  this.height += Blockly.BlockSvg.NOTCH_HEIGHT;
   // Bottom horizontal line
   steps.push('H', Blockly.BlockSvg.CORNER_RADIUS);
   // Bottom left corner

--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -656,7 +656,7 @@ Blockly.BlockSvg.prototype.renderDrawRight_ = function(steps,
       steps.push('h', '-' + Blockly.BlockSvg.STATEMENT_INPUT_INNER_SPACE);
       steps.push(Blockly.BlockSvg.INNER_TOP_LEFT_CORNER);
 
-      steps.push('v', row.height - 2 * Blockly.BlockSvg.CORNER_RADIUS);
+      steps.push('v', row.height - 2 * Blockly.BlockSvg.CORNER_RADIUS - Blockly.BlockSvg.NOTCH_HEIGHT);
 
       steps.push(Blockly.BlockSvg.INNER_BOTTOM_LEFT_CORNER);
       // Bottom notch

--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -733,8 +733,8 @@ Blockly.BlockSvg.prototype.renderDrawRight_ = function(steps,
         // If the final input is a statement stack, add a small row underneath.
         // Consecutive statement stacks are also separated by a small divider.
         steps.push(Blockly.BlockSvg.TOP_RIGHT_CORNER);
-        steps.push('v', Blockly.BlockSvg.SEP_SPACE_Y - Blockly.BlockSvg.CORNER_RADIUS);
-        cursorY += Blockly.BlockSvg.SEP_SPACE_Y + Blockly.BlockSvg.CORNER_RADIUS;
+        steps.push('v', Blockly.BlockSvg.MIN_BLOCK_Y - Blockly.BlockSvg.CORNER_RADIUS);
+        cursorY += Blockly.BlockSvg.MIN_BLOCK_Y + Blockly.BlockSvg.CORNER_RADIUS;
       }
     }
     cursorY += row.height;

--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -39,22 +39,22 @@ Blockly.BlockSvg.GRID_UNIT = 4;
  * Horizontal space between elements.
  * @const
  */
-Blockly.BlockSvg.SEP_SPACE_X = 10;
+Blockly.BlockSvg.SEP_SPACE_X = 2 * Blockly.BlockSvg.GRID_UNIT;
 /**
  * Vertical space between elements.
  * @const
  */
-Blockly.BlockSvg.SEP_SPACE_Y = 10;
+Blockly.BlockSvg.SEP_SPACE_Y = 2 * Blockly.BlockSvg.GRID_UNIT;
 /**
  * Vertical padding around inline elements.
  * @const
  */
-Blockly.BlockSvg.INLINE_PADDING_Y = 5;
+Blockly.BlockSvg.INLINE_PADDING_Y = 2 * Blockly.BlockSvg.GRID_UNIT;
 /**
  * Minimum height of a block.
  * @const
  */
-Blockly.BlockSvg.MIN_BLOCK_Y = 25;
+Blockly.BlockSvg.MIN_BLOCK_Y = 8 * Blockly.BlockSvg.GRID_UNIT;
 /**
  * Height of horizontal puzzle tab.
  * @const
@@ -66,10 +66,15 @@ Blockly.BlockSvg.TAB_HEIGHT = 20;
  */
 Blockly.BlockSvg.TAB_WIDTH = 8;
 /**
- * Width of vertical tab (inc left margin).
+ * Width of vertical notch.
  * @const
  */
-Blockly.BlockSvg.NOTCH_WIDTH = 30;
+Blockly.BlockSvg.NOTCH_WIDTH = 8 * Blockly.BlockSvg.GRID_UNIT;
+/**
+ * Height of vertical notch.
+ * @const
+ */
+Blockly.BlockSvg.NOTCH_HEIGHT = 2 * Blockly.BlockSvg.GRID_UNIT;
 /**
  * Rounded corner radius.
  * @const
@@ -103,12 +108,35 @@ Blockly.BlockSvg.START_HAT_PATH = 'c 30,-' +
  * SVG path for drawing next/previous notch from left to right.
  * @const
  */
-Blockly.BlockSvg.NOTCH_PATH_LEFT = 'l 6,4 3,0 6,-4';
+Blockly.BlockSvg.NOTCH_PATH_LEFT = (
+  'c 2,0 3,1 4,2 ' +
+  'l 4,4 ' +
+  'c 1,1 2,2 4,2 ' +
+  'h 12 ' +
+  'c 2,0 3,-1 4,-2 ' +
+  'l 4,-4 ' +
+  'c 1,-1 2,-2 4,-2'
+);
 /**
  * SVG path for drawing next/previous notch from right to left.
  * @const
  */
-Blockly.BlockSvg.NOTCH_PATH_RIGHT = 'l -6,4 -3,0 -6,-4';
+Blockly.BlockSvg.NOTCH_PATH_RIGHT = (
+  'c -2,0 -3,1 -4,2 '+
+  'l -4,4 ' +
+  'c -1,1 -2,2 -4,2 ' +
+  'h -12 ' +
+  'c -2,0 -3,-1 -4,-2 ' +
+  'l -4,-4 ' +
+  'c -1,-1 -2,-2 -4,-2'
+);
+
+/**
+ * Amount of padding before the notch, on the left (in LTR).
+ * @const
+ */
+Blockly.BlockSvg.NOTCH_LEFT_PADDING = 3 * Blockly.BlockSvg.GRID_UNIT;
+
 /**
  * SVG path for drawing a horizontal puzzle tab from top to bottom.
  * @const
@@ -564,7 +592,8 @@ Blockly.BlockSvg.prototype.renderDrawTop_ =
 
   // Top edge.
   if (this.previousConnection) {
-    steps.push('H', Blockly.BlockSvg.NOTCH_WIDTH - 15);
+    // Space before the notch
+    steps.push('H', Blockly.BlockSvg.NOTCH_LEFT_PADDING);
     steps.push(Blockly.BlockSvg.NOTCH_PATH_LEFT);
     // Create previous block connection.
     var connectionX = connectionsXY.x + (this.RTL ?
@@ -573,7 +602,6 @@ Blockly.BlockSvg.prototype.renderDrawTop_ =
     this.previousConnection.moveTo(connectionX, connectionY);
     // This connection will be tightened when the parent renders.
   }
-  steps.push('H', rightEdge);
   this.width = rightEdge;
 };  /* eslint-enable indent */
 
@@ -723,8 +751,14 @@ Blockly.BlockSvg.prototype.renderDrawBottom_ = function(steps, connectionsXY,
   this.height = cursorY;
   steps.push(Blockly.BlockSvg.BOTTOM_RIGHT_CORNER);
   if (this.nextConnection) {
-    steps.push('H', (Blockly.BlockSvg.NOTCH_WIDTH + (this.RTL ? 0.5 : - 0.5)) +
-        ' ' + Blockly.BlockSvg.NOTCH_PATH_RIGHT);
+    // Move to the right-side of the notch.
+    var notchStart = (
+      Blockly.BlockSvg.NOTCH_WIDTH +
+      Blockly.BlockSvg.NOTCH_LEFT_PADDING +
+      Blockly.BlockSvg.CORNER_RADIUS
+    );
+    steps.push('H', notchStart, ' ');
+    steps.push(Blockly.BlockSvg.NOTCH_PATH_RIGHT);
     // Create next block connection.
     var connectionX;
     if (this.RTL) {
@@ -737,7 +771,7 @@ Blockly.BlockSvg.prototype.renderDrawBottom_ = function(steps, connectionsXY,
     if (this.nextConnection.isConnected()) {
       this.nextConnection.tighten_();
     }
-    this.height += 4;  // Height of tab.
+    this.height += Blockly.BlockSvg.NOTCH_HEIGHT;
   }
   // Bottom horizontal line
   steps.push('H', Blockly.BlockSvg.CORNER_RADIUS);

--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -63,6 +63,12 @@ Blockly.BlockSvg.MIN_BLOCK_Y = 12 * Blockly.BlockSvg.GRID_UNIT;
 Blockly.BlockSvg.MIN_BLOCK_X_WITH_STATEMENT = 40 * Blockly.BlockSvg.GRID_UNIT;
 
 /**
+ * Minimum space for a statement input height.
+ * @const
+ */
+Blockly.BlockSvg.MIN_STATEMENT_INPUT_HEIGHT = 8 * Blockly.BlockSvg.GRID_UNIT;
+
+/**
  * Width of vertical notch.
  * @const
  */
@@ -420,7 +426,11 @@ Blockly.BlockSvg.prototype.renderCompute_ = function(iconWidth) {
     row.push(input);
 
     // Compute minimum input size.
-    input.renderHeight = Blockly.BlockSvg.MIN_BLOCK_Y;
+    if (row.type == Blockly.NEXT_STATEMENT) {
+      input.renderHeight = Blockly.BlockSvg.MIN_STATEMENT_INPUT_HEIGHT;
+    } else {
+      input.renderHeight = Blockly.BlockSvg.MIN_BLOCK_Y;
+    }
     // The width is currently only needed for inline value inputs.
     if (input.type == Blockly.INPUT_VALUE) {
       input.renderWidth = Blockly.BlockSvg.SEP_SPACE_X * 1.25;
@@ -434,7 +444,6 @@ Blockly.BlockSvg.prototype.renderCompute_ = function(iconWidth) {
       input.renderHeight = Math.max(input.renderHeight, bBox.height);
       input.renderWidth = Math.max(input.renderWidth, bBox.width);
     }
-
     row.height = Math.max(row.height, input.renderHeight);
     input.fieldWidth = 0;
     if (inputRows.length == 1) {

--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -78,12 +78,6 @@ Blockly.BlockSvg.CORNER_RADIUS = 4;
 Blockly.BlockSvg.STATEMENT_INPUT_EDGE_WIDTH = 4 * Blockly.BlockSvg.GRID_UNIT;
 
 /**
- * Do blocks with no previous or output connections have a 'hat' on top?
- * @const
- */
-Blockly.BlockSvg.START_HAT = true;
-
-/**
  * Height of the top hat.
  * @const
  */
@@ -500,7 +494,7 @@ Blockly.BlockSvg.prototype.renderDraw_ = function(iconWidth, inputRows) {
   // Should the top left corners be rounded or square?
   // Currently, it is squared only if it's a hat.
   this.squareTopLeftCorner_ = false;
-  if (Blockly.BlockSvg.START_HAT && !this.outputConnection && !this.previousConnection) {
+  if (!this.outputConnection && !this.previousConnection) {
     // No output or previous connection.
     this.squareTopLeftCorner_ = true;
     this.startHat_ = true;

--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -591,8 +591,8 @@ Blockly.BlockSvg.prototype.renderDrawTop_ =
  */
 Blockly.BlockSvg.prototype.renderDrawRight_ = function(steps,
     connectionsXY, inputRows, iconWidth) {
-  var cursorX;
-  var cursorY = -1; // Blocks overhang their parent by 1px.
+  var cursorX = 0;
+  var cursorY = 0;
   var connectionX, connectionY;
   for (var y = 0, row; row = inputRows[y]; y++) {
     cursorX = Blockly.BlockSvg.SEP_SPACE_X;
@@ -721,7 +721,7 @@ Blockly.BlockSvg.prototype.renderDrawBottom_ = function(steps, connectionsXY,
     } else {
       connectionX = connectionsXY.x + Blockly.BlockSvg.NOTCH_WIDTH;
     }
-    var connectionY = connectionsXY.y + cursorY + 1;
+    var connectionY = connectionsXY.y + cursorY;
     this.nextConnection.moveTo(connectionX, connectionY);
     if (this.nextConnection.isConnected()) {
       this.nextConnection.tighten_();

--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -408,6 +408,8 @@ Blockly.BlockSvg.prototype.renderCompute_ = function(iconWidth) {
   var hasDummy = false;
   var lastType = undefined;
 
+  // Previously created row, for special-casing row heights on C- and E- shaped blocks.
+  var previousRow;
   for (var i = 0, input; input = inputList[i]; i++) {
     if (!input.isVisible()) {
       continue;
@@ -434,6 +436,8 @@ Blockly.BlockSvg.prototype.renderCompute_ = function(iconWidth) {
     // Compute minimum input size.
     if (row.type == Blockly.NEXT_STATEMENT) {
       input.renderHeight = Blockly.BlockSvg.MIN_STATEMENT_INPUT_HEIGHT;
+    } else if (previousRow && previousRow.type == Blockly.NEXT_STATEMENT) {
+      input.renderHeight = Blockly.BlockSvg.EXTRA_STATEMENT_ROW_Y;
     } else {
       input.renderHeight = Blockly.BlockSvg.MIN_BLOCK_Y;
     }
@@ -484,6 +488,7 @@ Blockly.BlockSvg.prototype.renderCompute_ = function(iconWidth) {
         fieldValueWidth = Math.max(fieldValueWidth, input.fieldWidth);
       }
     }
+    previousRow = row;
   }
   // Compute the statement edge.
   // This is the width of a block where statements are nested.

--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -468,7 +468,6 @@ Blockly.BlockSvg.prototype.renderCompute_ = function(iconWidth) {
   inputRows.statementEdge = Blockly.BlockSvg.STATEMENT_INPUT_EDGE_WIDTH +
       fieldStatementWidth;
   // Compute the preferred right edge.  Inline blocks may extend beyond.
-  // This is the width of the block where external inputs connect.
   if (hasStatement) {
     inputRows.rightEdge = Math.max(inputRows.rightEdge,
         inputRows.statementEdge + Blockly.BlockSvg.NOTCH_WIDTH);
@@ -629,22 +628,6 @@ Blockly.BlockSvg.prototype.renderDrawRight_ = function(steps,
       // Subtract CORNER_RADIUS * 2 to account for the top right corner
       // and also the bottom right corner. Only move vertically the non-corner length.
       steps.push('v', row.height - Blockly.BlockSvg.CORNER_RADIUS * 2);
-    } else if (row.type == Blockly.DUMMY_INPUT) {
-      // External naked field.
-      var input = row[0];
-      var fieldX = cursorX;
-      var fieldY = cursorY;
-      if (input.align != Blockly.ALIGN_LEFT) {
-        var fieldRightX = inputRows.rightEdge - input.fieldWidth -
-            2 * Blockly.BlockSvg.SEP_SPACE_X;
-        if (input.align == Blockly.ALIGN_RIGHT) {
-          fieldX += fieldRightX;
-        } else if (input.align == Blockly.ALIGN_CENTRE) {
-          fieldX += fieldRightX / 2;
-        }
-      }
-      this.renderFields_(input.fieldRow, fieldX, fieldY);
-      steps.push('v', row.height);
     } else if (row.type == Blockly.NEXT_STATEMENT) {
       // Nested statement.
       var input = row[0];

--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -57,6 +57,12 @@ Blockly.BlockSvg.MIN_BLOCK_X = 24 * Blockly.BlockSvg.GRID_UNIT;
 Blockly.BlockSvg.MIN_BLOCK_Y = 12 * Blockly.BlockSvg.GRID_UNIT;
 
 /**
+ * Height of extra row after a statement input.
+ * @const
+ */
+Blockly.BlockSvg.EXTRA_STATEMENT_ROW_Y = 8 * Blockly.BlockSvg.GRID_UNIT;
+
+/**
  * Minimum width of a C- or E-shaped block.
  * @const
  */
@@ -687,8 +693,8 @@ Blockly.BlockSvg.prototype.renderDrawRight_ = function(steps,
         // If the final input is a statement stack, add a small row underneath.
         // Consecutive statement stacks are also separated by a small divider.
         steps.push(Blockly.BlockSvg.TOP_RIGHT_CORNER);
-        steps.push('v', Blockly.BlockSvg.MIN_BLOCK_Y - Blockly.BlockSvg.CORNER_RADIUS);
-        cursorY += Blockly.BlockSvg.MIN_BLOCK_Y + Blockly.BlockSvg.CORNER_RADIUS;
+        steps.push('v', Blockly.BlockSvg.EXTRA_STATEMENT_ROW_Y - 2 * Blockly.BlockSvg.CORNER_RADIUS);
+        cursorY += Blockly.BlockSvg.EXTRA_STATEMENT_ROW_Y + 2 * Blockly.BlockSvg.CORNER_RADIUS;
       }
     }
     cursorY += row.height;

--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -190,12 +190,9 @@ Blockly.BlockSvg.BOTTOM_LEFT_CORNER =
      Blockly.BlockSvg.CORNER_RADIUS;
 /**
  * SVG path for drawing the top-left corner of a statement input.
- * Includes the top notch, a horizontal space, and the rounded inside corner.
  * @const
  */
 Blockly.BlockSvg.INNER_TOP_LEFT_CORNER =
-    Blockly.BlockSvg.NOTCH_PATH_RIGHT + ' h -' +
-    (Blockly.BlockSvg.NOTCH_WIDTH - 15 - Blockly.BlockSvg.CORNER_RADIUS) +
     ' a ' + Blockly.BlockSvg.CORNER_RADIUS + ',' +
     Blockly.BlockSvg.CORNER_RADIUS + ' 0 0,0 -' +
     Blockly.BlockSvg.CORNER_RADIUS + ',' +
@@ -704,13 +701,23 @@ Blockly.BlockSvg.prototype.renderDrawRight_ = function(steps,
         }
       }
       this.renderFields_(input.fieldRow, fieldX, fieldY);
-      cursorX = inputRows.statementEdge + Blockly.BlockSvg.NOTCH_WIDTH;
+
       steps.push(Blockly.BlockSvg.BOTTOM_RIGHT_CORNER);
-      steps.push('H', cursorX);
+      // Move to the right-side of the notch (in LTR)
+      var innerSpace = 2 * Blockly.BlockSvg.GRID_UNIT;
+      cursorX = inputRows.statementEdge + Blockly.BlockSvg.NOTCH_WIDTH;
+      steps.push('H', cursorX + innerSpace + Blockly.BlockSvg.CORNER_RADIUS);
+      steps.push(Blockly.BlockSvg.NOTCH_PATH_RIGHT);
+      steps.push('h', '-' + innerSpace);
       steps.push(Blockly.BlockSvg.INNER_TOP_LEFT_CORNER);
-      steps.push('v', row.height - 2 * Blockly.BlockSvg.CORNER_RADIUS);
+      steps.push('v', row.height - 2 * Blockly.BlockSvg.CORNER_RADIUS - Blockly.BlockSvg.NOTCH_HEIGHT);
       steps.push(Blockly.BlockSvg.INNER_BOTTOM_LEFT_CORNER);
+      // Bottom notch
+      steps.push('h ', innerSpace);
+      steps.push(Blockly.BlockSvg.NOTCH_PATH_LEFT);
       steps.push('H', inputRows.rightEdge);
+
+      cursorX -= innerSpace - Blockly.BlockSvg.CORNER_RADIUS;
 
       // Create statement connection.
       connectionX = connectionsXY.x + (this.RTL ? -cursorX : cursorX);

--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -341,16 +341,19 @@ Blockly.BlockSvg.prototype.renderFields_ =
     if (!root) {
       continue;
     }
+    // Align all fields vertically by their own height.
+    var yOffset = -field.getSize().height / 2;
+    // Baseline for text is special in vertical
     if (this.RTL) {
       cursorX -= field.renderSep + field.renderWidth;
       root.setAttribute('transform',
-          'translate(' + cursorX + ',' + cursorY + ')');
+          'translate(' + cursorX + ',' + (cursorY + yOffset) + ')');
       if (field.renderWidth) {
         cursorX -= Blockly.BlockSvg.SEP_SPACE_X;
       }
     } else {
       root.setAttribute('transform',
-          'translate(' + (cursorX + field.renderSep) + ',' + cursorY + ')');
+          'translate(' + (cursorX + field.renderSep) + ',' + (cursorY + yOffset) + ')');
       if (field.renderWidth) {
         cursorX += field.renderSep + field.renderWidth +
             Blockly.BlockSvg.SEP_SPACE_X;
@@ -588,6 +591,10 @@ Blockly.BlockSvg.prototype.renderDrawRight_ = function(steps,
       for (var x = 0, input; input = row[x]; x++) {
         var fieldX = cursorX;
         var fieldY = cursorY;
+        // Align fields vertically within the row.
+        // Moves the field to half of the row's height.
+        // In renderFields_, the field is further centered by its own height.
+        fieldY += input.renderHeight / 2;
         // TODO: Align inline field rows (left/right/centre).
         cursorX = this.renderFields_(input.fieldRow, fieldX, fieldY);
         if (input.type != Blockly.DUMMY_INPUT) {

--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -97,18 +97,18 @@ Blockly.BlockSvg.STATEMENT_INPUT_EDGE_WIDTH = 4 * Blockly.BlockSvg.GRID_UNIT;
  * @const
  */
 Blockly.BlockSvg.START_HAT = true;
+
 /**
  * Height of the top hat.
  * @const
  */
-Blockly.BlockSvg.START_HAT_HEIGHT = 15;
+Blockly.BlockSvg.START_HAT_HEIGHT = 16;
+
 /**
  * Path of the top hat's curve.
  * @const
  */
-Blockly.BlockSvg.START_HAT_PATH = 'c 30,-' +
-    Blockly.BlockSvg.START_HAT_HEIGHT + ' 70,-' +
-    Blockly.BlockSvg.START_HAT_HEIGHT + ' 100,0';
+Blockly.BlockSvg.START_HAT_PATH = 'c 25,-22 71,-22 96,0';
 /**
  * SVG path for drawing next/previous notch from left to right.
  * @const

--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -681,7 +681,7 @@ Blockly.BlockSvg.prototype.renderDrawRight_ = function(steps,
 
       // Create statement connection.
       connectionX = connectionsXY.x + (this.RTL ? -cursorX : cursorX);
-      connectionY = connectionsXY.y + cursorY + 1;
+      connectionY = connectionsXY.y + cursorY;
       input.connection.moveTo(connectionX, connectionY);
       if (input.connection.isConnected()) {
         input.connection.tighten_();

--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -286,11 +286,8 @@ Blockly.BlockSvg.prototype.getHeightWidth = function() {
   var nextBlock = this.getNextBlock();
   if (nextBlock) {
     var nextHeightWidth = nextBlock.getHeightWidth();
-    height += nextHeightWidth.height - 4;  // Height of tab.
+    height += nextHeightWidth.height - Blockly.BlockSvg.NOTCH_HEIGHT;
     width = Math.max(width, nextHeightWidth.width);
-  } else if (!this.nextConnection && !this.outputConnection) {
-    // Add a bit of margin under blocks with no bottom tab.
-    height += 2;
   }
   return {height: height, width: width};
 };

--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -264,6 +264,13 @@ Blockly.BlockSvg.FIELD_TOP_PADDING = 0;
 Blockly.BlockSvg.MAX_DISPLAY_LENGTH = Infinity;
 
 /**
+ * Minimum X of inputs on the first row of blocks with no previous connection.
+ * Ensures that inputs will not overlap with the top notch of blocks.
+ * @const
+ */
+Blockly.BlockSvg.NO_PREVIOUS_INPUT_X_MIN = 12 * Blockly.BlockSvg.GRID_UNIT;
+
+/**
  * Change the colour of a block.
  */
 Blockly.BlockSvg.prototype.updateColour = function() {
@@ -636,6 +643,10 @@ Blockly.BlockSvg.prototype.renderDrawRight_ = function(steps,
         cursorX = this.renderFields_(input.fieldRow, fieldX, fieldY);
         if (input.type == Blockly.INPUT_VALUE) {
           // Create inline input connection.
+          if (y === 0 && this.previousConnection) {
+            // Force inputs to be past the notch
+            cursorX = Math.max(cursorX, Blockly.BlockSvg.NO_PREVIOUS_INPUT_X_MIN);
+          }
           if (this.RTL) {
             connectionX = connectionsXY.x - cursorX;
           } else {

--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -397,10 +397,6 @@ Blockly.BlockSvg.prototype.renderCompute_ = function(iconWidth) {
   var inputRows = [];
   // Block will be drawn from 0 (left edge) to rightEdge, in px.
   inputRows.rightEdge = 0;
-  if (this.previousConnection || this.nextConnection) {
-    // Blocks with notches have a minimum width.
-    inputRows.rightEdge = Blockly.BlockSvg.MIN_BLOCK_X;
-  }
   var fieldValueWidth = 0;  // Width of longest external value field.
   var fieldStatementWidth = 0;  // Width of longest statement field.
   var hasValue = false;
@@ -495,17 +491,15 @@ Blockly.BlockSvg.prototype.renderCompute_ = function(iconWidth) {
   inputRows.statementEdge = Blockly.BlockSvg.STATEMENT_INPUT_EDGE_WIDTH +
       fieldStatementWidth;
   // Compute the preferred right edge.
+  if (this.previousConnection || this.nextConnection) {
+    // Blocks with notches
+    inputRows.rightEdge = Math.max(inputRows.rightEdge,
+      Blockly.BlockSvg.MIN_BLOCK_X);
+  }
   if (hasStatement) {
     // Statement blocks (C- or E- shaped) have a longer minimum width.
     inputRows.rightEdge = Math.max(inputRows.rightEdge,
       Blockly.BlockSvg.MIN_BLOCK_X_WITH_STATEMENT);
-  }
-  if (hasValue) {
-    inputRows.rightEdge = Math.max(inputRows.rightEdge, fieldValueWidth +
-        Blockly.BlockSvg.SEP_SPACE_X * 2);
-  } else if (hasDummy) {
-    inputRows.rightEdge = Math.max(inputRows.rightEdge, fieldValueWidth +
-        Blockly.BlockSvg.SEP_SPACE_X * 2);
   }
 
   inputRows.hasValue = hasValue;

--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -634,19 +634,14 @@ Blockly.BlockSvg.prototype.renderDrawRight_ = function(steps,
         fieldY += input.renderHeight / 2;
         // TODO: Align inline field rows (left/right/centre).
         cursorX = this.renderFields_(input.fieldRow, fieldX, fieldY);
-        if (input.type != Blockly.DUMMY_INPUT) {
-          cursorX += input.renderWidth + Blockly.BlockSvg.SEP_SPACE_X;
-        }
         if (input.type == Blockly.INPUT_VALUE) {
           // Create inline input connection.
           if (this.RTL) {
-            connectionX = connectionsXY.x - cursorX + Blockly.BlockSvg.SEP_SPACE_X +
-                input.renderWidth + 1;
+            connectionX = connectionsXY.x - cursorX;
           } else {
-            connectionX = connectionsXY.x + cursorX + Blockly.BlockSvg.SEP_SPACE_X -
-                input.renderWidth - 1;
+            connectionX = connectionsXY.x + cursorX;
           }
-          connectionY = connectionsXY.y + cursorY + 1;
+          connectionY = connectionsXY.y + cursorY;
           input.connection.moveTo(connectionX, connectionY);
           if (input.connection.isConnected()) {
             input.connection.tighten_();

--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -51,6 +51,11 @@ Blockly.BlockSvg.SEP_SPACE_Y = 2 * Blockly.BlockSvg.GRID_UNIT;
  */
 Blockly.BlockSvg.INLINE_PADDING_Y = 2 * Blockly.BlockSvg.GRID_UNIT;
 /**
+ * Minimum width of a block.
+ * @const
+ */
+Blockly.BlockSvg.MIN_BLOCK_X = 16 * Blockly.BlockSvg.GRID_UNIT;
+/**
  * Minimum height of a block.
  * @const
  */
@@ -394,9 +399,9 @@ Blockly.BlockSvg.prototype.renderFields_ =
 Blockly.BlockSvg.prototype.renderCompute_ = function(iconWidth) {
   var inputList = this.inputList;
   var inputRows = [];
-  inputRows.rightEdge = iconWidth + Blockly.BlockSvg.SEP_SPACE_X * 2;
+  inputRows.rightEdge = 0;
   if (this.previousConnection || this.nextConnection) {
-    inputRows.rightEdge = Math.max(inputRows.rightEdge,
+    inputRows.rightEdge = Math.max(Blockly.BlockSvg.MIN_BLOCK_X,
         Blockly.BlockSvg.NOTCH_WIDTH + Blockly.BlockSvg.SEP_SPACE_X);
   }
   var fieldValueWidth = 0;  // Width of longest external value field.

--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -149,10 +149,10 @@ Blockly.BlockSvg.NOTCH_PATH_RIGHT = (
 );
 
 /**
- * Amount of padding before the notch, on the left (in LTR).
+ * Amount of padding before the notch.
  * @const
  */
-Blockly.BlockSvg.NOTCH_LEFT_PADDING = 3 * Blockly.BlockSvg.GRID_UNIT;
+Blockly.BlockSvg.NOTCH_START_PADDING = 3 * Blockly.BlockSvg.GRID_UNIT;
 
 /**
  * SVG start point for drawing the top-left corner.
@@ -589,7 +589,7 @@ Blockly.BlockSvg.prototype.renderDrawTop_ =
   // Top edge.
   if (this.previousConnection) {
     // Space before the notch
-    steps.push('H', Blockly.BlockSvg.NOTCH_LEFT_PADDING);
+    steps.push('H', Blockly.BlockSvg.NOTCH_START_PADDING);
     steps.push(Blockly.BlockSvg.NOTCH_PATH_LEFT);
     // Create previous block connection.
     var connectionX = connectionsXY.x + (this.RTL ?
@@ -732,7 +732,7 @@ Blockly.BlockSvg.prototype.renderDrawBottom_ = function(steps, connectionsXY,
     // Move to the right-side of the notch.
     var notchStart = (
       Blockly.BlockSvg.NOTCH_WIDTH +
-      Blockly.BlockSvg.NOTCH_LEFT_PADDING +
+      Blockly.BlockSvg.NOTCH_START_PADDING +
       Blockly.BlockSvg.CORNER_RADIUS
     );
     steps.push('H', notchStart, ' ');

--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -35,21 +35,25 @@ goog.require('Blockly.BlockSvg');
 * @const
 */
 Blockly.BlockSvg.GRID_UNIT = 4;
+
 /**
  * Horizontal space between elements.
  * @const
  */
 Blockly.BlockSvg.SEP_SPACE_X = 2 * Blockly.BlockSvg.GRID_UNIT;
+
 /**
  * Vertical space between elements.
  * @const
  */
 Blockly.BlockSvg.SEP_SPACE_Y = 2 * Blockly.BlockSvg.GRID_UNIT;
+
 /**
  * Minimum width of a block.
  * @const
  */
 Blockly.BlockSvg.MIN_BLOCK_X = 24 * Blockly.BlockSvg.GRID_UNIT;
+
 /**
  * Minimum height of a block.
  * @const
@@ -79,11 +83,13 @@ Blockly.BlockSvg.MIN_STATEMENT_INPUT_HEIGHT = 6 * Blockly.BlockSvg.GRID_UNIT;
  * @const
  */
 Blockly.BlockSvg.NOTCH_WIDTH = 8 * Blockly.BlockSvg.GRID_UNIT;
+
 /**
  * Height of vertical notch.
  * @const
  */
 Blockly.BlockSvg.NOTCH_HEIGHT = 2 * Blockly.BlockSvg.GRID_UNIT;
+
 /**
  * Rounded corner radius.
  * @const
@@ -113,6 +119,7 @@ Blockly.BlockSvg.START_HAT_HEIGHT = 16;
  * @const
  */
 Blockly.BlockSvg.START_HAT_PATH = 'c 25,-22 71,-22 96,0';
+
 /**
  * SVG path for drawing next/previous notch from left to right.
  * @const
@@ -126,6 +133,7 @@ Blockly.BlockSvg.NOTCH_PATH_LEFT = (
   'l 4,-4 ' +
   'c 1,-1 2,-2 4,-2'
 );
+
 /**
  * SVG path for drawing next/previous notch from right to left.
  * @const
@@ -152,6 +160,7 @@ Blockly.BlockSvg.NOTCH_LEFT_PADDING = 3 * Blockly.BlockSvg.GRID_UNIT;
  */
 Blockly.BlockSvg.TOP_LEFT_CORNER_START =
     'm 0,' + Blockly.BlockSvg.CORNER_RADIUS;
+
 /**
  * SVG path for drawing the rounded top-left corner.
  * @const
@@ -190,6 +199,7 @@ Blockly.BlockSvg.BOTTOM_LEFT_CORNER =
      Blockly.BlockSvg.CORNER_RADIUS + ' 0 0,1 -' +
      Blockly.BlockSvg.CORNER_RADIUS + ',-' +
      Blockly.BlockSvg.CORNER_RADIUS;
+
 /**
  * SVG path for drawing the top-left corner of a statement input.
  * @const
@@ -199,6 +209,7 @@ Blockly.BlockSvg.INNER_TOP_LEFT_CORNER =
     Blockly.BlockSvg.CORNER_RADIUS + ' 0 0,0 -' +
     Blockly.BlockSvg.CORNER_RADIUS + ',' +
     Blockly.BlockSvg.CORNER_RADIUS;
+
 /**
  * SVG path for drawing the bottom-left corner of a statement input.
  * Includes the rounded inside corner.

--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -377,7 +377,6 @@ Blockly.BlockSvg.prototype.renderFields_ =
     // Offset the field upward by half its height.
     // This vertically centers the fields around cursorY.
     var yOffset = -field.getSize().height / 2;
-    // Baseline for text is special in vertical
     if (this.RTL) {
       cursorX -= field.renderSep + field.renderWidth;
       root.setAttribute('transform',

--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -72,7 +72,7 @@ Blockly.BlockSvg.MIN_BLOCK_X_WITH_STATEMENT = 40 * Blockly.BlockSvg.GRID_UNIT;
  * Minimum space for a statement input height.
  * @const
  */
-Blockly.BlockSvg.MIN_STATEMENT_INPUT_HEIGHT = 8 * Blockly.BlockSvg.GRID_UNIT;
+Blockly.BlockSvg.MIN_STATEMENT_INPUT_HEIGHT = 6 * Blockly.BlockSvg.GRID_UNIT;
 
 /**
  * Width of vertical notch.
@@ -298,7 +298,7 @@ Blockly.BlockSvg.prototype.getHeightWidth = function() {
   var nextBlock = this.getNextBlock();
   if (nextBlock) {
     var nextHeightWidth = nextBlock.getHeightWidth();
-    height += nextHeightWidth.height - Blockly.BlockSvg.NOTCH_HEIGHT;
+    height += nextHeightWidth.height;
     width = Math.max(width, nextHeightWidth.width);
   }
   return {height: height, width: width};
@@ -676,7 +676,7 @@ Blockly.BlockSvg.prototype.renderDrawRight_ = function(steps,
       steps.push('h', '-' + Blockly.BlockSvg.STATEMENT_INPUT_INNER_SPACE);
       steps.push(Blockly.BlockSvg.INNER_TOP_LEFT_CORNER);
 
-      steps.push('v', row.height - 2 * Blockly.BlockSvg.CORNER_RADIUS - Blockly.BlockSvg.NOTCH_HEIGHT);
+      steps.push('v', row.height - 2 * Blockly.BlockSvg.CORNER_RADIUS);
 
       steps.push(Blockly.BlockSvg.INNER_BOTTOM_LEFT_CORNER);
       // Bottom notch
@@ -688,6 +688,7 @@ Blockly.BlockSvg.prototype.renderDrawRight_ = function(steps,
       connectionX = connectionsXY.x + (this.RTL ? -cursorX : cursorX);
       connectionY = connectionsXY.y + cursorY;
       input.connection.moveTo(connectionX, connectionY);
+
       if (input.connection.isConnected()) {
         input.connection.tighten_();
         this.width = Math.max(this.width, inputRows.statementEdge +
@@ -699,7 +700,7 @@ Blockly.BlockSvg.prototype.renderDrawRight_ = function(steps,
         // Consecutive statement stacks are also separated by a small divider.
         steps.push(Blockly.BlockSvg.TOP_RIGHT_CORNER);
         steps.push('v', Blockly.BlockSvg.EXTRA_STATEMENT_ROW_Y - 2 * Blockly.BlockSvg.CORNER_RADIUS);
-        cursorY += Blockly.BlockSvg.EXTRA_STATEMENT_ROW_Y + 2 * Blockly.BlockSvg.CORNER_RADIUS;
+        cursorY += Blockly.BlockSvg.EXTRA_STATEMENT_ROW_Y;
       }
     }
     cursorY += row.height;
@@ -744,11 +745,6 @@ Blockly.BlockSvg.prototype.renderDrawBottom_ = function(steps, connectionsXY,
       this.nextConnection.tighten_();
     }
   }
-  // Always pretend height is extended by NOTCH_HEIGHT, even if there's no next.
-  // This is so blocks with no next connection stretch statement inputs to the
-  // correct size, as if there was a notch. Otherwise the height of a block
-  // with no next doesn't really matter anyway....
-  this.height += Blockly.BlockSvg.NOTCH_HEIGHT;
   // Bottom horizontal line
   steps.push('H', Blockly.BlockSvg.CORNER_RADIUS);
   // Bottom left corner

--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -55,6 +55,13 @@ Blockly.BlockSvg.MIN_BLOCK_X = 24 * Blockly.BlockSvg.GRID_UNIT;
  * @const
  */
 Blockly.BlockSvg.MIN_BLOCK_Y = 12 * Blockly.BlockSvg.GRID_UNIT;
+
+/**
+ * Minimum width of a C- or E-shaped block.
+ * @const
+ */
+Blockly.BlockSvg.MIN_BLOCK_X_WITH_STATEMENT = 40 * Blockly.BlockSvg.GRID_UNIT;
+
 /**
  * Width of vertical notch.
  * @const
@@ -373,10 +380,11 @@ Blockly.BlockSvg.prototype.renderFields_ =
 Blockly.BlockSvg.prototype.renderCompute_ = function(iconWidth) {
   var inputList = this.inputList;
   var inputRows = [];
+  // Block will be drawn from 0 (left edge) to rightEdge, in px.
   inputRows.rightEdge = 0;
   if (this.previousConnection || this.nextConnection) {
-    inputRows.rightEdge = Math.max(Blockly.BlockSvg.MIN_BLOCK_X,
-        Blockly.BlockSvg.NOTCH_WIDTH + Blockly.BlockSvg.SEP_SPACE_X);
+    // Blocks with notches have a minimum width.
+    inputRows.rightEdge = Blockly.BlockSvg.MIN_BLOCK_X;
   }
   var fieldValueWidth = 0;  // Width of longest external value field.
   var fieldStatementWidth = 0;  // Width of longest statement field.
@@ -459,15 +467,15 @@ Blockly.BlockSvg.prototype.renderCompute_ = function(iconWidth) {
       }
     }
   }
-
   // Compute the statement edge.
   // This is the width of a block where statements are nested.
   inputRows.statementEdge = Blockly.BlockSvg.STATEMENT_INPUT_EDGE_WIDTH +
       fieldStatementWidth;
-  // Compute the preferred right edge.  Inline blocks may extend beyond.
+  // Compute the preferred right edge.
   if (hasStatement) {
+    // Statement blocks (C- or E- shaped) have a longer minimum width.
     inputRows.rightEdge = Math.max(inputRows.rightEdge,
-        inputRows.statementEdge + Blockly.BlockSvg.NOTCH_WIDTH);
+      Blockly.BlockSvg.MIN_BLOCK_X_WITH_STATEMENT);
   }
   if (hasValue) {
     inputRows.rightEdge = Math.max(inputRows.rightEdge, fieldValueWidth +

--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -85,6 +85,12 @@ Blockly.BlockSvg.CORNER_RADIUS = 4;
 Blockly.BlockSvg.STATEMENT_INPUT_EDGE_WIDTH = 4 * Blockly.BlockSvg.GRID_UNIT;
 
 /**
+ * Inner space between edge of statement input and notch.
+ * @const
+ */
+Blockly.BlockSvg.STATEMENT_INPUT_INNER_SPACE = 2 * Blockly.BlockSvg.GRID_UNIT;
+
+/**
  * Height of the top hat.
  * @const
  */
@@ -645,21 +651,21 @@ Blockly.BlockSvg.prototype.renderDrawRight_ = function(steps,
       this.renderFields_(input.fieldRow, fieldX, fieldY);
 
       steps.push(Blockly.BlockSvg.BOTTOM_RIGHT_CORNER);
-      // Move to the right-side of the notch (in LTR)
-      var innerSpace = 2 * Blockly.BlockSvg.GRID_UNIT;
+      // Move to the start of the notch.
       cursorX = inputRows.statementEdge + Blockly.BlockSvg.NOTCH_WIDTH;
-      steps.push('H', cursorX + innerSpace + Blockly.BlockSvg.CORNER_RADIUS);
+      steps.push('H', cursorX + Blockly.BlockSvg.STATEMENT_INPUT_INNER_SPACE +
+        2 * Blockly.BlockSvg.CORNER_RADIUS);
       steps.push(Blockly.BlockSvg.NOTCH_PATH_RIGHT);
-      steps.push('h', '-' + innerSpace);
+      steps.push('h', '-' + Blockly.BlockSvg.STATEMENT_INPUT_INNER_SPACE);
       steps.push(Blockly.BlockSvg.INNER_TOP_LEFT_CORNER);
-      steps.push('v', row.height - 2 * Blockly.BlockSvg.CORNER_RADIUS - Blockly.BlockSvg.NOTCH_HEIGHT);
+
+      steps.push('v', row.height - 2 * Blockly.BlockSvg.CORNER_RADIUS);
+
       steps.push(Blockly.BlockSvg.INNER_BOTTOM_LEFT_CORNER);
       // Bottom notch
-      steps.push('h ', innerSpace);
+      steps.push('h ', Blockly.BlockSvg.STATEMENT_INPUT_INNER_SPACE);
       steps.push(Blockly.BlockSvg.NOTCH_PATH_LEFT);
       steps.push('H', inputRows.rightEdge);
-
-      cursorX -= innerSpace - Blockly.BlockSvg.CORNER_RADIUS;
 
       // Create statement connection.
       connectionX = connectionsXY.x + (this.RTL ? -cursorX : cursorX);

--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -46,11 +46,6 @@ Blockly.BlockSvg.SEP_SPACE_X = 2 * Blockly.BlockSvg.GRID_UNIT;
  */
 Blockly.BlockSvg.SEP_SPACE_Y = 2 * Blockly.BlockSvg.GRID_UNIT;
 /**
- * Vertical padding around inline elements.
- * @const
- */
-Blockly.BlockSvg.INLINE_PADDING_Y = 2 * Blockly.BlockSvg.GRID_UNIT;
-/**
  * Minimum width of a block.
  * @const
  */
@@ -59,7 +54,7 @@ Blockly.BlockSvg.MIN_BLOCK_X = 24 * Blockly.BlockSvg.GRID_UNIT;
  * Minimum height of a block.
  * @const
  */
-Blockly.BlockSvg.MIN_BLOCK_Y = 8 * Blockly.BlockSvg.GRID_UNIT;
+Blockly.BlockSvg.MIN_BLOCK_Y = 12 * Blockly.BlockSvg.GRID_UNIT;
 /**
  * Height of horizontal puzzle tab.
  * @const
@@ -361,7 +356,6 @@ Blockly.BlockSvg.prototype.render = function(opt_bubble) {
 Blockly.BlockSvg.prototype.renderFields_ =
     function(fieldList, cursorX, cursorY) {
   /* eslint-disable indent */
-  cursorY += Blockly.BlockSvg.INLINE_PADDING_Y;
   if (this.RTL) {
     cursorX = -cursorX;
   }
@@ -483,20 +477,6 @@ Blockly.BlockSvg.prototype.renderCompute_ = function(iconWidth) {
           hasDummy = true;
         }
         fieldValueWidth = Math.max(fieldValueWidth, input.fieldWidth);
-      }
-    }
-  }
-
-  // Make inline rows a bit thicker in order to enclose the values.
-  for (var y = 0, row; row = inputRows[y]; y++) {
-    row.thicker = false;
-    if (row.type == Blockly.BlockSvg.INLINE) {
-      for (var z = 0, input; input = row[z]; z++) {
-        if (input.type == Blockly.INPUT_VALUE) {
-          row.height += 2 * Blockly.BlockSvg.INLINE_PADDING_Y;
-          row.thicker = true;
-          break;
-        }
       }
     }
   }
@@ -633,10 +613,6 @@ Blockly.BlockSvg.prototype.renderDrawRight_ = function(steps,
       for (var x = 0, input; input = row[x]; x++) {
         var fieldX = cursorX;
         var fieldY = cursorY;
-        if (row.thicker) {
-          // Lower the field slightly.
-          fieldY += Blockly.BlockSvg.INLINE_PADDING_Y;
-        }
         // TODO: Align inline field rows (left/right/centre).
         cursorX = this.renderFields_(input.fieldRow, fieldX, fieldY);
         if (input.type != Blockly.DUMMY_INPUT) {
@@ -653,8 +629,7 @@ Blockly.BlockSvg.prototype.renderDrawRight_ = function(steps,
                 Blockly.BlockSvg.TAB_WIDTH - Blockly.BlockSvg.SEP_SPACE_X -
                 input.renderWidth - 1;
           }
-          connectionY = connectionsXY.y + cursorY +
-              Blockly.BlockSvg.INLINE_PADDING_Y + 1;
+          connectionY = connectionsXY.y + cursorY + 1;
           input.connection.moveTo(connectionX, connectionY);
           if (input.connection.isConnected()) {
             input.connection.tighten_();

--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -642,15 +642,6 @@ Blockly.BlockSvg.prototype.renderDrawRight_ = function(steps,
       var input = row[0];
       var fieldX = cursorX;
       var fieldY = cursorY;
-      if (input.align != Blockly.ALIGN_LEFT) {
-        var fieldRightX = inputRows.statementEdge - input.fieldWidth -
-            2 * Blockly.BlockSvg.SEP_SPACE_X;
-        if (input.align == Blockly.ALIGN_RIGHT) {
-          fieldX += fieldRightX;
-        } else if (input.align == Blockly.ALIGN_CENTRE) {
-          fieldX += fieldRightX / 2;
-        }
-      }
       this.renderFields_(input.fieldRow, fieldX, fieldY);
 
       steps.push(Blockly.BlockSvg.BOTTOM_RIGHT_CORNER);

--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -54,7 +54,7 @@ Blockly.BlockSvg.INLINE_PADDING_Y = 2 * Blockly.BlockSvg.GRID_UNIT;
  * Minimum width of a block.
  * @const
  */
-Blockly.BlockSvg.MIN_BLOCK_X = 16 * Blockly.BlockSvg.GRID_UNIT;
+Blockly.BlockSvg.MIN_BLOCK_X = 24 * Blockly.BlockSvg.GRID_UNIT;
 /**
  * Minimum height of a block.
  * @const

--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -359,7 +359,7 @@ Blockly.BlockSvg.prototype.render = function(opt_bubble) {
  * Render a list of fields starting at the specified location.
  * @param {!Array.<!Blockly.Field>} fieldList List of fields.
  * @param {number} cursorX X-coordinate to start the fields.
- * @param {number} cursorY Y-coordinate to start the fields.
+ * @param {number} cursorY Y-coordinate around which fields are centered.
  * @return {number} X-coordinate of the end of the field row (plus a gap).
  * @private
  */
@@ -374,7 +374,8 @@ Blockly.BlockSvg.prototype.renderFields_ =
     if (!root) {
       continue;
     }
-    // Align all fields vertically by their own height.
+    // Offset the field upward by half its height.
+    // This vertically centers the fields around cursorY.
     var yOffset = -field.getSize().height / 2;
     // Baseline for text is special in vertical
     if (this.RTL) {
@@ -629,7 +630,8 @@ Blockly.BlockSvg.prototype.renderDrawRight_ = function(steps,
         var fieldY = cursorY;
         // Align fields vertically within the row.
         // Moves the field to half of the row's height.
-        // In renderFields_, the field is further centered by its own height.
+        // In renderFields_, the field is further centered
+        // by its own rendered height.
         fieldY += input.renderHeight / 2;
         // TODO: Align inline field rows (left/right/centre).
         cursorX = this.renderFields_(input.fieldRow, fieldX, fieldY);
@@ -639,12 +641,10 @@ Blockly.BlockSvg.prototype.renderDrawRight_ = function(steps,
         if (input.type == Blockly.INPUT_VALUE) {
           // Create inline input connection.
           if (this.RTL) {
-            connectionX = connectionsXY.x - cursorX -
-                Blockly.BlockSvg.SEP_SPACE_X +
+            connectionX = connectionsXY.x - cursorX + Blockly.BlockSvg.SEP_SPACE_X +
                 input.renderWidth + 1;
           } else {
-            connectionX = connectionsXY.x + cursorX +
-                Blockly.BlockSvg.SEP_SPACE_X -
+            connectionX = connectionsXY.x + cursorX + Blockly.BlockSvg.SEP_SPACE_X -
                 input.renderWidth - 1;
           }
           connectionY = connectionsXY.y + cursorY + 1;

--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -56,16 +56,6 @@ Blockly.BlockSvg.MIN_BLOCK_X = 24 * Blockly.BlockSvg.GRID_UNIT;
  */
 Blockly.BlockSvg.MIN_BLOCK_Y = 12 * Blockly.BlockSvg.GRID_UNIT;
 /**
- * Height of horizontal puzzle tab.
- * @const
- */
-Blockly.BlockSvg.TAB_HEIGHT = 20;
-/**
- * Width of horizontal puzzle tab.
- * @const
- */
-Blockly.BlockSvg.TAB_WIDTH = 8;
-/**
  * Width of vertical notch.
  * @const
  */
@@ -137,13 +127,6 @@ Blockly.BlockSvg.NOTCH_PATH_RIGHT = (
  */
 Blockly.BlockSvg.NOTCH_LEFT_PADDING = 3 * Blockly.BlockSvg.GRID_UNIT;
 
-/**
- * SVG path for drawing a horizontal puzzle tab from top to bottom.
- * @const
- */
-Blockly.BlockSvg.TAB_PATH_DOWN = 'v 5 c 0,10 -' + Blockly.BlockSvg.TAB_WIDTH +
-    ',-8 -' + Blockly.BlockSvg.TAB_WIDTH + ',7.5 s ' +
-    Blockly.BlockSvg.TAB_WIDTH + ',-2.5 ' + Blockly.BlockSvg.TAB_WIDTH + ',7.5';
 /**
  * SVG start point for drawing the top-left corner.
  * @const
@@ -432,8 +415,7 @@ Blockly.BlockSvg.prototype.renderCompute_ = function(iconWidth) {
     input.renderHeight = Blockly.BlockSvg.MIN_BLOCK_Y;
     // The width is currently only needed for inline value inputs.
     if (input.type == Blockly.INPUT_VALUE) {
-      input.renderWidth = Blockly.BlockSvg.TAB_WIDTH +
-          Blockly.BlockSvg.SEP_SPACE_X * 1.25;
+      input.renderWidth = Blockly.BlockSvg.SEP_SPACE_X * 1.25;
     } else {
       input.renderWidth = 0;
     }
@@ -493,7 +475,7 @@ Blockly.BlockSvg.prototype.renderCompute_ = function(iconWidth) {
   }
   if (hasValue) {
     inputRows.rightEdge = Math.max(inputRows.rightEdge, fieldValueWidth +
-        Blockly.BlockSvg.SEP_SPACE_X * 2 + Blockly.BlockSvg.TAB_WIDTH);
+        Blockly.BlockSvg.SEP_SPACE_X * 2);
   } else if (hasDummy) {
     inputRows.rightEdge = Math.max(inputRows.rightEdge, fieldValueWidth +
         Blockly.BlockSvg.SEP_SPACE_X * 2);
@@ -622,11 +604,11 @@ Blockly.BlockSvg.prototype.renderDrawRight_ = function(steps,
           // Create inline input connection.
           if (this.RTL) {
             connectionX = connectionsXY.x - cursorX -
-                Blockly.BlockSvg.TAB_WIDTH + Blockly.BlockSvg.SEP_SPACE_X +
+                Blockly.BlockSvg.SEP_SPACE_X +
                 input.renderWidth + 1;
           } else {
             connectionX = connectionsXY.x + cursorX +
-                Blockly.BlockSvg.TAB_WIDTH - Blockly.BlockSvg.SEP_SPACE_X -
+                Blockly.BlockSvg.SEP_SPACE_X -
                 input.renderWidth - 1;
           }
           connectionY = connectionsXY.y + cursorY + 1;
@@ -655,9 +637,6 @@ Blockly.BlockSvg.prototype.renderDrawRight_ = function(steps,
       if (input.align != Blockly.ALIGN_LEFT) {
         var fieldRightX = inputRows.rightEdge - input.fieldWidth -
             2 * Blockly.BlockSvg.SEP_SPACE_X;
-        if (inputRows.hasValue) {
-          fieldRightX -= Blockly.BlockSvg.TAB_WIDTH;
-        }
         if (input.align == Blockly.ALIGN_RIGHT) {
           fieldX += fieldRightX;
         } else if (input.align == Blockly.ALIGN_CENTRE) {

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -487,26 +487,20 @@ Blockly.BlockSvg.prototype.getHeightWidth = function() {
  */
 Blockly.BlockSvg.prototype.getBoundingRectangle = function() {
   var blockXY = this.getRelativeToSurfaceXY(this);
-  var tab = 0;
   var blockBounds = this.getHeightWidth();
   var topLeft;
   var bottomRight;
   if (this.RTL) {
-    // Width has the tab built into it already so subtract it here.
-    topLeft = new goog.math.Coordinate(blockXY.x - (blockBounds.width - tab),
+    topLeft = new goog.math.Coordinate(blockXY.x - blockBounds.width,
         blockXY.y);
-    // Add the width of the tab/puzzle piece knob to the x coordinate
-    // since X is the corner of the rectangle, not the whole puzzle piece.
-    bottomRight = new goog.math.Coordinate(blockXY.x + tab,
+    bottomRight = new goog.math.Coordinate(blockXY.x,
         blockXY.y + blockBounds.height);
   } else {
-    // Subtract the width of the tab/puzzle piece knob to the x coordinate
-    // since X is the corner of the rectangle, not the whole puzzle piece.
-    topLeft = new goog.math.Coordinate(blockXY.x - tab, blockXY.y);
-    // Width has the tab built into it already so subtract it here.
-    bottomRight = new goog.math.Coordinate(blockXY.x + blockBounds.width - tab,
+    topLeft = new goog.math.Coordinate(blockXY.x, blockXY.y);
+    bottomRight = new goog.math.Coordinate(blockXY.x + blockBounds.width,
         blockXY.y + blockBounds.height);
   }
+
   return {topLeft: topLeft, bottomRight: bottomRight};
 };
 

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -487,7 +487,7 @@ Blockly.BlockSvg.prototype.getHeightWidth = function() {
  */
 Blockly.BlockSvg.prototype.getBoundingRectangle = function() {
   var blockXY = this.getRelativeToSurfaceXY(this);
-  var tab = this.outputConnection ? Blockly.BlockSvg.TAB_WIDTH : 0;
+  var tab = 0;
   var blockBounds = this.getHeightWidth();
   var topLeft;
   var bottomRight;

--- a/core/field_label.js
+++ b/core/field_label.js
@@ -61,7 +61,7 @@ Blockly.FieldLabel.prototype.init = function() {
   }
   // Build the DOM.
   this.textElement_ = Blockly.createSvgElement('text',
-      {'class': 'blocklyText', 'y': this.size_.height - 5}, null);
+      {'class': 'blocklyText', 'y': this.size_.height - 1}, null);
   if (this.class_) {
     Blockly.addClass_(this.textElement_, this.class_);
   }

--- a/core/flyout.js
+++ b/core/flyout.js
@@ -666,14 +666,10 @@ Blockly.Flyout.prototype.layoutBlocks_ = function(blocks, gaps) {
     }
     var root = block.getSvgRoot();
     var blockHW = block.getHeightWidth();
-    var tab = 0;
-    if (this.horizontalLayout_) {
-      cursorX += tab;
-    }
     block.moveBy((this.horizontalLayout_ && this.RTL) ? -cursorX : cursorX,
         cursorY);
     if (this.horizontalLayout_) {
-      cursorX += (blockHW.width + gaps[i] - tab);
+      cursorX += blockHW.width + gaps[i];
     } else {
       cursorY += blockHW.height + gaps[i];
     }
@@ -1165,11 +1161,10 @@ Blockly.Flyout.prototype.reflowHorizontal = function(blocks) {
         block.flyoutRect_.setAttribute('width', blockHW.width);
         block.flyoutRect_.setAttribute('height', blockHW.height);
         // Rectangles behind blocks with output tabs are shifted a bit.
-        var tab = 0;
         var blockXY = block.getRelativeToSurfaceXY();
         block.flyoutRect_.setAttribute('y', blockXY.y);
         block.flyoutRect_.setAttribute('x',
-            this.RTL ? blockXY.x - blockHW.width + tab : blockXY.x - tab);
+            this.RTL ? blockXY.x - blockHW.width : blockXY.x);
         // For hat blocks we want to shift them down by the hat height
         // since the y coordinate is the corner, not the top of the hat.
         var hatOffset =
@@ -1215,10 +1210,9 @@ Blockly.Flyout.prototype.reflowVertical = function(blocks) {
         block.flyoutRect_.setAttribute('width', blockHW.width);
         block.flyoutRect_.setAttribute('height', blockHW.height);
         // Blocks with output tabs are shifted a bit.
-        var tab = 0;
         var blockXY = block.getRelativeToSurfaceXY();
         block.flyoutRect_.setAttribute('x',
-            this.RTL ? blockXY.x - blockHW.width + tab : blockXY.x - tab);
+            this.RTL ? blockXY.x - blockHW.width : blockXY.x);
         // For hat blocks we want to shift them down by the hat height
         // since the y coordinate is the corner, not the top of the hat.
         var hatOffset =

--- a/core/flyout.js
+++ b/core/flyout.js
@@ -654,7 +654,7 @@ Blockly.Flyout.prototype.show = function(xmlList) {
  */
 Blockly.Flyout.prototype.layoutBlocks_ = function(blocks, gaps) {
   var margin = this.MARGIN * this.workspace_.scale;
-  var cursorX = this.RTL ? margin : margin + Blockly.BlockSvg.TAB_WIDTH;
+  var cursorX = margin;
   var cursorY = margin;
   for (var i = 0, block; block = blocks[i]; i++) {
     var allBlocks = block.getDescendants();
@@ -666,7 +666,7 @@ Blockly.Flyout.prototype.layoutBlocks_ = function(blocks, gaps) {
     }
     var root = block.getSvgRoot();
     var blockHW = block.getHeightWidth();
-    var tab = block.outputConnection ? Blockly.BlockSvg.TAB_WIDTH : 0;
+    var tab = 0;
     if (this.horizontalLayout_) {
       cursorX += tab;
     }
@@ -1165,7 +1165,7 @@ Blockly.Flyout.prototype.reflowHorizontal = function(blocks) {
         block.flyoutRect_.setAttribute('width', blockHW.width);
         block.flyoutRect_.setAttribute('height', blockHW.height);
         // Rectangles behind blocks with output tabs are shifted a bit.
-        var tab = block.outputConnection ? Blockly.BlockSvg.TAB_WIDTH : 0;
+        var tab = 0;
         var blockXY = block.getRelativeToSurfaceXY();
         block.flyoutRect_.setAttribute('y', blockXY.y);
         block.flyoutRect_.setAttribute('x',
@@ -1196,12 +1196,9 @@ Blockly.Flyout.prototype.reflowVertical = function(blocks) {
   var flyoutWidth = 0;
   for (var i = 0, block; block = blocks[i]; i++) {
     var width = block.getHeightWidth().width;
-    if (block.outputConnection) {
-      width -= Blockly.BlockSvg.TAB_WIDTH;
-    }
     flyoutWidth = Math.max(flyoutWidth, width);
   }
-  flyoutWidth += this.MARGIN * 1.5 + Blockly.BlockSvg.TAB_WIDTH;
+  flyoutWidth += this.MARGIN * 1.5;
   flyoutWidth *= this.workspace_.scale;
   flyoutWidth += Blockly.Scrollbar.scrollbarThickness;
   if (this.width_ != flyoutWidth) {
@@ -1212,14 +1209,13 @@ Blockly.Flyout.prototype.reflowVertical = function(blocks) {
         var oldX = block.getRelativeToSurfaceXY().x;
         var dx = flyoutWidth - this.MARGIN;
         dx /= this.workspace_.scale;
-        dx -= Blockly.BlockSvg.TAB_WIDTH;
         block.moveBy(dx - oldX, 0);
       }
       if (block.flyoutRect_) {
         block.flyoutRect_.setAttribute('width', blockHW.width);
         block.flyoutRect_.setAttribute('height', blockHW.height);
         // Blocks with output tabs are shifted a bit.
-        var tab = block.outputConnection ? Blockly.BlockSvg.TAB_WIDTH : 0;
+        var tab = 0;
         var blockXY = block.getRelativeToSurfaceXY();
         block.flyoutRect_.setAttribute('x',
             this.RTL ? blockXY.x - blockHW.width + tab : blockXY.x - tab);

--- a/core/rendered_connection.js
+++ b/core/rendered_connection.js
@@ -161,11 +161,7 @@ Blockly.RenderedConnection.prototype.closest = function(maxLimit, dxy) {
  */
 Blockly.RenderedConnection.prototype.highlight = function() {
   var steps;
-  if (this.type == Blockly.INPUT_VALUE || this.type == Blockly.OUTPUT_VALUE) {
-    steps = 'm 0,0 ' + Blockly.BlockSvg.TAB_PATH_DOWN + ' v 5';
-  } else {
-    steps = 'm -20,0 h 5 ' + Blockly.BlockSvg.NOTCH_PATH_LEFT + ' h 5';
-  }
+  steps = 'm -20,0 h 5 ' + Blockly.BlockSvg.NOTCH_PATH_LEFT + ' h 5';
   var xy = this.sourceBlock_.getRelativeToSurfaceXY();
   var x = this.x_ - xy.x;
   var y = this.y_ - xy.y;

--- a/tests/vertical_playground.html
+++ b/tests/vertical_playground.html
@@ -94,7 +94,7 @@
       function fromXml() {
         var input = document.getElementById('importExport');
         var xml = Blockly.Xml.textToDom(input.value);
-        Blockly.Xml.domToWorkspace(workspace, xml);
+        Blockly.Xml.domToWorkspace(xml, workspace);
         taChange();
       }
 

--- a/tests/vertical_playground.html
+++ b/tests/vertical_playground.html
@@ -49,7 +49,7 @@
           zoom: {
             controls: true,
             wheel: true,
-            startScale: 1.0,
+            startScale: 0.75,
             maxScale: 4,
             minScale: 0.25,
             scaleSpeed: 1.1


### PR DESCRIPTION
Before:
<img width="298" alt="before" src="https://cloud.githubusercontent.com/assets/120403/15591136/4eb6b378-2369-11e6-9187-916257737717.png">
After:
<img width="254" alt="screen shot 2016-05-26 at 5 41 06 pm" src="https://cloud.githubusercontent.com/assets/120403/15591141/524dd5e8-2369-11e6-820e-2c558d0b6b0e.png">

This has many changes - probably some things that can be better documented/improved too. I may push a few more commits to clean up some of the messiest areas.

In addition to getting the shapes a lot closer to spec, there is an attempt inside to vertically center all fields within their row. I think it works but haven't tested it extensively.

I've also removed a bunch of old code (e.g., for external inputs, the "puzzle piece" output tab, turning on/off hats, lots of old hard-coded constants).

Things that are clearly broken:
-Reporters/outputs are still very undone.
-In doing this, I decided to not include the notches in the calculated heights of the blocks (just like we did in horizontal) to help with the cases where the notch overlaps the next block. This has messed with the flyout positioning a bit but hopefully shouldn't be too hard to fix.
