### PR TITLE
Fix click target from merge #722

### DIFF
--- a/core/field.js
+++ b/core/field.js
@@ -174,7 +174,7 @@ Blockly.Field.prototype.init = function() {
   this.updateEditable();
   this.sourceBlock_.getSvgRoot().appendChild(this.fieldGroup_);
   this.mouseUpWrapper_ =
-      Blockly.bindEventWithChecks_(this.fieldGroup_, 'mouseup', this,
+      Blockly.bindEventWithChecks_(this.getClickTarget_(), 'mouseup', this,
       this.onMouseUp_);
   // Force a render.
   this.updateTextNode_();


### PR DESCRIPTION
This should fix the issue in #722 from the Blockly merge, where click targets for fields were not correctly set.