### PR TITLE
Restore insertion marker fields; set them to display: none

### DIFF
--- a/core/block_render_svg_horizontal.js
+++ b/core/block_render_svg_horizontal.js
@@ -522,6 +522,10 @@ Blockly.BlockSvg.prototype.renderDraw_ = function(metrics) {
       }
     }
     if (imageField) {
+      // Fields are invisible on insertion marker.
+      if (this.isInsertionMarker()) {
+        imageField.setAttribute('display', 'none');
+      }
       imageField.setAttribute('transform',
           'translate(' + imageFieldX + ',' + imageFieldY + ') ' +
           imageFieldScale);

--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -399,6 +399,10 @@ Blockly.BlockSvg.prototype.renderFields_ =
             Blockly.BlockSvg.SEP_SPACE_X;
       }
     }
+    // Fields are invisible on insertion marker.
+    if (this.isInsertionMarker()) {
+      root.setAttribute('display', 'none');
+    }
   }
   return this.RTL ? -cursorX : cursorX;
 }; /* eslint-enable indent */

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -121,14 +121,12 @@ Blockly.BlockSvg.INLINE = -1;
  */
 Blockly.BlockSvg.prototype.initSvg = function() {
   goog.asserts.assert(this.workspace.rendered, 'Workspace is headless.');
-  if (!this.isInsertionMarker()) { // Insertion markers not allowed to have inputs or icons
-    for (var i = 0, input; input = this.inputList[i]; i++) {
-      input.init();
-    }
-    var icons = this.getIcons();
-    for (i = 0; i < icons.length; i++) {
-      icons[i].createIcon();
-    }
+  for (var i = 0, input; input = this.inputList[i]; i++) {
+    input.init();
+  }
+  var icons = this.getIcons();
+  for (i = 0; i < icons.length; i++) {
+    icons[i].createIcon();
   }
   this.updateColour();
   this.updateMovable();


### PR DESCRIPTION
Here is a strawman fix for #250. It reverts #215 and extends the old methodology to vertical blocks.

Basically, the fields are "actually" rendered and then hidden. After thinking about it, I'm pretty sure there's no way around this unless we grab dimensions from the block generating the insertion marker. If you wanted to try implementing that instead, we could do it...
