### PR TITLE
Use bindEvent_ for dropdown buttons

### DIFF
--- a/core/field_iconmenu.js
+++ b/core/field_iconmenu.js
@@ -203,23 +203,23 @@ Blockly.FieldIconMenu.prototype.showEditor_ = function() {
     }
     button.style.backgroundColor = backgroundColor;
     button.style.borderColor = this.sourceBlock_.getColourTertiary();
-    button.onclick = this.buttonClick_.bind(this);
-    button.ontouchend = this.buttonClick_.bind(this);
+    Blockly.bindEvent_(button, 'click', this, this.buttonClick_);
+    Blockly.bindEvent_(button, 'mouseup', this, this.buttonClick_);
     // These are applied manually instead of using the :hover pseudoclass
     // because Android has a bad long press "helper" menu and green highlight
     // that we must prevent with ontouchstart preventDefault
-    button.ontouchstart = function(e) {
+    Blockly.bindEvent_(button, 'mousedown', button, function(e) {
       this.setAttribute('class', 'blocklyDropDownButton blocklyDropDownButtonHover');
       e.preventDefault();
-    };
-    button.onmouseover = function() {
+    });
+    Blockly.bindEvent_(button, 'mouseover', button, function() {
       this.setAttribute('class', 'blocklyDropDownButton blocklyDropDownButtonHover');
       contentDiv.setAttribute('aria-activedescendant', this.id);
-    };
-    button.onmouseout = function() {
+    });
+    Blockly.bindEvent_(button, 'mouseout', button, function() {
       this.setAttribute('class', 'blocklyDropDownButton');
       contentDiv.removeAttribute('aria-activedescendant');
-    };
+    });
     var buttonImg = document.createElement('img');
     buttonImg.src = icon.src;
     //buttonImg.alt = icon.alt;

--- a/core/field_number.js
+++ b/core/field_number.js
@@ -168,8 +168,8 @@ Blockly.FieldNumber.prototype.showNumPad_ = function() {
     button.setAttribute('class', 'blocklyNumPadButton');
     button.title = buttonText;
     button.innerHTML = buttonText;
-    // Num-pad only reacts on touch devices
-    button.ontouchstart = Blockly.FieldNumber.numPadButtonTouch_;
+    Blockly.bindEvent_(button, 'mousedown', button,
+	Blockly.FieldNumber.numPadButtonTouch_);
     if (buttonText == '.' && this.precision_ == 0) {
       // Don't show the decimal point for inputs that must be round numbers
       button.setAttribute('style', 'visibility: hidden');
@@ -184,8 +184,8 @@ Blockly.FieldNumber.prototype.showNumPad_ = function() {
   var eraseImage = document.createElement('img');
   eraseImage.src = Blockly.FieldNumber.NUMPAD_DELETE_ICON;
   eraseButton.appendChild(eraseImage);
-  // Num-pad only reacts on touch devices
-  eraseButton.ontouchstart = Blockly.FieldNumber.numPadEraseButtonTouch_;
+  Blockly.bindEvent_(eraseButton, 'mousedown', null,
+      Blockly.FieldNumber.numPadEraseButtonTouch_);
   contentDiv.appendChild(eraseButton);
 
   // Set colour and size of drop-down


### PR DESCRIPTION
This matches the style of the rest of Blockly, and means that the
dropdowns can be tested with Chrome's Device Mode, which was not
possible before due to this bug:
https://bugs.chromium.org/p/chromium/issues/detail?id=133915

This also adds listeners for mousedown/mouseup - this should be better
on PCs with touchscreens (#305), although we'll need a further change to
open the numpad on touch events.
