### PR TITLE
Move square dropdown border under text

### DIFF
--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -109,7 +109,6 @@ Blockly.FieldDropdown.prototype.init = function() {
       'height': this.size_.height,
       'stroke': this.sourceBlock_.getColourTertiary(),
       'class': 'blocklyBlockBackground'
-      
     }, null);
     this.fieldGroup_.insertBefore(this.box_, this.textElement_);
   }

--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -108,7 +108,8 @@ Blockly.FieldDropdown.prototype.init = function() {
       'width': this.size_.width,
       'height': this.size_.height,
       'stroke': this.sourceBlock_.getColourTertiary()
-    }, this.fieldGroup_);
+    }, null);
+    this.fieldGroup_.insertBefore(this.box_, this.textElement_);
   }
   // Force a reset of the text to add the arrow.
   var text = this.text_;

--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -109,6 +109,7 @@ Blockly.FieldDropdown.prototype.init = function() {
       'height': this.size_.height,
       'stroke': this.sourceBlock_.getColourTertiary(),
       'class': 'blocklyBlockBackground'
+      
     }, null);
     this.fieldGroup_.insertBefore(this.box_, this.textElement_);
   }

--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -107,7 +107,8 @@ Blockly.FieldDropdown.prototype.init = function() {
       'y': 0,
       'width': this.size_.width,
       'height': this.size_.height,
-      'stroke': this.sourceBlock_.getColourTertiary()
+      'stroke': this.sourceBlock_.getColourTertiary(),
+      'class': 'blocklyBlockBackground'
     }, null);
     this.fieldGroup_.insertBefore(this.box_, this.textElement_);
   }


### PR DESCRIPTION
For styling purposes, it's easier to have the background rect for a square dropdown behind the text element. That way, users can add a fill color to create a background for the field without covering the text.

This doesn't seem to break the click event to open the menu, although I haven't tested it on mobile.
