### PR TITLE
Always update previews for output connections.

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -1039,6 +1039,11 @@ Blockly.BlockSvg.prototype.handleDragFree_ = function(oldXY, newXY, e) {
     }
   }
 
+  // Always update previews for output connections.
+  if (localConnection && localConnection.type == Blockly.OUTPUT_VALUE) {
+    updatePreviews = true;
+  }
+
   if (updatePreviews) {
     var candidateIsLast = (localConnection == lastOnStack);
     this.updatePreviews(closestConnection, localConnection, radiusConnection,

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -1025,7 +1025,9 @@ Blockly.BlockSvg.prototype.handleDragFree_ = function(oldXY, newXY, e) {
   }
 
   var updatePreviews = true;
-  if (Blockly.localConnection_ && Blockly.highlightedConnection_) {
+  if (localConnection && localConnection.type == Blockly.OUTPUT_VALUE) {
+    updatePreviews = true; // Always update previews for output connections.
+  } else if (Blockly.localConnection_ && Blockly.highlightedConnection_) {
     var xDiff = Blockly.localConnection_.x_ + dxy.x -
         Blockly.highlightedConnection_.x_;
     var yDiff = Blockly.localConnection_.y_ + dxy.y -
@@ -1037,11 +1039,6 @@ Blockly.BlockSvg.prototype.handleDragFree_ = function(oldXY, newXY, e) {
         Blockly.CURRENT_CONNECTION_PREFERENCE) {
       updatePreviews = false;
     }
-  }
-
-  // Always update previews for output connections.
-  if (localConnection && localConnection.type == Blockly.OUTPUT_VALUE) {
-    updatePreviews = true;
   }
 
   if (updatePreviews) {


### PR DESCRIPTION
Noticed a weird jumpiness in the updates for replacement markers:

![before](https://cloud.githubusercontent.com/assets/120403/16133671/1fe7396c-33e7-11e6-9ee8-0f59e1668977.gif)

After this fix:
![after](https://cloud.githubusercontent.com/assets/120403/16133682/2aed987e-33e7-11e6-8f24-1080969f410d.gif)
