### PR TITLE
Fix up vertical text field editor

### DIFF
--- a/core/block_render_svg_horizontal.js
+++ b/core/block_render_svg_horizontal.js
@@ -252,6 +252,18 @@ Blockly.BlockSvg.FONTSIZE_INITIAL = 12;
 Blockly.BlockSvg.FONTSIZE_FINAL = 14;
 
 /**
+ * Whether text fields are allowed to expand past their truncated block size.
+ * @const{boolean}
+ */
+Blockly.BlockSvg.FIELD_TEXTINPUT_EXPAND_PAST_TRUNCATION = true;
+
+/**
+ * Whether text fields should animate their positioning.
+ * @const{boolean}
+ */
+Blockly.BlockSvg.FIELD_TEXTINPUT_ANIMATE_POSITIONING = true;
+
+/**
  * @param {!Object} first An object containing computed measurements of a
  *    block.
  * @param {!Object} second Another object containing computed measurements of a

--- a/core/block_render_svg_horizontal.js
+++ b/core/block_render_svg_horizontal.js
@@ -240,6 +240,18 @@ Blockly.BlockSvg.renderingMetrics_ = null;
 Blockly.BlockSvg.MAX_DISPLAY_LENGTH = 4;
 
 /**
+ * Point size of text field before animation. Must match size in CSS.
+ * See implementation in field_textinput.
+ */
+Blockly.BlockSvg.FONTSIZE_INITIAL = 12;
+
+/**
+ * Point size of text field after animation.
+ * See implementation in field_textinput.
+ */
+Blockly.BlockSvg.FONTSIZE_FINAL = 14;
+
+/**
  * @param {!Object} first An object containing computed measurements of a
  *    block.
  * @param {!Object} second Another object containing computed measurements of a

--- a/core/block_render_svg_horizontal.js
+++ b/core/block_render_svg_horizontal.js
@@ -243,13 +243,13 @@ Blockly.BlockSvg.MAX_DISPLAY_LENGTH = 4;
  * Point size of text field before animation. Must match size in CSS.
  * See implementation in field_textinput.
  */
-Blockly.BlockSvg.FONTSIZE_INITIAL = 12;
+Blockly.BlockSvg.FIELD_TEXTINPUT_FONTSIZE_INITIAL = 12;
 
 /**
  * Point size of text field after animation.
  * See implementation in field_textinput.
  */
-Blockly.BlockSvg.FONTSIZE_FINAL = 14;
+Blockly.BlockSvg.FIELD_TEXTINPUT_FONTSIZE_FINAL = 14;
 
 /**
  * Whether text fields are allowed to expand past their truncated block size.

--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -388,6 +388,18 @@ Blockly.BlockSvg.FONTSIZE_INITIAL = 12;
 Blockly.BlockSvg.FONTSIZE_FINAL = 12;
 
 /**
+ * Whether text fields are allowed to expand past their truncated block size.
+ * @const{boolean}
+ */
+Blockly.BlockSvg.FIELD_TEXTINPUT_EXPAND_PAST_TRUNCATION = false;
+
+/**
+ * Whether text fields should animate their positioning.
+ * @const{boolean}
+ */
+Blockly.BlockSvg.FIELD_TEXTINPUT_ANIMATE_POSITIONING = false;
+
+/**
  * Change the colour of a block.
  */
 Blockly.BlockSvg.prototype.updateColour = function() {

--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -324,7 +324,7 @@ Blockly.BlockSvg.FIELD_WIDTH_MIN_EDIT = 8 * Blockly.BlockSvg.GRID_UNIT;
  * Maximum width of user inputs during editing
  * @const
  */
-Blockly.BlockSvg.FIELD_WIDTH_MAX_EDIT = 48 * Blockly.BlockSvg.GRID_UNIT;
+Blockly.BlockSvg.FIELD_WIDTH_MAX_EDIT = 52 * Blockly.BlockSvg.GRID_UNIT;
 
 /**
  * Maximum height of user inputs during editing

--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -379,13 +379,13 @@ Blockly.BlockSvg.INLINE_PADDING_Y = 2 * Blockly.BlockSvg.GRID_UNIT;
  * Point size of text field before animation. Must match size in CSS.
  * See implementation in field_textinput.
  */
-Blockly.BlockSvg.FONTSIZE_INITIAL = 12;
+Blockly.BlockSvg.FIELD_TEXTINPUT_FONTSIZE_INITIAL = 12;
 
 /**
  * Point size of text field after animation.
  * See implementation in field_textinput.
  */
-Blockly.BlockSvg.FONTSIZE_FINAL = 12;
+Blockly.BlockSvg.FIELD_TEXTINPUT_FONTSIZE_FINAL = 12;
 
 /**
  * Whether text fields are allowed to expand past their truncated block size.

--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -324,7 +324,7 @@ Blockly.BlockSvg.FIELD_WIDTH_MIN_EDIT = 8 * Blockly.BlockSvg.GRID_UNIT;
  * Maximum width of user inputs during editing
  * @const
  */
-Blockly.BlockSvg.FIELD_WIDTH_MAX_EDIT = Infinity;
+Blockly.BlockSvg.FIELD_WIDTH_MAX_EDIT = 48 * Blockly.BlockSvg.GRID_UNIT;
 
 /**
  * Maximum height of user inputs during editing

--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -376,6 +376,18 @@ Blockly.BlockSvg.NO_PREVIOUS_INPUT_X_MIN = 12 * Blockly.BlockSvg.GRID_UNIT;
 Blockly.BlockSvg.INLINE_PADDING_Y = 2 * Blockly.BlockSvg.GRID_UNIT;
 
 /**
+ * Point size of text field before animation. Must match size in CSS.
+ * See implementation in field_textinput.
+ */
+Blockly.BlockSvg.FONTSIZE_INITIAL = 12;
+
+/**
+ * Point size of text field after animation.
+ * See implementation in field_textinput.
+ */
+Blockly.BlockSvg.FONTSIZE_FINAL = 12;
+
+/**
  * Change the colour of a block.
  */
 Blockly.BlockSvg.prototype.updateColour = function() {

--- a/core/css.js
+++ b/core/css.js
@@ -449,7 +449,7 @@ Blockly.Css.CONTENT = [
     'margin: 0;',
     'outline: none;',
     'box-sizing: border-box;',
-    'padding: 2px 8px 0 8px;',
+    'padding: 2px 0 0 0;',
     'width: 100%;',
     'text-align: center;',
     'color: $colour_text;',

--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -302,7 +302,6 @@ Blockly.FieldTextInput.prototype.resizeEditor_ = function() {
     xy.y += 1 * scale;
   }
   if (goog.userAgent.WEBKIT) {
-    xy.x += 0;
     xy.y -= 1 * scale;
   }
   // Finally, set the actual style

--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -161,11 +161,14 @@ Blockly.FieldTextInput.prototype.showEditor_ = function(opt_quietInput, opt_read
   this.workspace_.addChangeListener(htmlInput.onWorkspaceChangeWrapper_);
 
   // Add animation transition properties
-  div.style.transition = 'padding ' + Blockly.FieldTextInput.ANIMATION_TIME + 's,' +
-    'width ' + Blockly.FieldTextInput.ANIMATION_TIME + 's,' +
-    'height ' + Blockly.FieldTextInput.ANIMATION_TIME + 's,' +
-    'margin-left ' + Blockly.FieldTextInput.ANIMATION_TIME + 's,' +
-    'box-shadow ' + Blockly.FieldTextInput.ANIMATION_TIME + 's';
+  var transitionProperties = 'box-shadow ' + Blockly.FieldTextInput.ANIMATION_TIME + 's';
+  if (Blockly.BlockSvg.FIELD_TEXTINPUT_ANIMATE_POSITIONING) {
+    div.style.transition += ',padding ' + Blockly.FieldTextInput.ANIMATION_TIME + 's,' +
+      'width ' + Blockly.FieldTextInput.ANIMATION_TIME + 's,' +
+      'height ' + Blockly.FieldTextInput.ANIMATION_TIME + 's,' +
+      'margin-left ' + Blockly.FieldTextInput.ANIMATION_TIME + 's';
+  }
+  div.style.transition = transitionProperties;
   htmlInput.style.transition = 'font-size ' + Blockly.FieldTextInput.ANIMATION_TIME + 's';
   // The animated properties themselves
   htmlInput.style.fontSize = Blockly.BlockSvg.FONTSIZE_FINAL + 'pt';
@@ -239,18 +242,26 @@ Blockly.FieldTextInput.prototype.validate_ = function() {
 Blockly.FieldTextInput.prototype.resizeEditor_ = function() {
   var scale = this.sourceBlock_.workspace.scale;
   var div = Blockly.WidgetDiv.DIV;
-  // Resize the box based on the measured width of the text, pre-truncation
-  var textWidth = Blockly.measureText(
-    Blockly.FieldTextInput.htmlInput_.style.fontSize,
-    Blockly.FieldTextInput.htmlInput_.style.fontFamily,
-    Blockly.FieldTextInput.htmlInput_.style.fontWeight,
-    Blockly.FieldTextInput.htmlInput_.value
-  );
-  // Size drawn in the canvas needs padding and scaling
-  textWidth += Blockly.FieldTextInput.TEXT_MEASURE_PADDING_MAGIC;
-  textWidth *= scale;
+
+  var width;
+  if (Blockly.BlockSvg.FIELD_TEXTINPUT_EXPAND_PAST_TRUNCATION) {
+    // Resize the box based on the measured width of the text, pre-truncation
+    var textWidth = Blockly.measureText(
+      Blockly.FieldTextInput.htmlInput_.style.fontSize,
+      Blockly.FieldTextInput.htmlInput_.style.fontFamily,
+      Blockly.FieldTextInput.htmlInput_.style.fontWeight,
+      Blockly.FieldTextInput.htmlInput_.value
+    );
+    // Size drawn in the canvas needs padding and scaling
+    textWidth += Blockly.FieldTextInput.TEXT_MEASURE_PADDING_MAGIC;
+    textWidth *= scale;
+    width = textWidth;
+  } else {
+    // Set width to (truncated) block size.
+    width = this.sourceBlock_.getHeightWidth().width * scale;
+  }
   // The width must be at least FIELD_WIDTH and at most FIELD_WIDTH_MAX_EDIT
-  var width = Math.max(textWidth, Blockly.BlockSvg.FIELD_WIDTH_MIN_EDIT * scale);
+  width = Math.max(width, Blockly.BlockSvg.FIELD_WIDTH_MIN_EDIT * scale);
   width = Math.min(width, Blockly.BlockSvg.FIELD_WIDTH_MAX_EDIT * scale);
   // Add 1px to width and height to account for border (pre-scale)
   div.style.width = (width / scale + 1) + 'px';
@@ -260,7 +271,8 @@ Blockly.FieldTextInput.prototype.resizeEditor_ = function() {
   // Use margin-left to animate repositioning of the box (value is unscaled).
   // This is the difference between the default position and the positioning
   // after growing the box.
-  var initialWidth = Blockly.BlockSvg.FIELD_WIDTH * scale;
+  var fieldWidth = this.sourceBlock_.getHeightWidth().width;
+  var initialWidth = fieldWidth * scale;
   var finalWidth = width;
   div.style.marginLeft = -0.5 * (finalWidth - initialWidth) + 'px';
 
@@ -339,8 +351,12 @@ Blockly.FieldTextInput.prototype.widgetDispose_ = function() {
     // Animation of disposal
     htmlInput.style.fontSize = Blockly.BlockSvg.FONTSIZE_INITIAL + 'pt';
     div.style.boxShadow = '';
-    div.style.width = Blockly.BlockSvg.FIELD_WIDTH + 'px';
-    div.style.height = Blockly.BlockSvg.FIELD_HEIGHT + 'px';
+    // Resize to actual size of final source block.
+    if (thisField.sourceBlock_) {
+      var size = thisField.sourceBlock_.getHeightWidth();
+      div.style.width = (size.width + 1) + 'px';
+      div.style.height = (size.height + 1) + 'px';
+    }
     div.style.marginLeft = 0;
   };
 };

--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -171,7 +171,7 @@ Blockly.FieldTextInput.prototype.showEditor_ = function(opt_quietInput, opt_read
   div.style.transition = transitionProperties;
   htmlInput.style.transition = 'font-size ' + Blockly.FieldTextInput.ANIMATION_TIME + 's';
   // The animated properties themselves
-  htmlInput.style.fontSize = Blockly.BlockSvg.FONTSIZE_FINAL + 'pt';
+  htmlInput.style.fontSize = Blockly.BlockSvg.FIELD_TEXTINPUT_FONTSIZE_FINAL + 'pt';
   div.style.boxShadow = '0px 0px 0px 4px ' + Blockly.Colours.fieldShadow;
 };
 
@@ -349,7 +349,7 @@ Blockly.FieldTextInput.prototype.widgetDispose_ = function() {
         htmlInput.onWorkspaceChangeWrapper_);
 
     // Animation of disposal
-    htmlInput.style.fontSize = Blockly.BlockSvg.FONTSIZE_INITIAL + 'pt';
+    htmlInput.style.fontSize = Blockly.BlockSvg.FIELD_TEXTINPUT_FONTSIZE_INITIAL + 'pt';
     div.style.boxShadow = '';
     // Resize to actual size of final source block.
     if (thisField.sourceBlock_) {

--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -291,7 +291,7 @@ Blockly.FieldTextInput.prototype.resizeEditor_ = function() {
   // whereas the right edge is fixed.  Reposition the editor.
   if (this.sourceBlock_.RTL) {
     xy.x += width;
-    xy.x -= div.offsetWidth;
+    xy.x -= div.offsetWidth * scale;
   }
   // Shift by a few pixels to line up exactly.
   xy.y += 1 * scale;
@@ -302,7 +302,7 @@ Blockly.FieldTextInput.prototype.resizeEditor_ = function() {
     xy.y += 1 * scale;
   }
   if (goog.userAgent.WEBKIT) {
-    xy.x += 0.5;
+    xy.x += 0;
     xy.y -= 1 * scale;
   }
   // Finally, set the actual style

--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -53,16 +53,6 @@ Blockly.FieldTextInput = function(text, opt_validator) {
 goog.inherits(Blockly.FieldTextInput, Blockly.Field);
 
 /**
- * Point size of text before animation. Must match size in CSS.
- */
-Blockly.FieldTextInput.FONTSIZE_INITIAL = 12;
-
-/**
- * Point size of text after animation.
- */
-Blockly.FieldTextInput.FONTSIZE_FINAL = 14;
-
-/**
  * Length of animations in seconds.
  */
 Blockly.FieldTextInput.ANIMATION_TIME = 0.25;
@@ -178,7 +168,7 @@ Blockly.FieldTextInput.prototype.showEditor_ = function(opt_quietInput, opt_read
     'box-shadow ' + Blockly.FieldTextInput.ANIMATION_TIME + 's';
   htmlInput.style.transition = 'font-size ' + Blockly.FieldTextInput.ANIMATION_TIME + 's';
   // The animated properties themselves
-  htmlInput.style.fontSize = Blockly.FieldTextInput.FONTSIZE_FINAL + 'pt';
+  htmlInput.style.fontSize = Blockly.BlockSvg.FONTSIZE_FINAL + 'pt';
   div.style.boxShadow = '0px 0px 0px 4px ' + Blockly.Colours.fieldShadow;
 };
 
@@ -347,7 +337,7 @@ Blockly.FieldTextInput.prototype.widgetDispose_ = function() {
         htmlInput.onWorkspaceChangeWrapper_);
 
     // Animation of disposal
-    htmlInput.style.fontSize = Blockly.FieldTextInput.FONTSIZE_INITIAL + 'pt';
+    htmlInput.style.fontSize = Blockly.BlockSvg.FONTSIZE_INITIAL + 'pt';
     div.style.boxShadow = '';
     div.style.width = Blockly.BlockSvg.FIELD_WIDTH + 'px';
     div.style.height = Blockly.BlockSvg.FIELD_HEIGHT + 'px';


### PR DESCRIPTION
Should fix #379, #146, #147.

Adds a couple of flags to the rendering modules to pin down the difference between vertical and horizontal field editor behavior. Use the flags and properties to create the proper mess of CSS.

The field editing feels almost good after this. There's a weird "lag" between when a character is typed and when the block grows. In Scratch 2.0 this happens in the same frame, which is really nice. Blockly addresses the lag by adding a little bit of space after the typed characters (the field editor is slightly bigger than the text, and it grows after the space is filled in). I wonder how or if we could address the lag? Will raise a new bug for that.
