### PR TITLE
Fix for #307, #566

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -682,10 +682,10 @@ Blockly.BlockSvg.prototype.onMouseDown_ = function(e) {
  * @private
  */
 Blockly.BlockSvg.prototype.onMouseUp_ = function(e) {
-  // XXX: This condition is broken because isShadow returns the wrong value.
-  // See: https://github.com/google/blockly/issues/336
-  // and https://github.com/LLK/scratch-blocks/issues/307
-  if (Blockly.dragMode_ != Blockly.DRAG_FREE && !Blockly.WidgetDiv.isVisible() && !this.isShadow()) {
+  // A field is being edited if either the WidgetDiv or DropDownDiv is currently open.
+  // If a field is being edited, don't fire any click events.
+  var fieldEditing = Blockly.WidgetDiv.isVisible() || Blockly.DropDownDiv.isVisible();
+  if (Blockly.dragMode_ != Blockly.DRAG_FREE && !fieldEditing) {
     Blockly.Events.fire(
         new Blockly.Events.Ui(this, 'click', undefined, undefined));
     // Scratch-specific: also fire a "stack click" event for this stack.

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -636,6 +636,7 @@ Blockly.BlockSvg.prototype.onMouseDown_ = function(e) {
   Blockly.terminateDrag_();
   this.select();
   Blockly.hideChaff();
+  Blockly.DropDownDiv.hideWithoutAnimation();
   if (Blockly.isRightButton(e)) {
     // Right-click.
     this.showContextMenu_(e);

--- a/core/dropdowndiv.js
+++ b/core/dropdowndiv.js
@@ -335,6 +335,14 @@ Blockly.DropDownDiv.getPositionMetrics = function(primaryX, primaryY, secondaryX
 };
 
 /**
+ * Is the container visible?
+ * @return {boolean} True if visible.
+ */
+Blockly.DropDownDiv.isVisible = function() {
+  return !!Blockly.DropDownDiv.owner_;
+};
+
+/**
  * Hide the menu only if it is owned by the provided object.
  * @param {Object} owner Object which must be owning the drop-down to hide
  * @return {Boolean} True if hidden


### PR DESCRIPTION
Here is one possible fix for #307.

The basic problem here is that we don't want to fire click events when a field is open/being edited. Instead of worrying about whether the block clicked is a shadow block (and which is still reporting the incorrect block ID), I extended Neil's existing method of checking if the WidgetDiv is opened (which worked for text fields, number fields, etc.) to also checking if the DropDownDiv is opened (which now works for drop-downs).

Demo:
![dropdown-vs-execute](https://cloud.githubusercontent.com/assets/120403/17667409/d120e556-62d2-11e6-91bf-80ac30e32bd8.gif)
