### PR TITLE
Add a class for block background

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -55,7 +55,7 @@ Blockly.BlockSvg = function(workspace, prototypeName, opt_id) {
    */
   this.svgGroup_ = Blockly.createSvgElement('g', {}, null);
   /** @type {SVGElement} */
-  this.svgPath_ = Blockly.createSvgElement('path', {'class': 'blocklyPath'},
+  this.svgPath_ = Blockly.createSvgElement('path', {'class': 'blocklyPath blocklyBlockBackground'},
       this.svgGroup_);
   this.svgPath_.tooltip = this;
 


### PR DESCRIPTION
It's tricky to identify a block's background path with CSS selectors. There can be other things in the svgGroup with the class blocklyPath (e.g boolean inputs). This adds a class `blocklyBlockBackground` to the svgPath. Now the path can be styled in CSS like so:

```
g[data-category="looks"] > path.blocklyBlockBackground {
  fill: red;
}
```
