### PR TITLE
Fix multitouch bug on flyout drag: don't reset flyout drag mode befor…

### DIFF
--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -792,7 +792,6 @@ Blockly.Flyout.prototype.createBlockFunc_ = function(originBlock) {
  * @private
  */
 Blockly.Flyout.terminateDrag_ = function() {
-  this.dragMode_ = Blockly.DRAG_NONE;
   if (Blockly.Flyout.startFlyout_) {
     // User was dragging the flyout background, and has stopped.
     if (Blockly.Flyout.startFlyout_.dragMode_ == Blockly.DRAG_FREE) {


### PR DESCRIPTION
…e clearing touch identifier.

Leftover code that should have been cleaned out.  At least it was easy to find.

Fixes #715 
