### PR TITLE
Only use "grabby" cursors when dragging

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -644,8 +644,6 @@ Blockly.BlockSvg.prototype.onMouseDown_ = function(e) {
       Blockly.Events.setGroup(true);
     }
     // Left-click (or middle click)
-    Blockly.Css.setCursor(Blockly.Css.Cursor.CLOSED);
-
     this.dragStartXY_ = this.getRelativeToSurfaceXY();
     this.workspace.startDrag(e, this.dragStartXY_);
 
@@ -953,6 +951,7 @@ Blockly.BlockSvg.prototype.onMouseMove_ = function(e) {
     // Still dragging within the sticky DRAG_RADIUS.
     var dr = goog.math.Coordinate.distance(oldXY, newXY) * this.workspace.scale;
     if (dr > Blockly.DRAG_RADIUS) {
+      Blockly.Css.setCursor(Blockly.Css.Cursor.CLOSED);
       // Switch to unrestricted dragging.
       Blockly.dragMode_ = Blockly.DRAG_FREE;
       Blockly.longStop_();

--- a/core/css.js
+++ b/core/css.js
@@ -121,7 +121,13 @@ Blockly.Css.setCursor = function(cursor) {
     return;
   }
   Blockly.Css.currentCursor_ = cursor;
-  var url = 'url(' + Blockly.Css.mediaPath_ + '/' + cursor + '.cur), auto';
+  var url;
+  if (cursor == Blockly.Css.Cursor.OPEN) {
+    // Scratch-specific: use CSS default cursor instead of "open hand."
+    url = 'default';
+  } else {
+    url = 'url(' + Blockly.Css.mediaPath_ + '/' + cursor + '.cur), auto';
+  }
   // There are potentially hundreds of draggable objects.  Changing their style
   // properties individually is too slow, so change the CSS rule instead.
   var rule = '.blocklyDraggable {\n  cursor: ' + url + ';\n}\n';
@@ -356,7 +362,6 @@ Blockly.Css.CONTENT = [
   '}',
 
   '.blocklyText {',
-    'cursor: default;',
     'fill: #fff;',
     'font-family: sans-serif;',
     'font-size: 12pt;',


### PR DESCRIPTION
I wanted us to play with this version of mouse cursors to start getting a feel for it. This replaces the Blockly "open hand" cursor with the CSS default (i.e., mouse pointer) cursor. When a drag exceeds DRAG_RADIUS, we switch to the closed cursor (instead of on mouse-down previously).
