### PR TITLE
Classify blocks by shape

### DIFF
--- a/core/block_render_svg_horizontal.js
+++ b/core/block_render_svg_horizontal.js
@@ -613,16 +613,20 @@ Blockly.BlockSvg.prototype.renderDraw_ = function(metrics) {
 Blockly.BlockSvg.prototype.renderClassify_ = function(metrics) {
   var shapes = [];
   
-  if(metrics.statement) {
-    shapes.push('c-block');
-  }
-  if(metrics.startHat) {
-    shapes.push('hat'); // c-block+hats are possible (e.x. reprter procedures)
-  } else if(!metrics.statement) {
-    shapes.push('stack'); //only call it "stack" if it's not a c-block
-  }
-  if(!this.nextConnection) {
-    shapes.push('end');
+  if(this.isShadow_) {
+    shapes.push('argument');
+  } else {
+    if(metrics.statement) {
+      shapes.push('c-block');
+    }
+    if(metrics.startHat) {
+      shapes.push('hat'); // c-block+hats are possible (e.x. reprter procedures)
+    } else if(!metrics.statement) {
+      shapes.push('stack'); //only call it "stack" if it's not a c-block
+    }
+    if(!this.nextConnection) {
+      shapes.push('end');
+    }
   }
   
   this.svgGroup_.setAttribute('data-shapes', shapes.join(' '));

--- a/core/block_render_svg_horizontal.js
+++ b/core/block_render_svg_horizontal.js
@@ -398,6 +398,8 @@ Blockly.BlockSvg.prototype.render = function(opt_bubble) {
     this.renderDraw_(metrics);
     this.renderingMetrics_ = metrics;
   }
+  
+  this.renderClassify_(metrics);
 
   if (opt_bubble !== false) {
     // Render all blocks above this one (propagate a reflow).
@@ -600,6 +602,30 @@ Blockly.BlockSvg.prototype.renderDraw_ = function(metrics) {
     var transformation = 'translate(' + valueX + ',' + valueY + ')';
     input.setAttribute('transform', transformation);
   }
+};
+
+/**
+ * Give the block an attribute 'data-shapes' that lists its shape[s]
+ * @param {!Object} metrics An object containing computed measurements of the
+ *    block.
+ * @private
+ */
+Blockly.BlockSvg.prototype.renderClassify_ = function(metrics) {
+  var shapes = [];
+  
+  if(metrics.statement) {
+    shapes.push('c-block');
+  }
+  if(metrics.startHat) {
+    shapes.push('hat'); // c-block+hats are possible (e.x. reprter procedures)
+  } else if(!metrics.statement) {
+    shapes.push('stack'); //only call it "stack" if it's not a c-block
+  }
+  if(!this.nextConnection) {
+    shapes.push('end');
+  }
+  
+  this.svgGroup_.setAttribute('data-shapes', shapes.join(' '));
 };
 
 /**

--- a/core/block_render_svg_horizontal.js
+++ b/core/block_render_svg_horizontal.js
@@ -604,7 +604,7 @@ Blockly.BlockSvg.prototype.renderDraw_ = function(metrics) {
 };
 
 /**
- * Give the block an attribute 'data-shapes' that lists its shape[s]
+ * Give the block an attribute 'data-shapes' that lists its shape[s].
  * @param {!Object} metrics An object containing computed measurements of the
  *    block.
  * @private
@@ -612,18 +612,18 @@ Blockly.BlockSvg.prototype.renderDraw_ = function(metrics) {
 Blockly.BlockSvg.prototype.renderClassify_ = function(metrics) {
   var shapes = [];
   
-  if(this.isShadow_) {
+  if (this.isShadow_) {
     shapes.push('argument');
   } else {
     if(metrics.statement) {
       shapes.push('c-block');
     }
-    if(metrics.startHat) {
+    if (metrics.startHat) {
       shapes.push('hat'); // c-block+hats are possible (e.x. reprter procedures)
-    } else if(!metrics.statement) {
+    } else if (!metrics.statement) {
       shapes.push('stack'); //only call it "stack" if it's not a c-block
     }
-    if(!this.nextConnection) {
+    if (!this.nextConnection) {
       shapes.push('end');
     }
   }

--- a/core/block_render_svg_horizontal.js
+++ b/core/block_render_svg_horizontal.js
@@ -396,10 +396,9 @@ Blockly.BlockSvg.prototype.render = function(opt_bubble) {
     this.height = metrics.height;
     this.width = metrics.width;
     this.renderDraw_(metrics);
+    this.renderClassify_(metrics);
     this.renderingMetrics_ = metrics;
   }
-  
-  this.renderClassify_(metrics);
 
   if (opt_bubble !== false) {
     // Render all blocks above this one (propagate a reflow).

--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -983,7 +983,11 @@ Blockly.BlockSvg.prototype.renderClassify_ = function() {
   var shapes = [];
   
   if(this.outputConnection) {
-    shapes.push("reporter");
+    if(this.isShadow_) {
+      shapes.push("input");
+    } else {
+      shapes.push("reporter");
+    }
     if(this.edgeShape_ === Blockly.OUTPUT_SHAPE_HEXAGONAL) {
       shapes.push("boolean");
     } else if(this.edgeShape_ === Blockly.OUTPUT_SHAPE_ROUND) {

--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -984,16 +984,14 @@ Blockly.BlockSvg.prototype.renderClassify_ = function() {
   
   if(this.outputConnection) {
     if(this.isShadow_) {
-      shapes.push("input");
+      shapes.push('argument');
     } else {
-      shapes.push("reporter");
+      shapes.push('reporter');
     }
     if(this.edgeShape_ === Blockly.OUTPUT_SHAPE_HEXAGONAL) {
-      shapes.push("boolean");
+      shapes.push('boolean');
     } else if(this.edgeShape_ === Blockly.OUTPUT_SHAPE_ROUND) {
-      shapes.push("string");
-    } else {
-      // this shouldn't happen anymore because string-shaped reporters were phased out
+      shapes.push('round');
     }
   } else {
     // count the number of statement inputs
@@ -1006,22 +1004,20 @@ Blockly.BlockSvg.prototype.renderClassify_ = function() {
     }
     
     if(statementCount) {
-      shapes.push("c-block");
-      if(statementCount > 1) {
-        shapes.push("else");
-      }
+      shapes.push('c-block');
+      shapes.push('c-' + statementCount);
     }
     if(this.startHat_) {
-      shapes.push("hat"); // c-block+hats are possible (e.x. reprter procedures)
+      shapes.push('hat'); // c-block+hats are possible (e.x. reprter procedures)
     } else if(!statementCount) {
-      shapes.push("stack"); //only call it "stack" if it's not a c-block
+      shapes.push('stack'); //only call it "stack" if it's not a c-block
     }
     if(!this.nextConnection) {
-      shapes.push("end");
+      shapes.push('end');
     }
   }
   
-  this.svgGroup_.setAttribute('data-shapes', shapes.join(" "));
+  this.svgGroup_.setAttribute('data-shapes', shapes.join(' '));
 };
 
 /**

--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -976,21 +976,21 @@ Blockly.BlockSvg.prototype.renderDraw_ = function(iconWidth, inputRows) {
 };
 
 /**
- * Give the block an attribute 'data-shapes' that lists its shape[s]
+ * Give the block an attribute 'data-shapes' that lists its shape[s].
  * @private
  */
 Blockly.BlockSvg.prototype.renderClassify_ = function() {
   var shapes = [];
   
-  if(this.outputConnection) {
-    if(this.isShadow_) {
+  if (this.outputConnection) {
+    if (this.isShadow_) {
       shapes.push('argument');
     } else {
       shapes.push('reporter');
     }
-    if(this.edgeShape_ === Blockly.OUTPUT_SHAPE_HEXAGONAL) {
+    if (this.edgeShape_ === Blockly.OUTPUT_SHAPE_HEXAGONAL) {
       shapes.push('boolean');
-    } else if(this.edgeShape_ === Blockly.OUTPUT_SHAPE_ROUND) {
+    } else if (this.edgeShape_ === Blockly.OUTPUT_SHAPE_ROUND) {
       shapes.push('round');
     }
   } else {
@@ -1003,16 +1003,16 @@ Blockly.BlockSvg.prototype.renderClassify_ = function() {
       }
     }
     
-    if(statementCount) {
+    if (statementCount) {
       shapes.push('c-block');
       shapes.push('c-' + statementCount);
     }
-    if(this.startHat_) {
+    if (this.startHat_) {
       shapes.push('hat'); // c-block+hats are possible (e.x. reprter procedures)
-    } else if(!statementCount) {
+    } else if (!statementCount) {
       shapes.push('stack'); //only call it "stack" if it's not a c-block
     }
-    if(!this.nextConnection) {
+    if (!this.nextConnection) {
       shapes.push('end');
     }
   }

--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -1021,11 +1021,7 @@ Blockly.BlockSvg.prototype.renderClassify_ = function() {
     }
   }
   
-  var tempShapes = this.svgGroup_.getAttribute('data-shapes');
-  var shapesStringified = shapes.join(" ");
-  if(tempShapes !== shapesStringified) {
-    this.svgGroup_.setAttribute('data-shapes', shapesStringified);
-  }
+  this.svgGroup_.setAttribute('data-shapes', shapes.join(" "));
 };
 
 /**


### PR DESCRIPTION
This is my first attempt at implementing the shapes part of #365. My initial idea had been to add classes to the elements. After some consideration, I decided to put the list in a data-attribute instead to avoid interfering with Blockly's classes (like `blocklyDraggable`, etc). This data attribute is called `data-shapes` and users should still be able to access it with CSS and JS.

Thoughts:
- Right now the function runs on render. It might be better to have it run on block init, but then we'd have to make a special exception for blocks that change shape (like `stop [ v]`)
- The shape names I used were whatever seemed most obvious to me. They're definitely up for discussion
