### PR TITLE
Properly center text in fields based on calculated width

### DIFF
--- a/core/field.js
+++ b/core/field.js
@@ -267,6 +267,16 @@ Blockly.Field.prototype.render_ = function() {
         Blockly.Field.cacheWidths_[key] = width;
       }
     }
+    // Update text centering, based on newly calculated width.
+    var centerTextX = width / 2;
+    // In a text-editing shadow block's field,
+    // if half the text length is not at least center of
+    // visible field (FIELD_WIDTH), center it there instead.
+    if (this.sourceBlock_.isShadow()) {
+      centerTextX = Math.max(centerTextX, Blockly.BlockSvg.FIELD_WIDTH / 2);
+    }
+    this.textElement_.setAttribute('x', centerTextX);
+
   } else {
     var width = 0;
   }

--- a/core/field.js
+++ b/core/field.js
@@ -273,10 +273,17 @@ Blockly.Field.prototype.render_ = function() {
     // if half the text length is not at least center of
     // visible field (FIELD_WIDTH), center it there instead.
     if (this.sourceBlock_.isShadow()) {
+      var minOffset = Blockly.BlockSvg.FIELD_WIDTH / 2;
       if (this.sourceBlock_.RTL) {
-        centerTextX = Math.min(centerTextX, width - (Blockly.BlockSvg.FIELD_WIDTH / 2));
+        // X position starts at the left edge of the block, in both RTL and LTR.
+        // First offset by the width of the block to move to the right edge,
+        // and then subtract to move to the same position as LTR.
+        var minCenter = width - minOffset;
+        centerTextX = Math.min(minCenter, centerTextX);
       } else {
-        centerTextX = Math.max(centerTextX, Blockly.BlockSvg.FIELD_WIDTH / 2);
+        // (width / 2) should exceed Blockly.BlockSvg.FIELD_WIDTH / 2
+        // if the text is longer.
+        centerTextX = Math.max(minOffset, centerTextX);
       }
     }
     this.textElement_.setAttribute('x', centerTextX);

--- a/core/field.js
+++ b/core/field.js
@@ -273,7 +273,11 @@ Blockly.Field.prototype.render_ = function() {
     // if half the text length is not at least center of
     // visible field (FIELD_WIDTH), center it there instead.
     if (this.sourceBlock_.isShadow()) {
-      centerTextX = Math.max(centerTextX, Blockly.BlockSvg.FIELD_WIDTH / 2);
+      if (this.sourceBlock_.RTL) {
+        centerTextX = Math.min(centerTextX, width - (Blockly.BlockSvg.FIELD_WIDTH / 2));
+      } else {
+        centerTextX = Math.max(centerTextX, Blockly.BlockSvg.FIELD_WIDTH / 2);
+      }
     }
     this.textElement_.setAttribute('x', centerTextX);
 

--- a/core/field_label.js
+++ b/core/field_label.js
@@ -61,7 +61,7 @@ Blockly.FieldLabel.prototype.init = function() {
   }
   // Build the DOM.
   this.textElement_ = Blockly.createSvgElement('text',
-      {'class': 'blocklyText', 'y': this.size_.height - 1}, null);
+      {'class': 'blocklyText', 'y': this.size_.height - 1, 'text-anchor': 'middle'}, null);
   if (this.class_) {
     Blockly.addClass_(this.textElement_, this.class_);
   }


### PR DESCRIPTION
Before:
<img width="279" alt="screen shot 2016-06-13 at 8 04 42 pm" src="https://cloud.githubusercontent.com/assets/120403/16027203/23ca79fa-31a2-11e6-94d5-5163aabb4c46.png">

After:
<img width="245" alt="screen shot 2016-06-13 at 8 04 53 pm" src="https://cloud.githubusercontent.com/assets/120403/16027206/298c192a-31a2-11e6-8d00-c4a1c17b3d16.png">
