### PR TITLE
Hide DropDownDivs and WidgetDivs on workspace clear

### DIFF
--- a/core/workspace.js
+++ b/core/workspace.js
@@ -204,8 +204,14 @@ Blockly.Workspace.prototype.clear = function() {
   if (!existingGroup) {
     Blockly.Events.setGroup(false);
   }
-
   this.variableList.length = 0;
+  // Any block with a drop-down or WidgetDiv was disposed.
+  if (Blockly.DropDownDiv) {
+    Blockly.DropDownDiv.hideWithoutAnimation();
+  }
+  if (Blockly.WidgetDiv) {
+    Blockly.WidgetDiv.hide(true);
+  }
 };
 
 /**


### PR DESCRIPTION
One way to fix #611. At the top-level, avoid calling this over and over as blocks are disposed.
