### PR TITLE
Publish to NPM

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,15 @@
+# Localization / I18N
+common.pyc
+.settings
+.project
+*.pyc
+*.komodoproject
+/nbproject/private/
+
+# Unused by scratch-blocks
+javascript_compressed.js
+lua_compressed.js
+php_compressed.js
+python_compressed.js
+
+/accessible/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,16 @@ after_script:
   $(npm bin)/travis-after-all
   exitCode=$?
   if [[
+    # Execute after all jobs finish successfully
     $exitCode = 0 &&
+    # Only release on release branches
     $RELEASE_BRANCHES =~ $TRAVIS_BRANCH &&
+    # Don't release on PR builds
     $TRAVIS_PULL_REQUEST = "false"
   ]]; then
+    # Authenticate NPM
     echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" > .npmrc
+    # Set version to commit SHA
     npm --no-git-tag-version version $(node -p -e "require('./package.json').version")-${TRAVIS_COMMIT:0:5}
     npm publish
   fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,18 @@ sudo: false
 cache:
   directories:
   - node_modules
+after_script:
+- |
+  # RELEASE_BRANCHES and NPM_TOKEN defined in Travis settings panel
+  declare exitCode
+  $(npm bin)/travis-after-all
+  exitCode=$?
+  if [[
+    $exitCode = 0 &&
+    $RELEASE_BRANCHES =~ $TRAVIS_BRANCH &&
+    $TRAVIS_PULL_REQUEST = "false"
+  ]]; then
+    echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" > .npmrc
+    npm --no-git-tag-version version $(node -p -e "require('./package.json').version")-${TRAVIS_COMMIT:0:5}
+    npm publish
+  fi

--- a/package.json
+++ b/package.json
@@ -11,15 +11,15 @@
   },
   "main": "./dist/vertical.js",
   "scripts": {
-    "postinstall": "./node_modules/.bin/webpack",
+    "prepublish": "./node_modules/.bin/webpack",
     "test": "./node_modules/.bin/eslint ."
   },
-  "dependencies": {
+  "dependencies": {},
+  "devDependencies": {
+    "eslint": "2.9.0",
     "exports-loader": "0.6.3",
     "imports-loader": "0.6.5",
+    "travis-after-all": "1.4.4",
     "webpack": "1.13.2"
-  },
-  "devDependencies": {
-    "eslint": "2.9.0"
   }
 }


### PR DESCRIPTION
Move build dependencies back to devDependencies.

The build is now a prepublish step, not a postinstall step since the build will be supplied with the package when installed.

Use travis-after-all to deploy to npm only after all tests pass in all Node environments.

Only release non-PR builds for master and develop branches. For convenience, these branches are defined in the Settings panel for the repo in Travis. This way builds can be rerun without a new push with different values for these vars (e.g. if the token needs to change or a release should happen outside of the normal release branches)

Since this happens in `after_script`, we can't use Travis's built-in npm deployment. So create an .npmrc for authentication for `npm publish`.

Publish versions with the package.json version + "-[git sha]", e.g. 0.1.0-93d2f. This allows us to deploy every push to GitHub without considering version bumps. This is intended to be a temporary solution until we have more systematic releases.
