### PR TITLE
Add attribute for argument type (take 2)

### DIFF
--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -1242,19 +1242,23 @@ Blockly.BlockSvg.prototype.renderInputShape_ = function(input, x, y) {
     var inputShapeX = 0, inputShapeY = 0;
     // If the input connection is not connected, draw a hole shape.
     var inputShapePath = null;
+    var inputShapeArgType = null;
     switch (input.connection.getOutputShape()) {
       case Blockly.OUTPUT_SHAPE_HEXAGONAL:
         inputShapePath = Blockly.BlockSvg.INPUT_SHAPE_HEXAGONAL;
         inputShapeWidth = Blockly.BlockSvg.INPUT_SHAPE_HEXAGONAL_WIDTH;
+        inputShapeArgType = 'boolean';
         break;
       case Blockly.OUTPUT_SHAPE_ROUND:
         inputShapePath = Blockly.BlockSvg.INPUT_SHAPE_ROUND;
         inputShapeWidth = Blockly.BlockSvg.INPUT_SHAPE_ROUND_WIDTH;
+        inputShapeArgType = 'round';
         break;
       case Blockly.OUTPUT_SHAPE_SQUARE:
       default:
         inputShapePath = Blockly.BlockSvg.INPUT_SHAPE_SQUARE;
         inputShapeWidth = Blockly.BlockSvg.INPUT_SHAPE_SQUARE_WIDTH;
+        inputShapeArgType = 'square';
         break;
     }
     if (this.RTL) {
@@ -1267,6 +1271,7 @@ Blockly.BlockSvg.prototype.renderInputShape_ = function(input, x, y) {
     inputShape.setAttribute('transform',
       'translate(' + inputShapeX + ',' + inputShapeY + ')'
     );
+    inputShape.setAttribute('data-argument-type', inputShapeArgType);
     inputShape.setAttribute('style', 'visibility: visible');
   }
 };

--- a/core/field.js
+++ b/core/field.js
@@ -103,6 +103,13 @@ Blockly.Field.prototype.sourceBlock_ = null;
 Blockly.Field.prototype.visible_ = true;
 
 /**
+ * The field's argType (for styling).
+ * @type {Blockly.Block}
+ * @private
+ */
+Blockly.Field.prototype.argType_ = null;
+
+/**
  * Validation function called when user edits an editable field.
  * @type {Function}
  * @private
@@ -141,6 +148,15 @@ Blockly.Field.prototype.init = function() {
   this.fieldGroup_ = Blockly.createSvgElement('g', {}, null);
   if (!this.visible_) {
     this.fieldGroup_.style.display = 'none';
+  }
+  // Add an attribute to cassify the type of field.
+  if (this.getArgType() !== null) {
+    if (this.sourceBlock_.isShadow()) {
+      this.sourceBlock_.svgGroup_.setAttribute('data-argument-type', this.getArgType());
+    } else {
+      // Fields without a shadow wrapper, like square dropdowns.
+      this.fieldGroup_.setAttribute('data-argument-type', this.getArgType());
+    }
   }
   // Adjust X to be flipped for RTL. Position is relative to horizontal start of source block.
   var size = this.getSize();
@@ -219,6 +235,22 @@ Blockly.Field.prototype.setVisible = function(visible) {
     root.style.display = visible ? 'block' : 'none';
     this.render_();
   }
+};
+
+/**
+ * Sets the field's argType (used for styling).
+ * @param {string} argType New argType.
+ */
+Blockly.Field.prototype.setArgType = function(argType) {
+  this.argType_ = argType;
+};
+
+/**
+ * Gets the field's argType (used for styling).
+ * @return {string} argType string, or null.
+ */
+Blockly.Field.prototype.getArgType = function() {
+  return this.argType_;
 };
 
 /**

--- a/core/field_angle.js
+++ b/core/field_angle.js
@@ -46,9 +46,9 @@ Blockly.FieldAngle = function(text, opt_validator) {
   // Add degree symbol: "360°" (LTR) or "°360" (RTL)
   this.symbol_ = Blockly.createSvgElement('tspan', {}, null);
   this.symbol_.appendChild(document.createTextNode('\u00B0'));
-  this.setArgType('angle');
 
   Blockly.FieldAngle.superClass_.constructor.call(this, text, opt_validator);
+  this.setArgType('angle');
 };
 goog.inherits(Blockly.FieldAngle, Blockly.FieldTextInput);
 

--- a/core/field_angle.js
+++ b/core/field_angle.js
@@ -46,6 +46,7 @@ Blockly.FieldAngle = function(text, opt_validator) {
   // Add degree symbol: "360°" (LTR) or "°360" (RTL)
   this.symbol_ = Blockly.createSvgElement('tspan', {}, null);
   this.symbol_.appendChild(document.createTextNode('\u00B0'));
+  this.setArgType('angle');
 
   Blockly.FieldAngle.superClass_.constructor.call(this, text, opt_validator);
 };

--- a/core/field_checkbox.js
+++ b/core/field_checkbox.js
@@ -43,6 +43,7 @@ Blockly.FieldCheckbox = function(state, opt_validator) {
   Blockly.FieldCheckbox.superClass_.constructor.call(this, '', opt_validator);
   // Set the initial state.
   this.setValue(state);
+  this.setArgType('checkbox');
 };
 goog.inherits(Blockly.FieldCheckbox, Blockly.Field);
 

--- a/core/field_colour.js
+++ b/core/field_colour.js
@@ -46,6 +46,7 @@ goog.require('goog.ui.ColorPicker');
  */
 Blockly.FieldColour = function(colour, opt_validator) {
   Blockly.FieldColour.superClass_.constructor.call(this, colour, opt_validator);
+  this.setArgType('colour');
 };
 goog.inherits(Blockly.FieldColour, Blockly.Field);
 

--- a/core/field_date.js
+++ b/core/field_date.js
@@ -53,6 +53,7 @@ Blockly.FieldDate = function(date, opt_validator) {
   }
   Blockly.FieldDate.superClass_.constructor.call(this, date, opt_validator);
   this.setValue(date);
+  this.setArgType('date');
 };
 goog.inherits(Blockly.FieldDate, Blockly.Field);
 

--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -54,6 +54,7 @@ Blockly.FieldDropdown = function(menuGenerator, opt_validator) {
   this.menuGenerator_ = menuGenerator;
   this.trimOptions_();
   var firstTuple = this.getOptions_()[0];
+  this.setArgType('dropdown');
 
   // Call parent's constructor.
   Blockly.FieldDropdown.superClass_.constructor.call(this, firstTuple[1],

--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -54,11 +54,11 @@ Blockly.FieldDropdown = function(menuGenerator, opt_validator) {
   this.menuGenerator_ = menuGenerator;
   this.trimOptions_();
   var firstTuple = this.getOptions_()[0];
-  this.setArgType('dropdown');
 
   // Call parent's constructor.
   Blockly.FieldDropdown.superClass_.constructor.call(this, firstTuple[1],
       opt_validator);
+  this.setArgType('dropdown');
 };
 goog.inherits(Blockly.FieldDropdown, Blockly.Field);
 

--- a/core/field_iconmenu.js
+++ b/core/field_iconmenu.js
@@ -44,6 +44,7 @@ Blockly.FieldIconMenu = function(icons) {
   // [{src: '...', width: 20, height: 20, alt: '...', value: 'machine_value'}, ...]
   // First icon provides the default values.
   var defaultValue = icons[0].value;
+  this.setArgType('iconmenu');
   Blockly.FieldIconMenu.superClass_.constructor.call(this, defaultValue);
 };
 goog.inherits(Blockly.FieldIconMenu, Blockly.Field);

--- a/core/field_iconmenu.js
+++ b/core/field_iconmenu.js
@@ -44,8 +44,8 @@ Blockly.FieldIconMenu = function(icons) {
   // [{src: '...', width: 20, height: 20, alt: '...', value: 'machine_value'}, ...]
   // First icon provides the default values.
   var defaultValue = icons[0].value;
-  this.setArgType('iconmenu');
   Blockly.FieldIconMenu.superClass_.constructor.call(this, defaultValue);
+  this.setArgType('iconmenu');
 };
 goog.inherits(Blockly.FieldIconMenu, Blockly.Field);
 

--- a/core/field_number.js
+++ b/core/field_number.js
@@ -72,6 +72,7 @@ Blockly.FieldNumber = function(value, opt_min, opt_max, opt_precision, opt_valid
     (Math.floor(opt_precision) != opt_precision);
   this.negativeAllowed_ = (typeof opt_min == 'undefined') || isNaN(opt_min) || opt_min < 0;
   var numRestrictor = getNumRestrictor(this.decimalAllowed_, this.negativeAllowed_);
+  this.setArgType('number');
   Blockly.FieldNumber.superClass_.constructor.call(this, value, opt_validator, numRestrictor);
 };
 goog.inherits(Blockly.FieldNumber, Blockly.FieldTextInput);

--- a/core/field_number.js
+++ b/core/field_number.js
@@ -72,8 +72,8 @@ Blockly.FieldNumber = function(value, opt_min, opt_max, opt_precision, opt_valid
     (Math.floor(opt_precision) != opt_precision);
   this.negativeAllowed_ = (typeof opt_min == 'undefined') || isNaN(opt_min) || opt_min < 0;
   var numRestrictor = getNumRestrictor(this.decimalAllowed_, this.negativeAllowed_);
-  this.setArgType('number');
   Blockly.FieldNumber.superClass_.constructor.call(this, value, opt_validator, numRestrictor);
+  this.setArgType('number');
 };
 goog.inherits(Blockly.FieldNumber, Blockly.FieldTextInput);
 

--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -54,6 +54,7 @@ Blockly.FieldTextInput = function(text, opt_validator, opt_restrictor) {
   Blockly.FieldTextInput.superClass_.constructor.call(this, text,
       opt_validator);
   this.setRestrictor(opt_restrictor);
+  this.setArgType('text');
 };
 goog.inherits(Blockly.FieldTextInput, Blockly.Field);
 

--- a/core/field_variable.js
+++ b/core/field_variable.js
@@ -45,6 +45,7 @@ Blockly.FieldVariable = function(varname, opt_validator) {
   Blockly.FieldVariable.superClass_.constructor.call(this,
       Blockly.FieldVariable.dropdownCreate, opt_validator);
   this.setValue(varname || '');
+  this.setArgType('variable');
 };
 goog.inherits(Blockly.FieldVariable, Blockly.FieldDropdown);
 


### PR DESCRIPTION
This adds an attribute `data-argument-type` to inputs so they can be styled based on that (for example, styling dropdowns with a secondary color but leaving inputs as white).

This system should be more robust than #644 and I made some of the changes suggested on that PR
