### PR TITLE
Use postinstall instead of prepublish

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,13 +11,15 @@
   },
   "main": "./dist/vertical.js",
   "scripts": {
-    "prepublish": "webpack",
+    "postinstall": "webpack",
     "test": "eslint ."
   },
-  "devDependencies": {
-    "eslint": "2.9.0",
+  "dependencies": {
     "exports-loader": "0.6.3",
     "imports-loader": "0.6.5",
     "webpack": "1.13.2"
+  },
+  "devDependencies": {
+    "eslint": "2.9.0"
   }
 }


### PR DESCRIPTION
When installing from github, npm doesn't run prepublish on install, like it does when you're using npm link.

npm also doesn't install the devDependencies of dependencies, so since these are needed for installation, move them to dependencies.
