### PR TITLE
Initial pass of vertical reporter rendering

### DIFF
--- a/blocks/logic.js
+++ b/blocks/logic.js
@@ -58,7 +58,7 @@ Blockly.Blocks['logic_equals'] = {
         }
       ],
       "inputsInline": true,
-      "output": null,
+      "output": "Boolean",
       "colour": Blockly.Colours.operators.primary,
       "colourSecondary": Blockly.Colours.operators.secondary,
       "colourTertiary": Blockly.Colours.operators.tertiary

--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -666,7 +666,16 @@ Blockly.BlockSvg.prototype.renderDrawRight_ = function(steps,
           } else {
             connectionX = connectionsXY.x + cursorX;
           }
-          connectionY = connectionsXY.y + cursorY;
+          // Attempt to center the connection vertically.
+          var connectionYOffset = input.renderHeight / 2;
+          // Read the block which is connected to subtract half its height.
+          if (input.connection.targetConnection) {
+            var sourceBlock = input.connection.targetConnection.getSourceBlock();
+            if (sourceBlock.rendered) {
+              connectionYOffset -= sourceBlock.getHeightWidth().height / 2;
+            }
+          }
+          connectionY = connectionsXY.y + cursorY + connectionYOffset;
           input.connection.moveTo(connectionX, connectionY);
           if (input.connection.isConnected()) {
             input.connection.tighten_();

--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -619,8 +619,6 @@ Blockly.BlockSvg.prototype.renderDraw_ = function(iconWidth, inputRows) {
       this.squareTopLeftCorner_ = true;
     }
   }
-  console.log(this.edgeShapeWidth_);
-
   // Fetch the block's coordinates on the surface for use in anchoring
   // the connections.
   var connectionsXY = this.getRelativeToSurfaceXY();

--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -810,11 +810,12 @@ Blockly.BlockSvg.prototype.renderDrawRight_ = function(steps,
     // Draw the right-side edge shape
     if (this.edgeShape_ === Blockly.Connection.NUMBER) {
       // Draw a rounded arc
-      steps.push('a ' + this.edgeShapeWidth_ + ' ' + this.edgeShapeWidth_ + ' 0 0 1 0 ' + this.edgeShapeWidth_*2);
+      steps.push('a ' + this.edgeShapeWidth_ + ' ' + this.edgeShapeWidth_ +
+          ' 0 0 1 0 ' + this.edgeShapeWidth_ * 2);
     } else if (this.edgeShape_ === Blockly.Connection.BOOLEAN) {
       // Draw an angle
       steps.push('l ' + this.edgeShapeWidth_ + ' ' + this.edgeShapeWidth_ +
-        ' l ' + -this.edgeShapeWidth_ + ' ' + this.edgeShapeWidth_);
+          ' l ' + -this.edgeShapeWidth_ + ' ' + this.edgeShapeWidth_);
     }
   }
   if (!inputRows.length) {

--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -73,6 +73,13 @@ Blockly.BlockSvg.EXTRA_STATEMENT_ROW_Y = 8 * Blockly.BlockSvg.GRID_UNIT;
 Blockly.BlockSvg.MIN_BLOCK_X_WITH_STATEMENT = 40 * Blockly.BlockSvg.GRID_UNIT;
 
 /**
+ * Minimum height of a block with output and a single field.
+ * This is used for shadow blocks that only contain a field - which are smaller than even reporters.
+ * @const
+ */
+Blockly.BlockSvg.MIN_BLOCK_Y_SINGLE_FIELD_OUTPUT = 8 * Blockly.BlockSvg.GRID_UNIT;
+
+/**
  * Minimum space for a statement input height.
  * @const
  */
@@ -451,8 +458,11 @@ Blockly.BlockSvg.prototype.renderCompute_ = function(iconWidth) {
     }
     row.push(input);
 
-    // Compute minimum input size.
-    if (row.type == Blockly.NEXT_STATEMENT) {
+    // Compute minimum height for this input.
+    if (inputList.length === 1 && this.outputConnection) {
+      // Special case: height of "lone" field blocks is smaller.
+      input.renderHeight = Blockly.BlockSvg.MIN_BLOCK_Y_SINGLE_FIELD_OUTPUT;
+    } else if (row.type == Blockly.NEXT_STATEMENT) {
       input.renderHeight = Blockly.BlockSvg.MIN_STATEMENT_INPUT_HEIGHT;
     } else if (previousRow && previousRow.type == Blockly.NEXT_STATEMENT) {
       input.renderHeight = Blockly.BlockSvg.EXTRA_STATEMENT_ROW_Y;

--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -491,7 +491,10 @@ Blockly.BlockSvg.prototype.renderCompute_ = function(iconWidth) {
     if (input.connection && input.connection.isConnected()) {
       var linkedBlock = input.connection.targetBlock();
       var bBox = linkedBlock.getHeightWidth();
-      var paddedHeight = bBox.height + 2 * Blockly.BlockSvg.INLINE_PADDING_Y;
+      var paddedHeight = bBox.height;
+      if (input.connection.type === Blockly.INPUT_VALUE) {
+        paddedHeight += 2 * Blockly.BlockSvg.INLINE_PADDING_Y;
+      }
       input.renderHeight = Math.max(input.renderHeight, paddedHeight);
       input.renderWidth = Math.max(input.renderWidth, bBox.width);
     }

--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -244,13 +244,13 @@ Blockly.BlockSvg.FIELD_HEIGHT = 8 * Blockly.BlockSvg.GRID_UNIT;
  * Width of user inputs
  * @const
  */
-Blockly.BlockSvg.FIELD_WIDTH = 12 * Blockly.BlockSvg.GRID_UNIT;
+Blockly.BlockSvg.FIELD_WIDTH = 8 * Blockly.BlockSvg.GRID_UNIT;
 
 /**
  * Minimum width of user inputs during editing
  * @const
  */
-Blockly.BlockSvg.FIELD_WIDTH_MIN_EDIT = 13 * Blockly.BlockSvg.GRID_UNIT;
+Blockly.BlockSvg.FIELD_WIDTH_MIN_EDIT = 8 * Blockly.BlockSvg.GRID_UNIT;
 
 /**
  * Maximum width of user inputs during editing

--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -262,13 +262,31 @@ Blockly.BlockSvg.FIELD_WIDTH_MAX_EDIT = Infinity;
  * Maximum height of user inputs during editing
  * @const
  */
-Blockly.BlockSvg.FIELD_HEIGHT_MAX_EDIT = Blockly.BlockSvg.FIELD_WIDTH;
+Blockly.BlockSvg.FIELD_HEIGHT_MAX_EDIT = Blockly.BlockSvg.FIELD_HEIGHT;
 
 /**
  * Top padding of user inputs
  * @const
  */
 Blockly.BlockSvg.FIELD_TOP_PADDING = 0;
+
+/**
+ * Corner radius of number inputs
+ * @const
+ */
+Blockly.BlockSvg.NUMBER_FIELD_CORNER_RADIUS = 4 * Blockly.BlockSvg.GRID_UNIT;
+
+/**
+ * Corner radius of text inputs
+ * @const
+ */
+Blockly.BlockSvg.TEXT_FIELD_CORNER_RADIUS = 1 * Blockly.BlockSvg.GRID_UNIT;
+
+/**
+ * Default radius for a field, in px.
+ * @const
+ */
+Blockly.BlockSvg.FIELD_DEFAULT_CORNER_RADIUS = 4 * Blockly.BlockSvg.GRID_UNIT;
 
 /**
  * Max text display length for a field (per-horizontal/vertical)

--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -268,7 +268,7 @@ Blockly.BlockSvg.FIELD_HEIGHT_MAX_EDIT = Blockly.BlockSvg.FIELD_HEIGHT;
  * Top padding of user inputs
  * @const
  */
-Blockly.BlockSvg.FIELD_TOP_PADDING = 0;
+Blockly.BlockSvg.FIELD_TOP_PADDING = 1.5 * Blockly.BlockSvg.GRID_UNIT;
 
 /**
  * Corner radius of number inputs

--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -797,8 +797,8 @@ Blockly.BlockSvg.prototype.renderDrawRight_ = function(steps,
       steps.push('a ' + this.edgeShapeWidth_ + ' ' + this.edgeShapeWidth_ + ' 0 0 1 0 ' + this.edgeShapeWidth_*2);
     } else if (this.edgeShape_ === Blockly.Connection.BOOLEAN) {
       // Draw an angle
-      // @todo
-      console.log("draw an angle");
+      steps.push('l ' + this.edgeShapeWidth_ + ' ' + this.edgeShapeWidth_ +
+        ' l ' + -this.edgeShapeWidth_ + ' ' + this.edgeShapeWidth_);
     }
   }
   if (!inputRows.length) {
@@ -873,8 +873,8 @@ Blockly.BlockSvg.prototype.renderDrawLeft_ = function(steps, connectionsXY) {
       steps.push('a ' + this.edgeShapeWidth_ + ' ' + this.edgeShapeWidth_ + ' 0 0 1 0 -' + this.edgeShapeWidth_*2);
     } else if (this.edgeShape_ === Blockly.Connection.BOOLEAN) {
       // Draw an angle
-      // @todo
-      console.log("draw an angle");
+      steps.push('l ' + -this.edgeShapeWidth_ + ' ' + -this.edgeShapeWidth_ +
+        ' l ' + this.edgeShapeWidth_ + ' ' + -this.edgeShapeWidth_);
     }
   }
   steps.push('z');

--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -669,7 +669,7 @@ Blockly.BlockSvg.prototype.renderDrawRight_ = function(steps,
         // Moves the field to half of the row's height.
         // In renderFields_, the field is further centered
         // by its own rendered height.
-        fieldY += input.renderHeight / 2;
+        fieldY += row.height / 2;
         // TODO: Align inline field rows (left/right/centre).
         cursorX = this.renderFields_(input.fieldRow, fieldX, fieldY);
         if (input.type == Blockly.INPUT_VALUE) {
@@ -684,7 +684,7 @@ Blockly.BlockSvg.prototype.renderDrawRight_ = function(steps,
             connectionX = connectionsXY.x + cursorX;
           }
           // Attempt to center the connection vertically.
-          var connectionYOffset = input.renderHeight / 2;
+          var connectionYOffset = row.height / 2;
           // Read the block which is connected to subtract half its height.
           if (input.connection.targetConnection) {
             var sourceBlock = input.connection.targetConnection.getSourceBlock();

--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -55,6 +55,12 @@ Blockly.BlockSvg.SEP_SPACE_Y = 2 * Blockly.BlockSvg.GRID_UNIT;
 Blockly.BlockSvg.MIN_BLOCK_X = 24 * Blockly.BlockSvg.GRID_UNIT;
 
 /**
+ * Minimum width of a block with output (reporters, single fields).
+ * @const
+ */
+Blockly.BlockSvg.MIN_BLOCK_X_OUTPUT = 12 * Blockly.BlockSvg.GRID_UNIT;
+
+/**
  * Minimum height of a block.
  * @const
  */
@@ -527,6 +533,10 @@ Blockly.BlockSvg.prototype.renderCompute_ = function(iconWidth) {
     // Blocks with notches
     inputRows.rightEdge = Math.max(inputRows.rightEdge,
       Blockly.BlockSvg.MIN_BLOCK_X);
+  } else if (this.outputConnection) {
+    // Single-fields and reporters
+    inputRows.rightEdge = Math.max(inputRows.rightEdge,
+      Blockly.BlockSvg.MIN_BLOCK_X_OUTPUT);
   }
   if (hasStatement) {
     // Statement blocks (C- or E- shaped) have a longer minimum width.

--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -284,6 +284,12 @@ Blockly.BlockSvg.MAX_DISPLAY_LENGTH = Infinity;
 Blockly.BlockSvg.NO_PREVIOUS_INPUT_X_MIN = 12 * Blockly.BlockSvg.GRID_UNIT;
 
 /**
+ * Vertical padding around inline elements.
+ * @const
+ */
+Blockly.BlockSvg.INLINE_PADDING_Y = 1 * Blockly.BlockSvg.GRID_UNIT;
+
+/**
  * Change the colour of a block.
  */
 Blockly.BlockSvg.prototype.updateColour = function() {
@@ -485,7 +491,8 @@ Blockly.BlockSvg.prototype.renderCompute_ = function(iconWidth) {
     if (input.connection && input.connection.isConnected()) {
       var linkedBlock = input.connection.targetBlock();
       var bBox = linkedBlock.getHeightWidth();
-      input.renderHeight = Math.max(input.renderHeight, bBox.height);
+      var paddedHeight = bBox.height + 2 * Blockly.BlockSvg.INLINE_PADDING_Y;
+      input.renderHeight = Math.max(input.renderHeight, paddedHeight);
       input.renderWidth = Math.max(input.renderWidth, bBox.width);
     }
     row.height = Math.max(row.height, input.renderHeight);

--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -680,6 +680,7 @@ Blockly.BlockSvg.prototype.renderDrawRight_ = function(steps,
           if (input.connection.isConnected()) {
             input.connection.tighten_();
           }
+          cursorX += input.renderWidth + Blockly.BlockSvg.SEP_SPACE_X;
         }
       }
       // Update right edge for all inputs, such that all rows

--- a/core/field.js
+++ b/core/field.js
@@ -143,12 +143,13 @@ Blockly.Field.prototype.init = function() {
     this.fieldGroup_.style.display = 'none';
   }
   // Adjust X to be flipped for RTL. Position is relative to horizontal start of source block.
-  var fieldX = (this.sourceBlock_.RTL) ? -this.size_.width / 2 : this.size_.width / 2;
+  var size = this.getSize();
+  var fieldX = (this.sourceBlock_.RTL) ? -size.width / 2 : size.width / 2;
   /** @type {!Element} */
   this.textElement_ = Blockly.createSvgElement('text',
       {'class': 'blocklyText',
        'x': fieldX,
-       'y': this.size_.height / 2 + Blockly.BlockSvg.FIELD_TOP_PADDING,
+       'y': size.height / 2 + Blockly.BlockSvg.FIELD_TOP_PADDING,
        'text-anchor': 'middle'},
       this.fieldGroup_);
 


### PR DESCRIPTION
Before:
<img width="306" alt="screen shot 2016-06-06 at 5 55 21 pm" src="https://cloud.githubusercontent.com/assets/120403/15839181/01cf2cd4-2c10-11e6-9580-99f2b589e1cf.png">

After:
<img width="297" alt="screen shot 2016-06-06 at 5 55 38 pm" src="https://cloud.githubusercontent.com/assets/120403/15839195/0ea3203c-2c10-11e6-9df8-5205b0bbf90e.png">

This is for rendering the blocks, not the fields. Editing the actually fields still makes crazy things happen.
The general method is:
- Determine the shape of the sides by checking the output type.
- Determine the size of that shape by measuring the height of the block (edgeShapeWidth_)
- Skip edgeShapeWidth_ pixels when rendering the top and bottom; render the specialized shape instead.

Also fixes vertical rendering of fields/connections by using `row.height` instead of something wrong...

Still to do:
- Adding extra (dynamic?) padding for the boolean shape.
- Actual implementation of the field editors to match.
