### PR TITLE
Adjust vertical alignment of horizontal field text

### DIFF
--- a/core/block_render_svg_horizontal.js
+++ b/core/block_render_svg_horizontal.js
@@ -94,7 +94,7 @@ Blockly.BlockSvg.FIELD_HEIGHT_MAX_EDIT = 10 * Blockly.BlockSvg.GRID_UNIT;
  * Top padding of user inputs
  * @const
  */
-Blockly.BlockSvg.FIELD_TOP_PADDING = 1 * Blockly.BlockSvg.GRID_UNIT;
+Blockly.BlockSvg.FIELD_TOP_PADDING = 0.25 * Blockly.BlockSvg.GRID_UNIT;
 
 /**
  * Corner radius of number inputs


### PR DESCRIPTION
Fixes #555.

This doesn't seem to affect the alignment when the editor is open. @tmickel, do you think it would affect anything else?

![block text alignment 2](https://cloud.githubusercontent.com/assets/632207/17519084/b4ded36c-5e4a-11e6-8d1b-31cbe82459d6.png)
_before regression, after regression, after fix_
