### PR TITLE
Fix effect names for fuzz and robot

### DIFF
--- a/blocks_vertical/sound.js
+++ b/blocks_vertical/sound.js
@@ -274,8 +274,8 @@ Blockly.Blocks['sound_effects_menu'] = {
               ['pan left/right', 'PAN'],
               ['echo', 'ECHO'],
               ['reverb', 'REVERB'],
-              ['fuzz', 'DISTORTION'],
-              ['robot', 'ROBOTIC']
+              ['fuzz', 'FUZZ'],
+              ['robot', 'ROBOT']
             ]
           }
         ],


### PR DESCRIPTION
### Resolves

The audio effects "fuzz" and "robot" do not currently work, due to incorrect strings in the block specification.

Addresses https://github.com/LLK/scratch-audio/issues/17

### Proposed Changes

Change the strings so that they match the names used in the audio engine, at https://github.com/LLK/scratch-audio/blob/develop/src/index.js#L155-L156

### Reason for Changes

Turn both of these effects up to 100 and your sprite will sound like a dalek!

### Test Coverage

No tests.