### PR TITLE
Explicit disabling of workspace resizing

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -445,9 +445,9 @@ Blockly.BlockSvg.prototype.moveBy = function(dx, dy) {
   this.moveConnections_(dx, dy);
   if (eventsEnabled) {
     event.recordNew();
-    this.workspace.resizeContents();
     Blockly.Events.fire(event);
   }
+  this.workspace.resizeContents();
 };
 
 /**

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -337,6 +337,8 @@ Blockly.BlockSvg.terminateDrag = function() {
       selected.setDragging_(false);
       selected.moveOffDragSurface_();
       selected.render();
+      // Re-enable workspace resizing.
+      selected.workspace.setResizesEnabled(true);
       // Ensure that any stap and bump are part of this move's event group.
       var group = Blockly.Events.getGroup();
       setTimeout(function() {
@@ -349,8 +351,6 @@ Blockly.BlockSvg.terminateDrag = function() {
         selected.bumpNeighbours_();
         Blockly.Events.setGroup(false);
       }, Blockly.BUMP_DELAY);
-      // Fire an event to allow scrollbars to resize.
-      selected.workspace.resizeContents();
     }
   }
   Blockly.dragMode_ = Blockly.DRAG_NONE;
@@ -975,6 +975,8 @@ Blockly.BlockSvg.prototype.onMouseMove_ = function(e) {
       // drag surface. By moving to the drag surface before unplug, connection
       // positions will be calculated correctly.
       this.moveToDragSurface_();
+      // Disable workspace resizing as an optimization.
+      this.workspace.setResizesEnabled(false);
       // Clear WidgetDiv/DropDownDiv without animating, in case blocks are moved
       // around
       Blockly.WidgetDiv.hide(true);

--- a/core/flyout.js
+++ b/core/flyout.js
@@ -1279,6 +1279,8 @@ Blockly.Flyout.prototype.createBlockFunc_ = function(originBlock) {
     Blockly.dragMode_ = Blockly.DRAG_FREE;
     block.setDragging_(true);
     block.moveToDragSurface_();
+    // Disable workspace resizing as an optimization.
+    flyout.targetWorkspace_.setResizesEnabled(false);
   };
 };
 

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -112,6 +112,14 @@ Blockly.WorkspaceSvg.prototype.isMutator = false;
 Blockly.WorkspaceSvg.prototype.dragMode_ = Blockly.DRAG_NONE;
 
 /**
+ * Whether this workspace has resizes enabled.
+ * Disable during batch operations for a performance improvement.
+ * @type {boolean}
+ * @private
+ */
+Blockly.WorkspaceSvg.prototype.resizesEnabled_ = true;
+
+/**
  * Current horizontal scrolling offset.
  * @type {number}
  */
@@ -418,12 +426,15 @@ Blockly.WorkspaceSvg.prototype.updateScreenCalculations_ = function() {
 };
 
 /**
- * Resize the parts of the workspace that change when the workspace
+ * If enabled, resize the parts of the workspace that change when the workspace
  * contents (e.g. block positions) change.  This will also scroll the
  * workspace contents if needed.
  * @package
  */
 Blockly.WorkspaceSvg.prototype.resizeContents = function() {
+  if (!this.resizesEnabled_) {
+    return;
+  }
   if (this.scrollbar) {
     // TODO(picklesrus): Once rachel-fenichel's scrollbar refactoring
     // is complete, call the method that only resizes scrollbar
@@ -1585,6 +1596,32 @@ Blockly.WorkspaceSvg.setTopLevelWorkspaceMetrics_ = function(xyRatio) {
     }
   }
 };
+
+/**
+ * Update whether this workspace has resizes enabled.
+ * If enabled, workspace will resize when appropriate.
+ * If disabled, workspace will not resize until re-enabled.
+ * Use to avoid resizing during a batch operation, for performance.
+ * @param {boolean} enabled Whether resizes should be enabled.
+ */
+Blockly.WorkspaceSvg.prototype.setResizesEnabled = function(enabled) {
+  var reenabled = (!this.resizesEnabled_ && enabled);
+  this.resizesEnabled_ = enabled;
+  if (reenabled) {
+    // Now enabled - trigger a resize.
+    this.resizeContents();
+  }
+};
+
+/**
+ * Dispose of all blocks in workspace, with an optimization to prevent resizes.
+ */
+Blockly.WorkspaceSvg.prototype.clear = function() {
+  this.setResizesEnabled(false);
+  Blockly.WorkspaceSvg.superClass_.clear.call(this);
+  this.setResizesEnabled(true);
+};
+
 // Export symbols that would otherwise be renamed by Closure compiler.
 Blockly.WorkspaceSvg.prototype['setVisible'] =
     Blockly.WorkspaceSvg.prototype.setVisible;

--- a/core/xml.js
+++ b/core/xml.js
@@ -291,6 +291,10 @@ Blockly.Xml.domToWorkspace = function(xml, workspace) {
   if (!existingGroup) {
     Blockly.Events.setGroup(true);
   }
+  // Disable workspace resizes as an optimization.
+  if (workspace.setResizesEnabled) {
+    workspace.setResizesEnabled(false);
+  }
   for (var i = 0; i < childCount; i++) {
     var xmlChild = xml.childNodes[i];
     var name = xmlChild.nodeName.toLowerCase();
@@ -315,6 +319,10 @@ Blockly.Xml.domToWorkspace = function(xml, workspace) {
   Blockly.Field.stopCache();
 
   workspace.updateVariableList(false);
+  // Re-enable workspace resizes, which were disabled as an optimization.
+  if (workspace.setResizesEnabled) {
+    workspace.setResizesEnabled(true);
+  }
 };
 
 /**


### PR DESCRIPTION
Should fix #639, as we discussed. Now resizing is explicitly disabled when clearing the workspace, and importing blocks from XML. But when those operations are finished, the workspace is resized in `workspace.setResizesEnabled(true)`.

As a fun experiment, I also added calls to this when a block drag begins/ends. This means the workspace is no longer resized when insertion markers are created/destroyed, which I think we also discussed at some point. It seems to work well so far!
