### PR TITLE
Build compressed js before publishing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,12 @@ python_compressed.js
 
 /accessible/*
 /dist
+/msg/json/synonyms.json
+/msg/json/qqq.json
+/blockly_compressed_horizontal.js
+/blockly_compressed_vertical.js
+/blockly_uncompressed_horizontal.js
+/blockly_uncompressed_vertical.js
+/blocks_compressed_horizontal.js
+/blocks_compressed_vertical.js
+/blocks_compressed.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ sudo: false
 cache:
   directories:
   - node_modules
+before_install:
+# Symlink closure library
+- ln -s $(npm root)/google-closure-library ../closure-library
 after_script:
 - |
   # RELEASE_BRANCHES and NPM_TOKEN defined in Travis settings panel

--- a/package.json
+++ b/package.json
@@ -11,14 +11,14 @@
   },
   "main": "./dist/vertical.js",
   "scripts": {
-    "prepublish": "./node_modules/.bin/webpack",
+    "prepublish": "python ./build.py && ./node_modules/.bin/webpack",
     "test": "./node_modules/.bin/eslint .",
     "version": "./node_modules/.bin/json -f package.json -I -e \"this.repository.sha = '$(git log -n1 --pretty=format:%H)'\""
   },
-  "dependencies": {},
   "devDependencies": {
     "eslint": "2.9.0",
     "exports-loader": "0.6.3",
+    "google-closure-library": "20160911.0.0",
     "imports-loader": "0.6.5",
     "json": "9.0.4",
     "travis-after-all": "1.4.4",


### PR DESCRIPTION
Untracks the compiled build assets, and builds them with Travis before each npm publish so that they're available on npm install. This ensures that the compiled assets always reflect the source files.
