### PR TITLE
Position drop-down based on actual block dimensions

### DIFF
--- a/core/dropdowndiv.js
+++ b/core/dropdowndiv.js
@@ -177,7 +177,7 @@ Blockly.DropDownDiv.setColour = function(backgroundColour, borderColour) {
 Blockly.DropDownDiv.showPositionedByBlock = function(owner, block,
       opt_onHide, opt_secondaryYOffset) {
   var scale = block.workspace.scale;
-  var bBox = block.getHeightWidth();
+  var bBox = {width: block.width, height: block.height};
   bBox.width *= scale;
   bBox.height *= scale;
   var position = goog.style.getPageOffset(block.getSvgRoot());

--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -181,7 +181,20 @@ Blockly.FieldDropdown.prototype.showEditor_ = function() {
     this.sourceBlock_.parentBlock_.getColour() : this.sourceBlock_.getColour();
 
   Blockly.DropDownDiv.setColour(primaryColour, this.sourceBlock_.getColourTertiary());
-  Blockly.DropDownDiv.showPositionedByBlock(this, this.sourceBlock_);
+
+  // Calculate positioning based on the field position.
+  var scale = this.sourceBlock_.workspace.scale;
+  var bBox = {width: this.size_.width, height: this.size_.height};
+  bBox.width *= scale;
+  bBox.height *= scale;
+  var position = goog.style.getPageOffset(this.fieldGroup_);
+  var primaryX = position.x + bBox.width / 2;
+  var primaryY = position.y + bBox.height;
+  var secondaryX = primaryX;
+  var secondaryY = position.y;
+  // Set bounds to workspace; show the drop-down.
+  Blockly.DropDownDiv.setBoundsElement(this.sourceBlock_.workspace.getParentSvg().parentNode);
+  Blockly.DropDownDiv.show(this, primaryX, primaryY, secondaryX, secondaryY);
 
   menu.setAllowAutoFocus(true);
   menuDom.focus();


### PR DESCRIPTION
`getHeightWidth` gets the height/width of all blocks in the stack below the block, but `block.height` and `block.width` should be the actual relevant dimensions of the block. Fixes #587.

Before:

<img width="283" alt="screen shot 2016-09-27 at 2 39 17 pm" src="https://cloud.githubusercontent.com/assets/120403/18886998/54e7dc28-84c0-11e6-9e11-3a65d2161c84.png">

After:

<img width="307" alt="screen shot 2016-09-27 at 2 39 03 pm" src="https://cloud.githubusercontent.com/assets/120403/18887003/5c101c5e-84c0-11e6-9490-3561f5b512cc.png">
