### PR TITLE
Add classes for insertion-markers and replacement-rings

### DIFF
--- a/core/block.js
+++ b/core/block.js
@@ -625,6 +625,7 @@ Blockly.Block.prototype.setInsertionMarker = function(insertionMarker) {
   if (this.isInsertionMarker_) {
     this.setColour(Blockly.Colours.insertionMarker);
     this.setOpacity(Blockly.Colours.insertionMarkerOpacity);
+    this.svgGroup_.classList.add('blocklyInsertionMarker');
   }
 };
 

--- a/core/block_render_svg_horizontal.js
+++ b/core/block_render_svg_horizontal.js
@@ -336,8 +336,10 @@ Blockly.BlockSvg.prototype.updateColour = function() {
 Blockly.BlockSvg.prototype.highlightForReplacement = function(add) {
   if (add) {
     this.svgPath_.setAttribute('filter', 'url(#blocklyReplacementGlowFilter)');
+    this.svgGroup_.classList.add('blocklyReplaceable');
   } else {
     this.svgPath_.removeAttribute('filter');
+    this.svgGroup_.classList.remove('blocklyReplaceable');
   }
 };
 

--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -504,8 +504,10 @@ Blockly.BlockSvg.prototype.updateColour = function() {
 Blockly.BlockSvg.prototype.highlightForReplacement = function(add) {
   if (add) {
     this.svgPath_.setAttribute('filter', 'url(#blocklyReplacementGlowFilter)');
+    this.svgGroup_.classList.add('blocklyReplaceable');
   } else {
     this.svgPath_.removeAttribute('filter');
+    this.svgGroup_.classList.remove('blocklyReplaceable');
   }
 };
 
@@ -523,8 +525,10 @@ Blockly.BlockSvg.prototype.highlightShapeForInput = function(conn, add) {
   var inputShape = this.inputShapes_[input.name];
   if (add) {
     inputShape.setAttribute('filter', 'url(#blocklyReplacementGlowFilter)');
+    inputShape.classList.add('blocklyReplaceable');
   } else {
     inputShape.removeAttribute('filter');
+    inputShape.classList.remove('blocklyReplaceable');
   }
 };
 


### PR DESCRIPTION
If a block is an insertion-marker, it'll have the class `blocklyInsertionMarker`. If a reporter, input, or inputShape has the replacementGlowFilter, it'll also have the class `blocklyReplaceable`.
