### PR TITLE
Remove reference to undefined variable

### DIFF
--- a/core/blockly.js
+++ b/core/blockly.js
@@ -565,4 +565,3 @@ if (!goog.global['Blockly']) {
   goog.global['Blockly'] = {};
 }
 goog.global['Blockly']['getMainWorkspace'] = Blockly.getMainWorkspace;
-goog.global['Blockly']['addChangeListener'] = Blockly.addChangeListener;


### PR DESCRIPTION
Introduced by removal of deprecated code in c42f554.
