### PR TITLE
Basic fixes for FieldColour

### DIFF
--- a/core/css.js
+++ b/core/css.js
@@ -677,7 +677,6 @@ Blockly.Css.CONTENT = [
   '}',
 
   '.blocklyWidgetDiv .goog-palette-table {',
-    'border: 1px solid #666;',
     'border-collapse: collapse;',
   '}',
 
@@ -688,7 +687,6 @@ Blockly.Css.CONTENT = [
     'border: 0;',
     'text-align: center;',
     'vertical-align: middle;',
-    'border-right: 1px solid #666;',
     'font-size: 1px;',
   '}',
 
@@ -696,15 +694,16 @@ Blockly.Css.CONTENT = [
     'position: relative;',
     'height: 13px;',
     'width: 15px;',
-    'border: 1px solid #666;',
   '}',
 
   '.blocklyWidgetDiv .goog-palette-cell-hover .goog-palette-colorswatch {',
     'border: 1px solid #FFF;',
+    'box-sizing: border-box;',
   '}',
 
   '.blocklyWidgetDiv .goog-palette-cell-selected .goog-palette-colorswatch {',
     'border: 1px solid #000;',
+    'box-sizing: border-box;',
     'color: #fff;',
   '}',
 

--- a/core/field_colour.js
+++ b/core/field_colour.js
@@ -46,14 +46,6 @@ goog.require('goog.ui.ColorPicker');
  */
 Blockly.FieldColour = function(colour, opt_validator) {
   Blockly.FieldColour.superClass_.constructor.call(this, colour, opt_validator);
-  // Used to take space for the width of the field.
-  this.setText(Blockly.Field.NBSP +
-    Blockly.Field.NBSP +
-    Blockly.Field.NBSP +
-    Blockly.Field.NBSP +
-    Blockly.Field.NBSP +
-    Blockly.Field.NBSP
-  );
 };
 goog.inherits(Blockly.FieldColour, Blockly.Field);
 
@@ -138,6 +130,14 @@ Blockly.FieldColour.prototype.getText = function() {
     colour = '#' + m[1] + m[2] + m[3];
   }
   return colour;
+};
+
+/**
+ * Returns the fixed height and width.
+ * @return {!goog.math.Size} Height and width.
+ */
+Blockly.FieldColour.prototype.getSize = function() {
+  return new goog.math.Size(Blockly.BlockSvg.FIELD_WIDTH, Blockly.BlockSvg.FIELD_HEIGHT);
 };
 
 /**

--- a/core/field_colour.js
+++ b/core/field_colour.js
@@ -70,8 +70,8 @@ Blockly.FieldColour.prototype.columns_ = 0;
 Blockly.FieldColour.prototype.init = function(block) {
   Blockly.FieldColour.superClass_.init.call(this, block);
   this.colourRect_ = Blockly.createSvgElement('rect',
-      {'rx': 4,
-       'ry': 4,
+      {'rx': Blockly.BlockSvg.CORNER_RADIUS,
+       'ry': Blockly.BlockSvg.CORNER_RADIUS,
        'x': 0,
        'y': 0,
        'width': Blockly.BlockSvg.FIELD_WIDTH,

--- a/core/field_colour.js
+++ b/core/field_colour.js
@@ -46,7 +46,14 @@ goog.require('goog.ui.ColorPicker');
  */
 Blockly.FieldColour = function(colour, opt_validator) {
   Blockly.FieldColour.superClass_.constructor.call(this, colour, opt_validator);
-  this.setText(Blockly.Field.NBSP + Blockly.Field.NBSP + Blockly.Field.NBSP);
+  // Used to take space for the width of the field.
+  this.setText(Blockly.Field.NBSP +
+    Blockly.Field.NBSP +
+    Blockly.Field.NBSP +
+    Blockly.Field.NBSP +
+    Blockly.Field.NBSP +
+    Blockly.Field.NBSP
+  );
 };
 goog.inherits(Blockly.FieldColour, Blockly.Field);
 
@@ -70,12 +77,15 @@ Blockly.FieldColour.prototype.columns_ = 0;
  */
 Blockly.FieldColour.prototype.init = function(block) {
   Blockly.FieldColour.superClass_.init.call(this, block);
-  // TODO(#163): borderRect_ has been removed from the field.
-  // When fixing field_colour, we should re-color the shadow block instead,
-  // or re-implement a rectangle in the field.
-  if (this.borderRect_) {
-    this.borderRect_.style['fillOpacity'] = 1;
-  }
+  this.colourRect_ = Blockly.createSvgElement('rect',
+      {'rx': 4,
+       'ry': 4,
+       'x': 0,
+       'y': 0,
+       'width': Blockly.BlockSvg.FIELD_WIDTH,
+       'height': Blockly.BlockSvg.FIELD_HEIGHT
+      }, this.fieldGroup_, this.sourceBlock_.workspace);
+  this.colourRect_.style['fillOpacity'] = 1;
   this.setValue(this.getValue());
 };
 
@@ -111,8 +121,8 @@ Blockly.FieldColour.prototype.setValue = function(colour) {
         this.sourceBlock_, 'field', this.name, this.colour_, colour));
   }
   this.colour_ = colour;
-  if (this.borderRect_) {
-    this.borderRect_.style.fill = colour;
+  if (this.colourRect_) {
+    this.colourRect_.style.fill = colour;
   }
 };
 


### PR DESCRIPTION
Fixes #163 by creating a new rect called colourRect_ specifically for the colour field.

And fix sizing to make more sense for our blocks. I am not a fan of using NBSPs to force the width, so fixed it to use some constants instead.

We need to do a lot with the picker chrome, but at least this gives us a placeholder to start playing with values and the relevant blocks.

<img width="242" alt="screen shot 2016-07-06 at 6 29 54 pm" src="https://cloud.githubusercontent.com/assets/120403/16636696/c18760ba-43a7-11e6-9441-3c26d7c5ad03.png">

cc: @carljbowman
