### PR TITLE
Use sans-serif fonts in valueReportBox

### DIFF
--- a/core/css.js
+++ b/core/css.js
@@ -334,6 +334,7 @@ Blockly.Css.CONTENT = [
     'overflow: auto;',
     'word-wrap: break-word;',
     'text-align: center;',
+    'font-family: "Helvetica Neue", Helvetica, sans-serif;',
     'font-size: .8em;',
   '}',
 


### PR DESCRIPTION
To match the rest of scratch-blocks.
<img width="170" alt="screen shot 2016-08-15 at 10 31 33 am" src="https://cloud.githubusercontent.com/assets/120403/17667628/9c51edba-62d3-11e6-93ca-19b20b58469d.png">
