### PR TITLE
Fix `angleValidator` reference and lint @this

### DIFF
--- a/core/field_angle.js
+++ b/core/field_angle.js
@@ -212,7 +212,7 @@ Blockly.FieldAngle.prototype.onMouseMove = function(e) {
     angle = Math.round(angle / Blockly.FieldAngle.ROUND) *
         Blockly.FieldAngle.ROUND;
   }
-  angle = Blockly.FieldAngle.angleValidator(angle);
+  angle = Blockly.FieldAngle.classValidator(angle);
   Blockly.FieldTextInput.htmlInput_.value = angle;
   this.setValue(angle);
   this.validate_();
@@ -281,7 +281,6 @@ Blockly.FieldAngle.prototype.updateGraph_ = function() {
  * Ensure that only an angle may be entered.
  * @param {string} text The user's text.
  * @return {?string} A string representing a valid angle, or null if invalid.
- * @this {!Blockly.FieldAngle}
  */
 Blockly.FieldAngle.classValidator = function(text) {
   if (text === null) {


### PR DESCRIPTION
`angleValidator` was renamed to `classValidator`. The `@this` didn't pass the JSDoc linter; not sure why it was there anyway, since nothing in the function uses `this`.
