### PR TITLE
Temporary fix for page-breaking drop-downs

### DIFF
--- a/core/css.js
+++ b/core/css.js
@@ -216,7 +216,7 @@ Blockly.Css.CONTENT = [
   '}',
 
   '.blocklyDropDownDiv {',
-    'position: absolute;',
+    'position: fixed;',
     'left: 0;',
     'top: 0;',
     'z-index: 1000;',
@@ -226,6 +226,11 @@ Blockly.Css.CONTENT = [
     'box-shadow: 0px 0px 8px 1px ' + Blockly.Colours.dropDownShadow + ';',
     'padding: 4px;',
     '-webkit-user-select: none;',
+  '}',
+
+  '.blocklyDropDownContent {',
+    'max-height: 300px;', // @todo: spec for maximum height.
+    'overflow: auto;',
   '}',
 
   '.blocklyDropDownArrow {',


### PR DESCRIPTION
Fixes #470 by putting a fixed limit on the drop-down. The drop-down is scrollable inside that limit. Not sure if we want this, or "stretch-to-the-end-of-the-page" as WidgetDiv/2.0 do, but this at least fixes it before we make that design decision (and other ones, such as showing arrows).
