### PR TITLE
Browser consistency for keycode special events

### DIFF
--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -238,15 +238,17 @@ Blockly.FieldTextInput.prototype.onHtmlInputChange_ = function(e) {
     var keyCode;
     var isWhitelisted = false;
     if (goog.userAgent.GECKO) {
-      // e.keyCode is not available in Firefox.
+      // e.keyCode is not available in Gecko.
       keyCode = e.charCode;
-      // 32 = " ". Values below this are special keys.
-      // See: http://www.asciitable.com/
-      if (keyCode < 32) {
+      // Gecko reports control characters (e.g., left, right, copy, paste)
+      // in the key event - whitelist these from being restricted.
+      // < 32 and 127 (delete) are control characters.
+      // See: http://www.theasciicode.com.ar/ascii-control-characters/delete-ascii-code-127.html
+      if (keyCode < 32 || keyCode == 127) {
         isWhitelisted = true;
       } else if (e.metaKey || e.ctrlKey) {
-        // Firefox reports special characters (e.g., left, right, copy, paste)
-        // in the key event - whitelist these from being restricted.
+        // For combos (ctrl-v, ctrl-c, etc.), Gecko reports the ASCII letter
+        // and the metaKey/ctrlKey flags.
         isWhitelisted = Blockly.FieldTextInput.GECKO_KEYCODE_WHITELIST.indexOf(keyCode) > -1;
       }
     } else {

--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -217,16 +217,14 @@ Blockly.FieldTextInput.prototype.onHtmlInputKeyDown_ = function(e) {
 
 /**
  * Key codes that are whitelisted from the restrictor.
+ * These are only needed and used on Gecko (Firefox).
+ * See: https://github.com/LLK/scratch-blocks/issues/503.
  */
-Blockly.FieldTextInput.KEYCODE_WHITELIST = [
-  8, // Backspace
-  37, // Left
-  39, // Right
-  46, // Delete
-  97, // Select all
-  99, // Copy
-  118, // Paste
-  120 // Cut
+Blockly.FieldTextInput.GECKO_KEYCODE_WHITELIST = [
+  97, // Select all, META-A.
+  99, // Copy, META-C.
+  118, // Paste, META-V.
+  120 // Cut, META-X.
 ];
 
 /**
@@ -237,9 +235,22 @@ Blockly.FieldTextInput.KEYCODE_WHITELIST = [
 Blockly.FieldTextInput.prototype.onHtmlInputChange_ = function(e) {
   // Check if the key matches the restrictor.
   if (e.type === 'keypress' && this.restrictor_) {
-    var keyCode = e.keyCode || e.charCode; // charCode in Firefox.
+    var keyCode;
+    var isWhitelisted = false;
+    if (goog.userAgent.GECKO) {
+      // e.keyCode is not available in Firefox.
+      keyCode = e.charCode;
+      if (keyCode < 45) { // 45 = "-". Values below this are special keys.
+        isWhitelisted = true;
+      } else if (e.metaKey || e.ctrlKey) {
+        // Firefox reports special characters (e.g., left, right, copy, paste)
+        // in the key event - whitelist these from being restricted.
+        isWhitelisted = Blockly.FieldTextInput.GECKO_KEYCODE_WHITELIST.indexOf(keyCode) > -1;
+      }
+    } else {
+      keyCode = e.keyCode;
+    }
     var char = String.fromCharCode(keyCode);
-    var isWhitelisted = Blockly.FieldTextInput.KEYCODE_WHITELIST.indexOf(keyCode) > -1;
     if (!isWhitelisted && !this.restrictor_.test(char) && e.preventDefault) {
       // Failed to pass restrictor.
       e.preventDefault();

--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -240,7 +240,9 @@ Blockly.FieldTextInput.prototype.onHtmlInputChange_ = function(e) {
     if (goog.userAgent.GECKO) {
       // e.keyCode is not available in Firefox.
       keyCode = e.charCode;
-      if (keyCode < 45) { // 45 = "-". Values below this are special keys.
+      // 32 = " ". Values below this are special keys.
+      // See: http://www.asciitable.com/
+      if (keyCode < 32) {
         isWhitelisted = true;
       } else if (e.metaKey || e.ctrlKey) {
         // Firefox reports special characters (e.g., left, right, copy, paste)


### PR DESCRIPTION
Should fix #503.

The issue was that some of the "special characters" are actually real characters (X,C,A,V) that are combined with meta-codes. I think this should fix it (and possibly allow other special codes I didn't think of). Also only applies the whitelist/e.charCode to gecko. I don't like this anymore, but not sure what else to do.
