### PR TITLE
Don't call SVG methods on headless workspaces

### DIFF
--- a/core/xml.js
+++ b/core/xml.js
@@ -355,11 +355,11 @@ Blockly.Xml.domToBlock = function(xmlBlock, workspace) {
           }
         }, 1);
       }
+      topBlock.updateDisabled();
+      // Allow the scrollbars to resize and move based on the new contents.
+      // TODO(@picklesrus): #387. Remove when domToBlock avoids resizing.
+      Blockly.resizeSvgContents(workspace);
     }
-    topBlock.updateDisabled();
-    // Allow the scrollbars to resize and move based on the new contents.
-    // TODO(@picklesrus): #387. Remove when domToBlock avoids resizing.
-    Blockly.resizeSvgContents(workspace);
   } finally {
     Blockly.Events.enable();
   }


### PR DESCRIPTION
This fixes XML import for headless workspaces. The bug was introduced by
8e652db (a merge of google/blockly/develop), which moved the code outside
the `if (workspace.rendered)` guard. See:
- [parent 1](https://github.com/LLK/scratch-blocks/blob/c92504fd98727c075c708559e61605c7def3f294/core/xml.js#L357)
- [parent 2](https://github.com/LLK/scratch-blocks/blob/efc2ca3/core/xml.js#L356)
- [merge](https://github.com/LLK/scratch-blocks/blob/8e652db9fefff098d462f626ec1f9b0a742b4264/core/xml.js#L359)
