### PR TITLE
Size insertion markers with creating block metrics

### DIFF
--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -824,6 +824,11 @@ Blockly.BlockSvg.prototype.renderCompute_ = function(iconWidth) {
     inputRows.bottomEdge += inputRows[i].height;
   }
 
+  // Ensure insertion markers are at least insertionMarkerMinWidth_ wide.
+  if (this.insertionMarkerMinWidth_ > 0) {
+    inputRows.rightEdge = Math.max(inputRows.rightEdge, this.insertionMarkerMinWidth_);
+  }
+
   inputRows.hasValue = hasValue;
   inputRows.hasStatement = hasStatement;
   inputRows.hasDummy = hasDummy;
@@ -1131,8 +1136,6 @@ Blockly.BlockSvg.prototype.renderDrawRight_ = function(steps,
 
       if (input.connection.isConnected()) {
         input.connection.tighten_();
-        this.width = Math.max(this.width, inputRows.statementEdge +
-            input.connection.targetBlock().getHeightWidth().width);
       }
       if (y == inputRows.length - 1 ||
           inputRows[y + 1].type == Blockly.NEXT_STATEMENT) {
@@ -1174,9 +1177,13 @@ Blockly.BlockSvg.prototype.renderDrawRight_ = function(steps,
  */
 Blockly.BlockSvg.prototype.renderInputShape_ = function(input, x, y) {
   var inputShape = this.inputShapes_[input.name];
+  if (!inputShape) {
+    // No input shape for this input - e.g., the block is an insertion marker.
+    return;
+  }
   var inputShapeWidth = 0;
-  // Input shapes are only visibly rendered on non-connected non-insertion-markers.
-  if (this.isInsertionMarker() || input.connection.targetConnection) {
+  // Input shapes are only visibly rendered on non-connected slots.
+  if (input.connection.targetConnection) {
     inputShape.setAttribute('style', 'visibility: hidden');
   } else {
     var inputShapeX = 0, inputShapeY = 0;

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -84,6 +84,12 @@ Blockly.BlockSvg.prototype.height = 0;
 Blockly.BlockSvg.prototype.width = 0;
 
 /**
+ * Minimum width of block if insertion marker; comes from inserting block.
+ * @type {number}
+ */
+Blockly.BlockSvg.prototype.insertionMarkerMinWidth_ = 0;
+
+/**
  * Opacity of this block between 0 and 1.
  * @type {number}
  * @private
@@ -124,16 +130,18 @@ Blockly.BlockSvg.INLINE = -1;
  */
 Blockly.BlockSvg.prototype.initSvg = function() {
   goog.asserts.assert(this.workspace.rendered, 'Workspace is headless.');
-  // Input shapes are empty holes drawn when a value input is not connected.
-  for (var i = 0, input; input = this.inputList[i]; i++) {
-    input.init();
-    if (input.type === Blockly.INPUT_VALUE) {
-      this.initInputShape(input);
+  if (!this.isInsertionMarker()) { // Insertion markers not allowed to have inputs or icons
+    // Input shapes are empty holes drawn when a value input is not connected.
+    for (var i = 0, input; input = this.inputList[i]; i++) {
+      input.init();
+      if (input.type === Blockly.INPUT_VALUE) {
+        this.initInputShape(input);
+      }
     }
-  }
-  var icons = this.getIcons();
-  for (i = 0; i < icons.length; i++) {
-    icons[i].createIcon();
+    var icons = this.getIcons();
+    for (i = 0; i < icons.length; i++) {
+      icons[i].createIcon();
+    }
   }
   this.updateColour();
   this.updateMovable();
@@ -1156,10 +1164,11 @@ Blockly.BlockSvg.removeReplacementMarker = function() {
  */
 Blockly.BlockSvg.prototype.connectInsertionMarker_ = function(localConnection,
     closestConnection) {
+  var insertingBlock = Blockly.localConnection_.sourceBlock_;
   if (!Blockly.insertionMarker_) {
     Blockly.insertionMarker_ =
-        this.workspace.newBlock(Blockly.localConnection_.sourceBlock_.type);
-    Blockly.insertionMarker_.setInsertionMarker(true);
+        this.workspace.newBlock(insertingBlock.type);
+    Blockly.insertionMarker_.setInsertionMarker(true, insertingBlock.width);
     Blockly.insertionMarker_.initSvg();
   }
 
@@ -1273,9 +1282,11 @@ Blockly.BlockSvg.prototype.setShadow = function(shadow) {
 /**
  * Set whether this block is an insertion marker block or not.
  * @param {boolean} insertionMarker True if an insertion marker.
+ * @param {Number=} opt_minWidth Optional minimum width of the marker.
  */
-Blockly.BlockSvg.prototype.setInsertionMarker = function(insertionMarker) {
+Blockly.BlockSvg.prototype.setInsertionMarker = function(insertionMarker, opt_minWidth) {
   Blockly.BlockSvg.superClass_.setInsertionMarker.call(this, insertionMarker);
+  this.insertionMarkerMinWidth_ = opt_minWidth;
   this.updateColour();
 };
 


### PR DESCRIPTION
Here's a possible "final" fix for #250.

When an insertion marker is created, the block that's creating it saves its rendered width to the insertion marker's `insertionMarkerMinWidth_`. Then, the insertion marker uses that property to properly set its width.

I also switched back to not drawing inputs/input shapes/icons in insertion markers, for the performance benefit, and because the width is correct anyway now.

before:
![before](https://cloud.githubusercontent.com/assets/120403/17676086/b7815252-62fa-11e6-8ec9-0c71961c57e5.gif)

after:
![after](https://cloud.githubusercontent.com/assets/120403/17676089/bdd29e5e-62fa-11e6-8389-dd20c9e694b9.gif)
