### PR TITLE
Cache height of the toolbox category box since it does not change.  A…

### DIFF
--- a/core/dropdowndiv.js
+++ b/core/dropdowndiv.js
@@ -386,6 +386,9 @@ Blockly.DropDownDiv.hide = function() {
  * Hide the menu, without animation.
  */
 Blockly.DropDownDiv.hideWithoutAnimation = function() {
+  if (!Blockly.DropDownDiv.isVisible()) {
+    return;
+  }
   var div = Blockly.DropDownDiv.DIV_;
   Blockly.DropDownDiv.animateOutTimer_ && window.clearTimeout(Blockly.DropDownDiv.animateOutTimer_);
   div.style.transform = '';

--- a/core/toolbox.js
+++ b/core/toolbox.js
@@ -311,13 +311,14 @@ Blockly.Toolbox.prototype.setSelectedItemFactory = function(item) {
 
 Blockly.Toolbox.CategoryMenu = function(parent, parentHtml) {
   this.parent_ = parent;
+  this.height_ = 0;
   this.parentHtml_ = parentHtml;
   this.createDom();
   this.categories_ = [];
 };
 
 Blockly.Toolbox.CategoryMenu.prototype.getHeight = function() {
-  return this.table.offsetHeight;
+  return this.height_;
 };
 
 Blockly.Toolbox.CategoryMenu.prototype.createDom = function() {
@@ -363,6 +364,7 @@ Blockly.Toolbox.CategoryMenu.prototype.populate = function(domTree) {
           categories[i + columnSeparator]));
     }
   }
+  this.height_ = this.table.offsetHeight;
 };
 
 Blockly.Toolbox.CategoryMenu.prototype.dispose = function() {


### PR DESCRIPTION
…lso only call hideWithoutAnimation on the dropdown div if it is visible (Bug #549).

Caching the height avoids a forced re-layout (because of the call to element.offsetHeight) on every mouse move event during a workspace drag.
