### PR TITLE
Restore including statement width in `this.width` calculation

### DIFF
--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -1180,9 +1180,10 @@ Blockly.BlockSvg.prototype.renderDrawRight_ = function(steps,
       connectionX = connectionsXY.x + (this.RTL ? -cursorX : cursorX);
       connectionY = connectionsXY.y + cursorY;
       input.connection.moveTo(connectionX, connectionY);
-
       if (input.connection.isConnected()) {
         input.connection.tighten_();
+        this.width = Math.max(this.width, inputRows.statementEdge +
+          input.connection.targetBlock().getHeightWidth().width);
       }
       if (y == inputRows.length - 1 ||
           inputRows[y + 1].type == Blockly.NEXT_STATEMENT) {


### PR DESCRIPTION
From here: https://github.com/google/blockly/blob/0fb77e09d0310fe7db8fc00fb27a30a1e16ea015/core/block_render_svg.js#L861

Fixes #637
