### PR TITLE
Draw empty "input shapes" for non-connected value inputs

### DIFF
--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -951,7 +951,8 @@ Blockly.BlockSvg.prototype.renderDrawRight_ = function(steps,
 Blockly.BlockSvg.prototype.renderInputShape_ = function(input, x, y) {
   var inputShape = this.inputShapes_[input.name];
   var inputShapeWidth = 0;
-  if (!input.connection.targetConnection) {
+  // Input shapes are only visibly rendered on non-connected non-insertion-markers.
+  if (!input.connection.targetConnection && !this.isInsertionMarker()) {
     var inputShapeX = 0, inputShapeY = 0;
     // If the input connection is not connected, draw a "hole" shape.
     var inputShapePath = null;
@@ -980,10 +981,7 @@ Blockly.BlockSvg.prototype.renderInputShape_ = function(input, x, y) {
     inputShape.setAttribute('transform',
       'translate(' + inputShapeX + ',' + inputShapeY + ')'
     );
-    // Input shapes are only visibly rendered on non-insertion-markers.
-    if (!this.isInsertionMarker()) {
-      inputShape.setAttribute('style', 'visibility: visible');
-    }
+    inputShape.setAttribute('style', 'visibility: visible');
   } else {
     inputShape.setAttribute('style', 'visibility: hidden');
   }

--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -946,13 +946,15 @@ Blockly.BlockSvg.prototype.renderDrawRight_ = function(steps,
  * @param {!Blockly.Input} input Input to be rendered.
  * @param {Number} x X offset of input.
  * @param {Number} y Y offset of input.
- * @return {Number} Amount cursor should be offset (depending on width of render)
+ * @return {Number} Width of rendered input shape, or 0 if not rendered.
  */
 Blockly.BlockSvg.prototype.renderInputShape_ = function(input, x, y) {
   var inputShape = this.inputShapes_[input.name];
   var inputShapeWidth = 0;
   // Input shapes are only visibly rendered on non-connected non-insertion-markers.
-  if (!input.connection.targetConnection && !this.isInsertionMarker()) {
+  if (this.isInsertionMarker() || input.connection.targetConnection) {
+    inputShape.setAttribute('style', 'visibility: hidden');
+  } else {
     var inputShapeX = 0, inputShapeY = 0;
     // If the input connection is not connected, draw a "hole" shape.
     var inputShapePath = null;
@@ -982,8 +984,6 @@ Blockly.BlockSvg.prototype.renderInputShape_ = function(input, x, y) {
       'translate(' + inputShapeX + ',' + inputShapeY + ')'
     );
     inputShape.setAttribute('style', 'visibility: visible');
-  } else {
-    inputShape.setAttribute('style', 'visibility: hidden');
   }
   return inputShapeWidth;
 };

--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -235,6 +235,74 @@ Blockly.BlockSvg.INNER_BOTTOM_LEFT_CORNER =
     Blockly.BlockSvg.CORNER_RADIUS;
 
 /**
+ * SVG path for an 'empty' boolean input shape slot.
+ * @const
+ */
+Blockly.BlockSvg.INPUT_SHAPE_BOOLEAN =
+    'M ' + 4 * Blockly.BlockSvg.GRID_UNIT + ',0 ' +
+    ' h ' + 4 * Blockly.BlockSvg.GRID_UNIT +
+    ' l ' + 4 * Blockly.BlockSvg.GRID_UNIT + ',' + 4 * Blockly.BlockSvg.GRID_UNIT +
+    ' l ' + -4 * Blockly.BlockSvg.GRID_UNIT + ',' + 4 * Blockly.BlockSvg.GRID_UNIT +
+    ' h ' + -4 * Blockly.BlockSvg.GRID_UNIT +
+    ' l ' + -4 * Blockly.BlockSvg.GRID_UNIT + ',' + -4 * Blockly.BlockSvg.GRID_UNIT +
+    ' l ' + 4 * Blockly.BlockSvg.GRID_UNIT + ',' + -4 * Blockly.BlockSvg.GRID_UNIT +
+    ' z';
+
+/**
+ * Width of 'empty' boolean input shape slot.
+ * @const
+ */
+Blockly.BlockSvg.INPUT_SHAPE_BOOLEAN_WIDTH = 10 * Blockly.BlockSvg.GRID_UNIT;
+
+/**
+ * SVG path for an 'empty' string input shape slot.
+ * @const
+ */
+Blockly.BlockSvg.INPUT_SHAPE_STRING =
+    Blockly.BlockSvg.TOP_LEFT_CORNER_START +
+    Blockly.BlockSvg.TOP_LEFT_CORNER +
+    ' h ' + (12 * Blockly.BlockSvg.GRID_UNIT - 2 * Blockly.BlockSvg.CORNER_RADIUS) +
+    Blockly.BlockSvg.TOP_RIGHT_CORNER +
+    ' v ' + (8 * Blockly.BlockSvg.GRID_UNIT - 2 * Blockly.BlockSvg.CORNER_RADIUS) +
+    Blockly.BlockSvg.BOTTOM_RIGHT_CORNER +
+    ' h ' + (-12 * Blockly.BlockSvg.GRID_UNIT + 2 * Blockly.BlockSvg.CORNER_RADIUS) +
+    Blockly.BlockSvg.BOTTOM_LEFT_CORNER +
+    ' z';
+
+/**
+ * Width of 'empty' string input shape slot.
+ * @const
+ */
+Blockly.BlockSvg.INPUT_SHAPE_STRING_WIDTH = 9 * Blockly.BlockSvg.GRID_UNIT;
+
+/**
+ * SVG path for an 'empty' string input shape slot.
+ * @const
+ */
+
+Blockly.BlockSvg.INPUT_SHAPE_NUMBER =
+  'M ' + (4 * Blockly.BlockSvg.GRID_UNIT) + ',0' +
+  ' h ' + (4 * Blockly.BlockSvg.GRID_UNIT) +
+  ' a ' + (4 * Blockly.BlockSvg.GRID_UNIT) + ' ' +
+      (4 * Blockly.BlockSvg.GRID_UNIT) + ' 0 0 1 0 ' + (8 * Blockly.BlockSvg.GRID_UNIT) +
+  ' h ' + (-4 * Blockly.BlockSvg.GRID_UNIT) +
+  ' a ' + (4 * Blockly.BlockSvg.GRID_UNIT) + ' ' +
+      (4 * Blockly.BlockSvg.GRID_UNIT) + ' 0 0 1 0 -' + (8 * Blockly.BlockSvg.GRID_UNIT) +
+  ' z';
+
+/**
+ * Width of 'empty' string input shape slot.
+ * @const
+ */
+Blockly.BlockSvg.INPUT_SHAPE_NUMBER_WIDTH = 10 * Blockly.BlockSvg.GRID_UNIT;
+
+/**
+ * Height of 'empty' input shape slots.
+ * @const
+ */
+Blockly.BlockSvg.INPUT_SHAPE_HEIGHT = 8 * Blockly.BlockSvg.GRID_UNIT;
+
+/**
  * Height of user inputs
  * @const
  */
@@ -326,6 +394,11 @@ Blockly.BlockSvg.prototype.updateColour = function() {
 
   // Render opacity
   this.svgPath_.setAttribute('fill-opacity', this.getOpacity());
+
+  // Update colours of input shapes.
+  for (var shape in this.inputShapes_) {
+    this.inputShapes_[shape].setAttribute('fill', this.getColourTertiary());
+  }
 
   // Render icon(s) if applicable
   var icons = this.getIcons();
@@ -519,11 +592,20 @@ Blockly.BlockSvg.prototype.renderCompute_ = function(iconWidth) {
       }
     }
 
-    // Expand input size if there is a connection.
-    if (input.connection && input.connection.isConnected()) {
+    // Expand input size.
+    if (input.connection) {
       var linkedBlock = input.connection.targetBlock();
-      var bBox = linkedBlock.getHeightWidth();
-      var paddedHeight = bBox.height;
+      var paddedHeight = 0;
+      var paddedWidth = 0;
+      if (linkedBlock) {
+        // A block is connected to the input - use its size.
+        var bBox = linkedBlock.getHeightWidth();
+        paddedHeight = bBox.height;
+        paddedWidth = bBox.width;
+      } else {
+        // No block connected - use the size of "empty" shape.
+        paddedHeight = Blockly.BlockSvg.INPUT_SHAPE_HEIGHT;
+      }
       if (input.connection.type === Blockly.INPUT_VALUE) {
         paddedHeight += 2 * Blockly.BlockSvg.INLINE_PADDING_Y;
       }
@@ -534,7 +616,7 @@ Blockly.BlockSvg.prototype.renderCompute_ = function(iconWidth) {
         }
       }
       input.renderHeight = Math.max(input.renderHeight, paddedHeight);
-      input.renderWidth = Math.max(input.renderWidth, bBox.width);
+      input.renderWidth = Math.max(input.renderWidth, paddedWidth);
     }
     row.height = Math.max(row.height, input.renderHeight);
     input.fieldWidth = 0;
@@ -772,6 +854,7 @@ Blockly.BlockSvg.prototype.renderDrawRight_ = function(steps,
           if (input.connection.isConnected()) {
             input.connection.tighten_();
           }
+          cursorX += this.renderInputShape_(input, cursorX, cursorY + connectionYOffset);
           cursorX += input.renderWidth + Blockly.BlockSvg.SEP_SPACE_X;
         }
       }
@@ -854,6 +937,57 @@ Blockly.BlockSvg.prototype.renderDrawRight_ = function(steps,
     steps.push('V', cursorY);
   }
   return cursorY;
+};
+
+/**
+ * Render the shape for an input.
+ * If there's a connected block, hide the input shape.
+ * Otherwise, draw and set the position of the input shape.
+ * @param {!Blockly.Input} input Input to be rendered.
+ * @param {Number} x X offset of input.
+ * @param {Number} y Y offset of input.
+ * @return {Number} Amount cursor should be offset (depending on width of render)
+ */
+Blockly.BlockSvg.prototype.renderInputShape_ = function(input, x, y) {
+  var inputShape = this.inputShapes_[input.name];
+  var inputShapeWidth = 0;
+  if (!input.connection.targetConnection) {
+    var inputShapeX = 0, inputShapeY = 0;
+    // If the input connection is not connected, draw a "hole" shape.
+    var inputShapePath = null;
+    switch (input.connection.getOutputShape()) {
+      case Blockly.Connection.BOOLEAN:
+        inputShapePath = Blockly.BlockSvg.INPUT_SHAPE_BOOLEAN;
+        inputShapeWidth = Blockly.BlockSvg.INPUT_SHAPE_BOOLEAN_WIDTH;
+        break;
+      case Blockly.Connection.NUMBER:
+        inputShapePath = Blockly.BlockSvg.INPUT_SHAPE_NUMBER;
+        inputShapeWidth = Blockly.BlockSvg.INPUT_SHAPE_NUMBER_WIDTH;
+        break;
+      case Blockly.Connection.STRING:
+      default:
+        inputShapePath = Blockly.BlockSvg.INPUT_SHAPE_STRING;
+        inputShapeWidth = Blockly.BlockSvg.INPUT_SHAPE_STRING_WIDTH;
+        break;
+    }
+    if (this.RTL) {
+      inputShapeX = -x - inputShapeWidth - Blockly.BlockSvg.SEP_SPACE_X;
+    } else {
+      inputShapeX = x;
+    }
+    inputShapeY = y - (Blockly.BlockSvg.INPUT_SHAPE_HEIGHT / 2);
+    inputShape.setAttribute('d', inputShapePath);
+    inputShape.setAttribute('transform',
+      'translate(' + inputShapeX + ',' + inputShapeY + ')'
+    );
+    // Input shapes are only visibly rendered on non-insertion-markers.
+    if (!this.isInsertionMarker()) {
+      inputShape.setAttribute('style', 'visibility: visible');
+    }
+  } else {
+    inputShape.setAttribute('style', 'visibility: hidden');
+  }
+  return inputShapeWidth;
 };
 
 /**

--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -235,7 +235,7 @@ Blockly.BlockSvg.INNER_BOTTOM_LEFT_CORNER =
     Blockly.BlockSvg.CORNER_RADIUS;
 
 /**
- * SVG path for an 'empty' boolean input shape slot.
+ * SVG path for an empty boolean input shape.
  * @const
  */
 Blockly.BlockSvg.INPUT_SHAPE_BOOLEAN =
@@ -249,13 +249,13 @@ Blockly.BlockSvg.INPUT_SHAPE_BOOLEAN =
     ' z';
 
 /**
- * Width of 'empty' boolean input shape slot.
+ * Width of empty boolean input shape.
  * @const
  */
 Blockly.BlockSvg.INPUT_SHAPE_BOOLEAN_WIDTH = 10 * Blockly.BlockSvg.GRID_UNIT;
 
 /**
- * SVG path for an 'empty' string input shape slot.
+ * SVG path for an empty string input shape.
  * @const
  */
 Blockly.BlockSvg.INPUT_SHAPE_STRING =
@@ -270,13 +270,13 @@ Blockly.BlockSvg.INPUT_SHAPE_STRING =
     ' z';
 
 /**
- * Width of 'empty' string input shape slot.
+ * Width of empty string input shape.
  * @const
  */
 Blockly.BlockSvg.INPUT_SHAPE_STRING_WIDTH = 9 * Blockly.BlockSvg.GRID_UNIT;
 
 /**
- * SVG path for an 'empty' string input shape slot.
+ * SVG path for an empty string input shape.
  * @const
  */
 
@@ -291,13 +291,13 @@ Blockly.BlockSvg.INPUT_SHAPE_NUMBER =
   ' z';
 
 /**
- * Width of 'empty' string input shape slot.
+ * Width of empty string input shape.
  * @const
  */
 Blockly.BlockSvg.INPUT_SHAPE_NUMBER_WIDTH = 10 * Blockly.BlockSvg.GRID_UNIT;
 
 /**
- * Height of 'empty' input shape slots.
+ * Height of empty input shape.
  * @const
  */
 Blockly.BlockSvg.INPUT_SHAPE_HEIGHT = 8 * Blockly.BlockSvg.GRID_UNIT;
@@ -603,7 +603,7 @@ Blockly.BlockSvg.prototype.renderCompute_ = function(iconWidth) {
         paddedHeight = bBox.height;
         paddedWidth = bBox.width;
       } else {
-        // No block connected - use the size of "empty" shape.
+        // No block connected - use the size of the rendered empty input shape.
         paddedHeight = Blockly.BlockSvg.INPUT_SHAPE_HEIGHT;
       }
       if (input.connection.type === Blockly.INPUT_VALUE) {
@@ -940,7 +940,7 @@ Blockly.BlockSvg.prototype.renderDrawRight_ = function(steps,
 };
 
 /**
- * Render the shape for an input.
+ * Render the input shapes.
  * If there's a connected block, hide the input shape.
  * Otherwise, draw and set the position of the input shape.
  * @param {!Blockly.Input} input Input to be rendered.
@@ -956,7 +956,7 @@ Blockly.BlockSvg.prototype.renderInputShape_ = function(input, x, y) {
     inputShape.setAttribute('style', 'visibility: hidden');
   } else {
     var inputShapeX = 0, inputShapeY = 0;
-    // If the input connection is not connected, draw a "hole" shape.
+    // If the input connection is not connected, draw a hole shape.
     var inputShapePath = null;
     switch (input.connection.getOutputShape()) {
       case Blockly.Connection.BOOLEAN:

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -121,8 +121,13 @@ Blockly.BlockSvg.INLINE = -1;
  */
 Blockly.BlockSvg.prototype.initSvg = function() {
   goog.asserts.assert(this.workspace.rendered, 'Workspace is headless.');
+  // "Input shapes" for each input. Used to draw "holes" for unoccupied value inputs.
+  this.inputShapes_ = {};
   for (var i = 0, input; input = this.inputList[i]; i++) {
     input.init();
+    if (input.type === Blockly.INPUT_VALUE) {
+      this.initInputShape(input);
+    }
   }
   var icons = this.getIcons();
   for (i = 0; i < icons.length; i++) {
@@ -142,6 +147,21 @@ Blockly.BlockSvg.prototype.initSvg = function() {
   if (!this.getSvgRoot().parentNode) {
     this.workspace.getCanvas().appendChild(this.getSvgRoot());
   }
+};
+
+/**
+ * Create and initialize the SVG element for an input shape hole.
+ * @param {!Blockly.Input} input Value input to add a shape for.
+ */
+Blockly.BlockSvg.prototype.initInputShape = function(input) {
+  this.inputShapes_[input.name] = Blockly.createSvgElement(
+    'path',
+    {
+      'class': 'blocklyPath',
+      'style': 'visibility: hidden' // Hide by default - shown when not connected.
+    },
+    this.svgGroup_
+  );
 };
 
 /**

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -121,7 +121,7 @@ Blockly.BlockSvg.INLINE = -1;
  */
 Blockly.BlockSvg.prototype.initSvg = function() {
   goog.asserts.assert(this.workspace.rendered, 'Workspace is headless.');
-  // "Input shapes" for each input. Used to draw "holes" for unoccupied value inputs.
+  // Input shapes are empty holes drawn when a value input is not connected.
   this.inputShapes_ = {};
   for (var i = 0, input; input = this.inputList[i]; i++) {
     input.init();
@@ -150,8 +150,8 @@ Blockly.BlockSvg.prototype.initSvg = function() {
 };
 
 /**
- * Create and initialize the SVG element for an input shape hole.
- * @param {!Blockly.Input} input Value input to add a shape for.
+ * Create and initialize the SVG element for an input shape.
+ * @param {!Blockly.Input} input Value input to add a shape SVG element for.
  */
 Blockly.BlockSvg.prototype.initInputShape = function(input) {
   this.inputShapes_[input.name] = Blockly.createSvgElement(


### PR DESCRIPTION
Previously, nothing was drawn in this case. Now it will look like this:
<img width="366" alt="screen shot 2016-06-13 at 5 38 28 pm" src="https://cloud.githubusercontent.com/assets/120403/16024451/f3a65936-318f-11e6-81a5-ddea6153af05.png">

RTL:
<img width="339" alt="screen shot 2016-06-13 at 5 55 17 pm" src="https://cloud.githubusercontent.com/assets/120403/16024459/031bbf00-3190-11e6-8d86-05cc000ab2e1.png">

Not 100% sure that the sizing and positioning is perfect, but I think that's something we can adjust.

Fixes #377. Decided to go for adding the extra shape SVG paths as it's more general, flexible, and closer to Blockly.
