### PR TITLE
Add handler for DOM input event to field_textinput

### DIFF
--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -157,6 +157,13 @@ Blockly.FieldTextInput.prototype.showEditor_ = function(opt_quietInput, opt_read
   // Bind to keyPress -- repeatedly resize when holding down a key.
   htmlInput.onKeyPressWrapper_ =
       Blockly.bindEvent_(htmlInput, 'keypress', this, this.onHtmlInputChange_);
+  // For modern browsers (IE 9+, Chrome, Firefox, etc.) that support the
+  // DOM input event, also trigger onHtmlInputChange_ then. The input event
+  // is triggered on keypress but after the value of the text input
+  // has updated, allowing us to resize the block at that time.
+  htmlInput.onInputWrapper_ =
+      Blockly.bindEvent_(htmlInput, 'input', this, this.onHtmlInputChange_);
+
   htmlInput.onWorkspaceChangeWrapper_ = this.resizeEditor_.bind(this);
   this.workspace_.addChangeListener(htmlInput.onWorkspaceChangeWrapper_);
 
@@ -344,6 +351,7 @@ Blockly.FieldTextInput.prototype.widgetDispose_ = function() {
     Blockly.unbindEvent_(htmlInput.onKeyDownWrapper_);
     Blockly.unbindEvent_(htmlInput.onKeyUpWrapper_);
     Blockly.unbindEvent_(htmlInput.onKeyPressWrapper_);
+    Blockly.unbindEvent_(htmlInput.onInputWrapper_);
     thisField.workspace_.removeChangeListener(
         htmlInput.onWorkspaceChangeWrapper_);
 

--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -215,12 +215,13 @@ Blockly.FieldTextInput.prototype.onHtmlInputChange_ = function(e) {
     htmlInput.oldValue_ = text;
     this.setValue(text);
     this.validate_();
+    this.resizeEditor_();
   } else if (goog.userAgent.WEBKIT) {
     // Cursor key.  Render the source block to show the caret moving.
     // Chrome only (version 26, OS X).
     this.sourceBlock_.render();
+    this.resizeEditor_();
   }
-  this.resizeEditor_();
 };
 
 /**


### PR DESCRIPTION
Before:
https://www.dropbox.com/s/j073u9ra4062zil/input-event-before.mov?dl=0

After:
https://www.dropbox.com/s/32ncd54s2avox0g/input-event-after.mov?dl=0

Here's what's going on: the 'keypress' event happens _before_ the value of the HTML input is updated. That's why you can't just resize the block there - the value isn't populated to be read. You could do something crazy where you try to predict the size change from e.keyCode, but that seems like a mess.

Luckily from StackOverflow I learned of this new "input" event. It gets fired right after keypress, but after the value of the input has been updated. By binding it to `onHtmlInputChange_`, the block gets sized appropriately right after keypress, and things look smooth even before keyup. Unfortunately this is not supported by < IE 9, but personally I'm fine with them having a slightly laggier "before" experience.
