### PR TITLE
Set checkboxes in drop-downs to scroll with menu

### DIFF
--- a/core/css.js
+++ b/core/css.js
@@ -917,17 +917,6 @@ Blockly.Css.CONTENT = [
     'width: 16px;',
   '}',
 
-  /* BiDi override for the selected/checked state. */
-  /* #noflip */
-  '.blocklyWidgetDiv .goog-menuitem-rtl .goog-menuitem-checkbox,',
-  '.blocklyWidgetDiv .goog-menuitem-rtl .goog-menuitem-icon,',
-  '.blocklyDropDownDiv .goog-menuitem-rtl .goog-menuitem-checkbox,',
-  '.blocklyDropDownDiv .goog-menuitem-rtl .goog-menuitem-icon {',
-     /* Flip left/right positioning. */
-    'left: auto;',
-    'right: 6px;',
-  '}',
-
   '.blocklyWidgetDiv .goog-option-selected .goog-menuitem-checkbox,',
   '.blocklyWidgetDiv .goog-option-selected .goog-menuitem-icon,',
   '.blocklyDropDownDiv .goog-option-selected .goog-menuitem-checkbox,',
@@ -937,6 +926,17 @@ Blockly.Css.CONTENT = [
     'position: static;', /* Scroll with the menu. */
     'float: left;',
     'margin-left: -24px;',
+  '}',
+
+  /* BiDi override for the selected/checked state. */
+  /* #noflip */
+  '.blocklyWidgetDiv .goog-menuitem-rtl .goog-menuitem-checkbox,',
+  '.blocklyWidgetDiv .goog-menuitem-rtl .goog-menuitem-icon,',
+  '.blocklyDropDownDiv .goog-menuitem-rtl .goog-menuitem-checkbox,',
+  '.blocklyDropDownDiv .goog-menuitem-rtl .goog-menuitem-icon {',
+     /* Flip left/right positioning. */
+     'float: right;',
+     'margin-left: 6px;',
   '}',
 
   /* Keyboard shortcut ("accelerator") style. */

--- a/core/css.js
+++ b/core/css.js
@@ -934,6 +934,9 @@ Blockly.Css.CONTENT = [
   '.blocklyDropDownDiv .goog-option-selected .goog-menuitem-icon {',
      /* Client apps may override the URL at which they serve the sprite. */
     'background: url(<<<PATH>>>/sprites.png) no-repeat -48px -16px !important;',
+    'position: static;', /* Scroll with the menu. */
+    'float: left;',
+    'margin-left: -24px;',
   '}',
 
   /* Keyboard shortcut ("accelerator") style. */


### PR DESCRIPTION
Previously the checkbox in the Closure menu would not scroll when a menu was scrolled. Since it now seems likely that we'll stick with the Closure menu, I thought I would fix this.

Before: see current https://llk.github.io/scratch-vm/

After:
![scroll](https://cloud.githubusercontent.com/assets/120403/18887800/ba98d01a-84c3-11e6-830f-402e46922375.gif)
