### PR TITLE
Remove workspace resize from FieldTextInput onchange

### DIFF
--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -332,7 +332,6 @@ Blockly.FieldTextInput.prototype.onHtmlInputChange_ = function(e) {
     this.sourceBlock_.render();
   }
   this.resizeEditor_();
-  Blockly.svgResize(this.sourceBlock_.workspace);
 };
 
 /**


### PR DESCRIPTION
There is a weird bug with the new flyout, where typing in text inputs anywhere on the page is leading the flyout to scroll. It might be worth investigating why that could be happening...but anyway. I noticed this svgResize call in the text input's typing event, and removing it makes the problem go away - but the workspace still resizes (presumably because the block changes size). If this isn't doing anything, we should probably remove it anyway?
