### PR TITLE
make blocklyDropDownArrow inherit background-color and border-color

### DIFF
--- a/core/css.js
+++ b/core/css.js
@@ -246,6 +246,8 @@ Blockly.Css.CONTENT = [
     'width: 16px;',
     'height: 16px;',
     'z-index: -1;',
+    'background-color: inherit;',
+    'border-color: inherit;',
   '}',
 
   '.blocklyDropDownButton {',

--- a/core/dropdowndiv.js
+++ b/core/dropdowndiv.js
@@ -160,9 +160,7 @@ Blockly.DropDownDiv.clearContent = function() {
  */
 Blockly.DropDownDiv.setColour = function(backgroundColour, borderColour) {
   Blockly.DropDownDiv.DIV_.style.backgroundColor = backgroundColour;
-  Blockly.DropDownDiv.arrow_.style.backgroundColor = backgroundColour;
   Blockly.DropDownDiv.DIV_.style.borderColor = borderColour;
-  Blockly.DropDownDiv.arrow_.style.borderColor = borderColour;
 };
 
 /**


### PR DESCRIPTION
See discussion at LLK/scratch-blocks#500
