### PR TITLE
Use semver-friendly version format when publishing to npm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ after_script:
   ]]; then
     # Authenticate NPM
     echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" > .npmrc
-    # Set version to commit SHA
-    npm --no-git-tag-version version $(node -p -e "require('./package.json').version")-${TRAVIS_COMMIT:0:5}
+    # Set version to timestamp
+    npm --no-git-tag-version version $($(npm bin)/json -f package.json version)-prerelease.$(date +%s)
     npm publish
   fi

--- a/package.json
+++ b/package.json
@@ -12,13 +12,15 @@
   "main": "./dist/vertical.js",
   "scripts": {
     "prepublish": "./node_modules/.bin/webpack",
-    "test": "./node_modules/.bin/eslint ."
+    "test": "./node_modules/.bin/eslint .",
+    "version": "./node_modules/.bin/json -f package.json -I -e \"this.repository.sha = '$(git log -n1 --pretty=format:%H)'\""
   },
   "dependencies": {},
   "devDependencies": {
     "eslint": "2.9.0",
     "exports-loader": "0.6.3",
     "imports-loader": "0.6.5",
+    "json": "9.0.4",
     "travis-after-all": "1.4.4",
     "webpack": "1.13.2"
   }


### PR DESCRIPTION
x.x.x-prerelease.x is semver friendly.
Move the git commit data to package.json's repo field.
