### PR TITLE
Add attribute for argument type

### DIFF
--- a/core/block.js
+++ b/core/block.js
@@ -1280,6 +1280,7 @@ Blockly.Block.prototype.interpolate_ = function(message, args, lastDummyAlign) {
         }
       } while (altRepeat);
       if (field) {
+        field.fieldType = element['type'].replace(/field_/, '');
         fieldStack.push([field, element['name']]);
       } else if (input) {
         if (element['check']) {

--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -1242,19 +1242,23 @@ Blockly.BlockSvg.prototype.renderInputShape_ = function(input, x, y) {
     var inputShapeX = 0, inputShapeY = 0;
     // If the input connection is not connected, draw a hole shape.
     var inputShapePath = null;
+    var inputShapeFieldType = null;
     switch (input.connection.getOutputShape()) {
       case Blockly.OUTPUT_SHAPE_HEXAGONAL:
         inputShapePath = Blockly.BlockSvg.INPUT_SHAPE_HEXAGONAL;
         inputShapeWidth = Blockly.BlockSvg.INPUT_SHAPE_HEXAGONAL_WIDTH;
+        inputShapeFieldType = 'boolean';
         break;
       case Blockly.OUTPUT_SHAPE_ROUND:
         inputShapePath = Blockly.BlockSvg.INPUT_SHAPE_ROUND;
         inputShapeWidth = Blockly.BlockSvg.INPUT_SHAPE_ROUND_WIDTH;
+        inputShapeFieldType = 'round';
         break;
       case Blockly.OUTPUT_SHAPE_SQUARE:
       default:
         inputShapePath = Blockly.BlockSvg.INPUT_SHAPE_SQUARE;
         inputShapeWidth = Blockly.BlockSvg.INPUT_SHAPE_SQUARE_WIDTH;
+        inputShapeFieldType = 'square';
         break;
     }
     if (this.RTL) {
@@ -1267,6 +1271,7 @@ Blockly.BlockSvg.prototype.renderInputShape_ = function(input, x, y) {
     inputShape.setAttribute('transform',
       'translate(' + inputShapeX + ',' + inputShapeY + ')'
     );
+    inputShape.setAttribute('data-argument-type', inputShapeFieldType);
     inputShape.setAttribute('style', 'visibility: visible');
   }
 };

--- a/core/field.js
+++ b/core/field.js
@@ -140,9 +140,9 @@ Blockly.Field.prototype.init = function() {
   // Build the DOM.
   this.fieldGroup_ = Blockly.createSvgElement('g', {}, null);
   if (this.sourceBlock_.isShadow_) {
-    this.sourceBlock_.svgGroup_.setAttribute('data-field-type', this.fieldType);
+    this.sourceBlock_.svgGroup_.setAttribute('data-argument-type', this.fieldType);
   } else {
-    this.fieldGroup_.setAttribute('data-field-type', this.fieldType); // square dropdowns
+    this.fieldGroup_.setAttribute('data-argument-type', this.fieldType); // square dropdowns
   }
   if (!this.visible_) {
     this.fieldGroup_.style.display = 'none';

--- a/core/field.js
+++ b/core/field.js
@@ -139,6 +139,11 @@ Blockly.Field.prototype.init = function() {
   }
   // Build the DOM.
   this.fieldGroup_ = Blockly.createSvgElement('g', {}, null);
+  if (this.sourceBlock_.isShadow_) {
+    this.sourceBlock_.svgGroup_.setAttribute('data-field-type', this.fieldType);
+  } else {
+    this.fieldGroup_.setAttribute('data-field-type', this.fieldType); // square dropdowns
+  }
   if (!this.visible_) {
     this.fieldGroup_.style.display = 'none';
   }


### PR DESCRIPTION
This adds an attribute `data-argument-type` to inputs so they can be styled based on that (for example, styling dropdowns with a secondary color but leaving inputs as white).

The way I achieved this was a little hacky, so I'd understand if you're more reluctant to accept this PR
