### PR TITLE
BUMP_DELAY = 0

### DIFF
--- a/core/constants.js
+++ b/core/constants.js
@@ -53,7 +53,7 @@ Blockly.CURRENT_CONNECTION_PREFERENCE = 20;
 /**
  * Delay in ms between trigger and bumping unconnected block out of alignment.
  */
-Blockly.BUMP_DELAY = 250;
+Blockly.BUMP_DELAY = 0;
 
 /**
  * Number of characters to truncate a collapsed block to.


### PR DESCRIPTION
seeing no discussion on #424, giving us `BUMP_DELAY` = 0 to try out. To me it feels like a nice "perceived" speed up. Any objections?
