### PR TITLE
Switch from Replacing argType to Appending To It

### DIFF
--- a/core/field.js
+++ b/core/field.js
@@ -238,11 +238,16 @@ Blockly.Field.prototype.setVisible = function(visible) {
 };
 
 /**
- * Sets the field's argType (used for styling).
+ * Sets or appends a string to the field's argType (used for styling).
  * @param {string} argType New argType.
  */
 Blockly.Field.prototype.setArgType = function(argType) {
-  this.argType_ = argType;
+  if (this.argType_ == null) {
+    this.argType_ = '';
+  } else {
+    this.argType_ += ' ';
+  }
+  this.argType_ += argType;
 };
 
 /**

--- a/core/field.js
+++ b/core/field.js
@@ -103,8 +103,8 @@ Blockly.Field.prototype.sourceBlock_ = null;
 Blockly.Field.prototype.visible_ = true;
 
 /**
- * The field's argType (for styling).
- * @type {Blockly.Block}
+ * Null, or an array of the field's argTypes (for styling).
+ * @type {Array}
  * @private
  */
 Blockly.Field.prototype.argType_ = null;
@@ -150,12 +150,13 @@ Blockly.Field.prototype.init = function() {
     this.fieldGroup_.style.display = 'none';
   }
   // Add an attribute to cassify the type of field.
-  if (this.getArgType() !== null) {
+  if (this.getArgTypes() !== null) {
     if (this.sourceBlock_.isShadow()) {
-      this.sourceBlock_.svgGroup_.setAttribute('data-argument-type', this.getArgType());
+      this.sourceBlock_.svgGroup_.setAttribute('data-argument-type',
+          this.getArgTypes());
     } else {
       // Fields without a shadow wrapper, like square dropdowns.
-      this.fieldGroup_.setAttribute('data-argument-type', this.getArgType());
+      this.fieldGroup_.setAttribute('data-argument-type', this.getArgTypes());
     }
   }
   // Adjust X to be flipped for RTL. Position is relative to horizontal start of source block.
@@ -238,24 +239,26 @@ Blockly.Field.prototype.setVisible = function(visible) {
 };
 
 /**
- * Sets or appends a string to the field's argType (used for styling).
+ * Adds a string to the field's array of argTypes (used for styling).
  * @param {string} argType New argType.
  */
-Blockly.Field.prototype.setArgType = function(argType) {
+Blockly.Field.prototype.addArgType = function(argType) {
   if (this.argType_ == null) {
-    this.argType_ = '';
-  } else {
-    this.argType_ += ' ';
+    this.argType_ = [];
   }
-  this.argType_ += argType;
+  this.argType_.push(argType);
 };
 
 /**
- * Gets the field's argType (used for styling).
+ * Gets the field's argTypes joined as a string, or returns null (used for styling).
  * @return {string} argType string, or null.
  */
-Blockly.Field.prototype.getArgType = function() {
-  return this.argType_;
+Blockly.Field.prototype.getArgTypes = function() {
+  if (this.argType_ === null || this.argType_.length === 0) {
+    return null;
+  } else {
+    return this.argType_.join(' ');
+  }
 };
 
 /**

--- a/core/field_angle.js
+++ b/core/field_angle.js
@@ -48,7 +48,7 @@ Blockly.FieldAngle = function(text, opt_validator) {
   this.symbol_.appendChild(document.createTextNode('\u00B0'));
 
   Blockly.FieldAngle.superClass_.constructor.call(this, text, opt_validator);
-  this.setArgType('angle');
+  this.addArgType('angle');
 };
 goog.inherits(Blockly.FieldAngle, Blockly.FieldTextInput);
 

--- a/core/field_checkbox.js
+++ b/core/field_checkbox.js
@@ -43,7 +43,7 @@ Blockly.FieldCheckbox = function(state, opt_validator) {
   Blockly.FieldCheckbox.superClass_.constructor.call(this, '', opt_validator);
   // Set the initial state.
   this.setValue(state);
-  this.setArgType('checkbox');
+  this.addArgType('checkbox');
 };
 goog.inherits(Blockly.FieldCheckbox, Blockly.Field);
 

--- a/core/field_colour.js
+++ b/core/field_colour.js
@@ -46,7 +46,7 @@ goog.require('goog.ui.ColorPicker');
  */
 Blockly.FieldColour = function(colour, opt_validator) {
   Blockly.FieldColour.superClass_.constructor.call(this, colour, opt_validator);
-  this.setArgType('colour');
+  this.addArgType('colour');
 };
 goog.inherits(Blockly.FieldColour, Blockly.Field);
 

--- a/core/field_date.js
+++ b/core/field_date.js
@@ -53,7 +53,7 @@ Blockly.FieldDate = function(date, opt_validator) {
   }
   Blockly.FieldDate.superClass_.constructor.call(this, date, opt_validator);
   this.setValue(date);
-  this.setArgType('date');
+  this.addArgType('date');
 };
 goog.inherits(Blockly.FieldDate, Blockly.Field);
 

--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -58,7 +58,7 @@ Blockly.FieldDropdown = function(menuGenerator, opt_validator) {
   // Call parent's constructor.
   Blockly.FieldDropdown.superClass_.constructor.call(this, firstTuple[1],
       opt_validator);
-  this.setArgType('dropdown');
+  this.addArgType('dropdown');
 };
 goog.inherits(Blockly.FieldDropdown, Blockly.Field);
 

--- a/core/field_iconmenu.js
+++ b/core/field_iconmenu.js
@@ -45,7 +45,7 @@ Blockly.FieldIconMenu = function(icons) {
   // First icon provides the default values.
   var defaultValue = icons[0].value;
   Blockly.FieldIconMenu.superClass_.constructor.call(this, defaultValue);
-  this.setArgType('iconmenu');
+  this.addArgType('iconmenu');
 };
 goog.inherits(Blockly.FieldIconMenu, Blockly.Field);
 

--- a/core/field_number.js
+++ b/core/field_number.js
@@ -73,7 +73,7 @@ Blockly.FieldNumber = function(value, opt_min, opt_max, opt_precision, opt_valid
   this.negativeAllowed_ = (typeof opt_min == 'undefined') || isNaN(opt_min) || opt_min < 0;
   var numRestrictor = getNumRestrictor(this.decimalAllowed_, this.negativeAllowed_);
   Blockly.FieldNumber.superClass_.constructor.call(this, value, opt_validator, numRestrictor);
-  this.setArgType('number');
+  this.addArgType('number');
 };
 goog.inherits(Blockly.FieldNumber, Blockly.FieldTextInput);
 

--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -54,7 +54,7 @@ Blockly.FieldTextInput = function(text, opt_validator, opt_restrictor) {
   Blockly.FieldTextInput.superClass_.constructor.call(this, text,
       opt_validator);
   this.setRestrictor(opt_restrictor);
-  this.setArgType('text');
+  this.addArgType('text');
 };
 goog.inherits(Blockly.FieldTextInput, Blockly.Field);
 

--- a/core/field_variable.js
+++ b/core/field_variable.js
@@ -45,7 +45,7 @@ Blockly.FieldVariable = function(varname, opt_validator) {
   Blockly.FieldVariable.superClass_.constructor.call(this,
       Blockly.FieldVariable.dropdownCreate, opt_validator);
   this.setValue(varname || '');
-  this.setArgType('variable');
+  this.addArgType('variable');
 };
 goog.inherits(Blockly.FieldVariable, Blockly.FieldDropdown);
 


### PR DESCRIPTION
When a field updates its argType (its `data-argument-type` attribute), now it'll append a string instead of writing over what was there before. So you'll end up with things like `dropdown variable` and `text angle`

I'm actively experimenting with the themes to figure out what works an what doesn't, and I think this change would make it easier to style things like variable dropdowns without excessive selectors
