### PR TITLE
Fix paths for scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
   },
   "main": "./dist/vertical.js",
   "scripts": {
-    "postinstall": "webpack",
-    "test": "eslint ."
+    "postinstall": "./node_modules/.bin/webpack",
+    "test": "./node_modules/.bin/eslint ."
   },
   "dependencies": {
     "exports-loader": "0.6.3",


### PR DESCRIPTION
The explicit path is necessary when installing as a dependency (e.g., when postinstall runs)

fyi @tmickel 
