### PR TITLE
Move checked menu item when new value set

### DIFF
--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -77,6 +77,12 @@ Blockly.FieldDropdown.ARROW_CHAR = goog.userAgent.ANDROID ? '\u25BC' : '\u25BE';
 Blockly.FieldDropdown.prototype.CURSOR = 'default';
 
 /**
+ * Closure menu item currently selected.
+ * @type {?goog.ui.MenuItem}
+ */
+Blockly.FieldDropdown.prototype.selectedItem = null;
+
+/**
  * Install this dropdown on a block.
  */
 Blockly.FieldDropdown.prototype.init = function() {
@@ -148,7 +154,11 @@ Blockly.FieldDropdown.prototype.showEditor_ = function() {
     menuItem.setValue(value);
     menuItem.setCheckable(true);
     menu.addChild(menuItem, true);
-    menuItem.setChecked(value == this.value_);
+    var checked = (value == this.value_);
+    menuItem.setChecked(checked);
+    if (checked) {
+      this.selectedItem = menuItem;
+    }
   }
   // Listen for mouse/keyboard events.
   goog.events.listen(menu, goog.ui.Component.EventType.ACTION, callback);
@@ -260,6 +270,11 @@ Blockly.FieldDropdown.prototype.setValue = function(newValue) {
     Blockly.Events.fire(new Blockly.Events.Change(
         this.sourceBlock_, 'field', this.name, this.value_, newValue));
   }
+  // Clear menu item for old value.
+  if (this.selectedItem) {
+    this.selectedItem.setChecked(false);
+    this.selectedItem = null;
+  }
   this.value_ = newValue;
   // Look up and display the human-readable text.
   var options = this.getOptions_();
@@ -311,6 +326,7 @@ Blockly.FieldDropdown.prototype.setText = function(text) {
  * Close the dropdown menu if this input is being deleted.
  */
 Blockly.FieldDropdown.prototype.dispose = function() {
+  this.selectedItem = null;
   Blockly.WidgetDiv.hideIfOwner(this);
   Blockly.FieldDropdown.superClass_.dispose.call(this);
 };


### PR DESCRIPTION
Previously, when a drop-down was animating out after you select an item, Closure UI would check the new selected item, but no one would uncheck the currently selected item. Since we never stored a reference to the currently selected item, I added an attribute to track that and clear it whenever the value is changed.

This is not a problem in Blockly because the drop-down disappears immediately.

Demo:
![demo](https://cloud.githubusercontent.com/assets/120403/18888156/283d9366-84c5-11e6-8ebe-e58e58491b73.gif)
