### PR TITLE
Build playgrounds for gh-pages

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -10,4 +10,5 @@
 /appengine/*
 /shim/*
 /dist/*
+/gh-pages/*
 /webpack.config.js

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,7 @@ python_compressed.js
 /blocks_compressed_horizontal.js
 /blocks_compressed_vertical.js
 /blocks_compressed.js
+/gh-pages/playgrounds
+/gh-pages/Gemfile.lock
+/gh-pages/closure-library
+/gh-pages/_site

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,5 @@ after_script:
     npm --no-git-tag-version version $($(npm bin)/json -f package.json version)-prerelease.$(date +%s)
     npm publish
     # Publish to gh-pages as most recent committer
-    git config --global user.email $(git log --pretty=format:"%ae" -n1)
-    git config --global user.name $(git log --pretty=format:"%an" -n1)
-    npm run --silent deploy -- -x -r https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git
+    GIT_AUTHOR_EMAIL=$(git log --pretty=format:"%ae" -n1) GIT_AUTHOR_NAME=$(git log --pretty=format:"%an" -n1) npm run --silent deploy -- -x -r https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git
   fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,4 +28,8 @@ after_script:
     # Set version to timestamp
     npm --no-git-tag-version version $($(npm bin)/json -f package.json version)-prerelease.$(date +%s)
     npm publish
+    # Publish to gh-pages as most recent committer
+    git config --global user.email $(git log --pretty=format:"%ae" -n1)
+    git config --global user.name $(git log --pretty=format:"%an" -n1)
+    npm run --silent deploy -- -x -r https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git
   fi

--- a/gh-pages/Gemfile
+++ b/gh-pages/Gemfile
@@ -1,0 +1,15 @@
+source "https://rubygems.org"
+ruby RUBY_VERSION
+
+# Hello! This is where you manage which Jekyll version is used to run.
+# When you want to use a different version, change it below, save the
+# file and run `bundle install`. Run Jekyll with `bundle exec`, like so:
+#
+#     bundle exec jekyll serve
+
+# This is the default theme for new Jekyll sites. You may change this to anything you like.
+gem "jekyll-theme-architect"
+
+# If you want to use GitHub Pages, remove the "gem "jekyll"" above and
+# uncomment the line below. To upgrade, run `bundle update github-pages`.
+gem "github-pages", group: :jekyll_plugins

--- a/gh-pages/_config.yml
+++ b/gh-pages/_config.yml
@@ -1,0 +1,2 @@
+theme: jekyll-theme-architect
+show_downloads: false

--- a/gh-pages/index.md
+++ b/gh-pages/index.md
@@ -1,0 +1,2 @@
+* [Vertical Playground](playgrounds/tests/vertical_playground.html)
+* [Horizontal Playground](playgrounds/tests/horizontal_playground.html)

--- a/package.json
+++ b/package.json
@@ -11,13 +11,16 @@
   },
   "main": "./dist/vertical.js",
   "scripts": {
+    "deploy": "gh-pages -t -d gh-pages -m \"Build for $(git log --pretty=format:%H -n1)\"",
     "prepublish": "python build.py && webpack",
     "test": "eslint .",
     "version": "json -f package.json -I -e \"this.repository.sha = '$(git log -n1 --pretty=format:%H)'\""
   },
   "devDependencies": {
+    "copy-webpack-plugin": "4.0.1",
     "eslint": "2.9.0",
     "exports-loader": "0.6.3",
+    "gh-pages": "0.12.0",
     "google-closure-library": "20160911.0.0",
     "imports-loader": "0.6.5",
     "json": "9.0.4",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,7 @@
+var CopyWebpackPlugin = require('copy-webpack-plugin');
 var path = require('path');
-module.exports = {
+
+module.exports = [{
   entry: {
     horizontal: './shim/horizontal.js',
     vertical: './shim/vertical.js'
@@ -10,4 +12,40 @@ module.exports = {
     path: path.resolve(__dirname, 'dist'),
     filename: '[name].js'
   }
-};
+}, {
+  output: {
+    filename: '[name].js',
+    path: path.resolve(__dirname, 'gh-pages')
+  },
+  plugins: [
+      new CopyWebpackPlugin([{
+        from: 'node_modules/google-closure-library',
+        to: 'closure-library'
+      }, {
+        from: 'blocks_common',
+        to: 'playgrounds/blocks_common',
+      }, {
+        from: 'blocks_horizontal',
+        to: 'playgrounds/blocks_horizontal',
+      }, {
+        from: 'blocks_vertical',
+        to: 'playgrounds/blocks_vertical',
+      }, {
+        from: 'core',
+        to: 'playgrounds/core'
+      }, {
+        from: 'media',
+        to: 'playgrounds/media'
+      }, {
+        from: 'msg',
+        to: 'playgrounds/msg'
+      }, {
+        from: 'tests',
+        to: 'playgrounds/tests'
+      }, {
+        from: '*.js',
+        ignore: 'webpack.config.js',
+        to: 'playgrounds'
+      }])
+  ]
+}];


### PR DESCRIPTION
Sets up the necessary structure in the gh-pages directory to run the uncompressed playgrounds. Deploy the gh-pages directory to the gh-pages branch after publishing to NPM.

Adds a landing page at the root to go to the horizontal and vertical playgrounds. Everything in `tests` is available under `/playgrounds/tests/` though.