### PR TITLE
Remove block-clicking hack put in for Google I/O demo

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -679,8 +679,10 @@ Blockly.BlockSvg.prototype.onMouseDown_ = function(e) {
  * @private
  */
 Blockly.BlockSvg.prototype.onMouseUp_ = function(e) {
-  var isNotShadowBlock = this.ioClickHackIsNotShadow_(e);
-  if (Blockly.dragMode_ != Blockly.DRAG_FREE && !Blockly.WidgetDiv.isVisible() && isNotShadowBlock) {
+  // XXX: This condition is broken because isShadow returns the wrong value.
+  // See: https://github.com/google/blockly/issues/336
+  // and https://github.com/LLK/scratch-blocks/issues/307
+  if (Blockly.dragMode_ != Blockly.DRAG_FREE && !Blockly.WidgetDiv.isVisible() && !this.isShadow()) {
     Blockly.Events.fire(
         new Blockly.Events.Ui(this, 'click', undefined, undefined));
     // Scratch-specific: also fire a "stack click" event for this stack.
@@ -721,29 +723,6 @@ Blockly.BlockSvg.prototype.onMouseUp_ = function(e) {
   if (!Blockly.WidgetDiv.isVisible()) {
     Blockly.Events.setGroup(false);
   }
-};
-
-/**
- * XXX: Hack to fix drop-down clicking issue for Google I/O.
- * We cannot just check isShadow, since `this` is the parent block.
- * See: https://github.com/google/blockly/issues/336
- * @param {!Event} e Mouse up event.
- * @return {boolean} True if the block is not the drop-down shadow.
- */
-Blockly.BlockSvg.prototype.ioClickHackIsNotShadow_ = function(e) {
-  // True if click target is a non-shadow block path.
-  if (e.target === this.svgPath_ &&
-      e.target.parentNode === this.getSvgRoot()) {
-    return true;
-  }
-  for (var i = 0, input; input = this.inputList[i]; i++) {
-    for (var j = 0, field; field = input.fieldRow[j]; j++) {
-      if (field.imageElement_ && field.imageElement_ === e.target) {
-        return true;
-      }
-    }
-  }
-  return false;
 };
 
 /**


### PR DESCRIPTION
It's still broken, but this way is less broken for the purposes of VM development. Bugs to have a final fix are listed in the comment...
