### PR TITLE
Horizontal field alignment for inline rows (#375)

### DIFF
--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -716,7 +716,18 @@ Blockly.BlockSvg.prototype.renderDrawRight_ = function(steps,
         // In renderFields_, the field is further centered
         // by its own rendered height.
         fieldY += row.height / 2;
-        // TODO: Align inline field rows (left/right/centre).
+
+        // Align inline field rows (left/right/centre).
+        if (input.align != Blockly.ALIGN_LEFT) {
+          var fieldRightX = inputRows.rightEdge - input.fieldWidth -
+              (2 * Blockly.BlockSvg.SEP_SPACE_X);
+          if (input.align == Blockly.ALIGN_RIGHT) {
+            fieldX += fieldRightX;
+          } else if (input.align == Blockly.ALIGN_CENTRE) {
+            fieldX += fieldRightX / 2;
+          }
+        }
+
         cursorX = this.renderFields_(input.fieldRow, fieldX, fieldY);
         if (input.type == Blockly.INPUT_VALUE) {
           // Create inline input connection.


### PR DESCRIPTION
Almost a direct copy of https://github.com/google/blockly/blob/04d6d119c076a42fb5777bb3f272d8256f2de499/core/block_render_svg.js#L751 minus subtracting TAB_WIDTH.

Before (LEFT_ALIGN):
<img width="136" alt="screen shot 2016-06-10 at 1 09 27 pm" src="https://cloud.githubusercontent.com/assets/120403/15972590/65310054-2f0d-11e6-87ee-89b6507cee47.png">

CENTRE_ALIGN:
<img width="314" alt="screen shot 2016-06-10 at 1 08 37 pm" src="https://cloud.githubusercontent.com/assets/120403/15972595/70670518-2f0d-11e6-9070-2595786bbe3e.png">

After RIGHT_ALIGN:
<img width="204" alt="screen shot 2016-06-10 at 1 08 54 pm" src="https://cloud.githubusercontent.com/assets/120403/15972597/77d547ba-2f0d-11e6-8d87-3052fc25646f.png">
