### PR TITLE
Make jsonInit able to create dropdowns again

### DIFF
--- a/core/block.js
+++ b/core/block.js
@@ -1246,6 +1246,9 @@ Blockly.Block.prototype.interpolate_ = function(message, args, lastDummyAlign) {
             case 'field_dropdown':
               field = new Blockly.FieldDropdown(element['options']);
               break;
+            case 'field_iconmenu':
+              field = new Blockly.FieldIconMenu(element['options']);
+              break;
             case 'field_image':
               field = new Blockly.FieldImage(element['src'],
                   element['width'], element['height'], element['alt']);

--- a/tests/jsunit/block_test.js
+++ b/tests/jsunit/block_test.js
@@ -1,0 +1,69 @@
+/**
+ * @license
+ * Blockly Tests
+ *
+ * Copyright 2016 Google Inc.
+ * https://developers.google.com/blockly/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+function test_appendField_FieldIconMenu() {
+  var workspace = new Blockly.Workspace();
+  var block_name = 'test_jsonInit_FieldIconMenu';
+  var field_name = 'TEST_FIELD';
+  var dropdown_options = [{
+    value: 'VALUE'
+  }];
+
+  Blockly.Blocks[block_name] = {
+    init: function() {
+      this.appendDummyInput()
+          .appendField(new Blockly.FieldIconMenu(dropdown_options),
+              field_name);
+      this.setOutput(true);
+    }
+  };
+
+  var block = workspace.newBlock(block_name);
+  assertTrue('IconMenu field not added to block by appendField',
+      block.getField(field_name) instanceof Blockly.FieldIconMenu);
+}
+
+function test_jsonInit_FieldIconMenu() {
+  var workspace = new Blockly.Workspace();
+  var block_name = 'test_jsonInit_FieldIconMenu';
+  var field_name = 'TEST_FIELD';
+  var dropdown_options = [{
+    value: 'VALUE'
+  }];
+
+  Blockly.Blocks[block_name] = {
+    init: function() {
+      this.jsonInit({
+        message0: '%1',
+        args0: [{
+          type: 'field_iconmenu',
+          name: field_name,
+          options: dropdown_options
+        }],
+        output: null
+      });
+    }
+  };
+
+  var block = workspace.newBlock(block_name);
+  assertTrue('IconMenu field not added to block by jsonInit',
+      block.getField(field_name) instanceof Blockly.FieldIconMenu);
+}


### PR DESCRIPTION
and add a test to detect future regressions. The bug was introduced by [this merge](https://github.com/LLK/scratch-blocks/commit/dfc142eb376d9002ffc6b67f0fd5201e74cb0165?w=1#diff-5148dfb78f1d110be97f1d3539fa647cL1243).

@rachel-fenichel, I noted that [`flip_rtl` was removed](https://github.com/LLK/scratch-blocks/commit/dfc142eb376d9002ffc6b67f0fd5201e74cb0165?w=1#diff-5148dfb78f1d110be97f1d3539fa647cL1246) by the same merge. Was this intentional?
