### PR TITLE
(Fixes #783) Check if block is real before checking if it's a shadow

### DIFF
--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -237,13 +237,11 @@ Blockly.FieldDropdown.prototype.onHide = function() {
   this.dropDownOpen_ = false;
   // Update colour to look selected.
   if (!this.disableColourChange_) {
-    if (this.sourceBlock_) {
-      if (this.sourceBlock_.isShadow()) {
-        this.sourceBlock_.setColour(this.savedPrimary_,
-          this.sourceBlock_.getColourSecondary(), this.sourceBlock_.getColourTertiary());
-      } else if (this.box_) {
-        this.box_.setAttribute('fill', this.sourceBlock_.getColour());
-      }
+    if (this.sourceBlock_ && this.sourceBlock_.isShadow()) {
+      this.sourceBlock_.setColour(this.savedPrimary_,
+        this.sourceBlock_.getColourSecondary(), this.sourceBlock_.getColourTertiary());
+    } else if (this.box_) {
+      this.box_.setAttribute('fill', this.sourceBlock_.getColour());
     }
   }
 };

--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -238,12 +238,12 @@ Blockly.FieldDropdown.prototype.onHide = function() {
   // Update colour to look selected.
   if (!this.disableColourChange_) {
     if (this.sourceBlock_) {
-     if (this.sourceBlock_.isShadow()) {
-       this.sourceBlock_.setColour(this.savedPrimary_,
-         this.sourceBlock_.getColourSecondary(), this.sourceBlock_.getColourTertiary());
-     } else if (this.box_) {
-       this.box_.setAttribute('fill', this.sourceBlock_.getColour());
-     }
+      if (this.sourceBlock_.isShadow()) {
+        this.sourceBlock_.setColour(this.savedPrimary_,
+          this.sourceBlock_.getColourSecondary(), this.sourceBlock_.getColourTertiary());
+      } else if (this.box_) {
+        this.box_.setAttribute('fill', this.sourceBlock_.getColour());
+      }
     }
   }
 };

--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -237,11 +237,13 @@ Blockly.FieldDropdown.prototype.onHide = function() {
   this.dropDownOpen_ = false;
   // Update colour to look selected.
   if (!this.disableColourChange_) {
-    if (this.sourceBlock_ && this.sourceBlock_.isShadow()) {
-      this.sourceBlock_.setColour(this.savedPrimary_,
-        this.sourceBlock_.getColourSecondary(), this.sourceBlock_.getColourTertiary());
-    } else if (this.box_) {
-      this.box_.setAttribute('fill', this.sourceBlock_.getColour());
+    if (this.sourceBlock_) {
+      if (this.sourceBlock_.isShadow()) {
+        this.sourceBlock_.setColour(this.savedPrimary_,
+          this.sourceBlock_.getColourSecondary(), this.sourceBlock_.getColourTertiary());
+      } else if (this.box_) {
+        this.box_.setAttribute('fill', this.sourceBlock_.getColour());
+      }
     }
   }
 };

--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -236,14 +236,12 @@ Blockly.FieldDropdown.prototype.showEditor_ = function() {
 Blockly.FieldDropdown.prototype.onHide = function() {
   this.dropDownOpen_ = false;
   // Update colour to look selected.
-  if (!this.disableColourChange_) {
-    if (this.sourceBlock_) {
-      if (this.sourceBlock_.isShadow()) {
-        this.sourceBlock_.setColour(this.savedPrimary_,
-          this.sourceBlock_.getColourSecondary(), this.sourceBlock_.getColourTertiary());
-      } else if (this.box_) {
-        this.box_.setAttribute('fill', this.sourceBlock_.getColour());
-      }
+  if (!this.disableColourChange_ && this.sourceBlock_) {
+    if (this.sourceBlock_.isShadow()) {
+      this.sourceBlock_.setColour(this.savedPrimary_,
+        this.sourceBlock_.getColourSecondary(), this.sourceBlock_.getColourTertiary());
+    } else if (this.box_) {
+      this.box_.setAttribute('fill', this.sourceBlock_.getColour());
     }
   }
 };

--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -237,11 +237,13 @@ Blockly.FieldDropdown.prototype.onHide = function() {
   this.dropDownOpen_ = false;
   // Update colour to look selected.
   if (!this.disableColourChange_) {
-    if (this.sourceBlock_.isShadow()) {
-      this.sourceBlock_.setColour(this.savedPrimary_,
-        this.sourceBlock_.getColourSecondary(), this.sourceBlock_.getColourTertiary());
-    } else if (this.box_) {
-      this.box_.setAttribute('fill', this.sourceBlock_.getColour());
+    if (this.sourceBlock_) {
+     if (this.sourceBlock_.isShadow()) {
+       this.sourceBlock_.setColour(this.savedPrimary_,
+         this.sourceBlock_.getColourSecondary(), this.sourceBlock_.getColourTertiary());
+     } else if (this.box_) {
+       this.box_.setAttribute('fill', this.sourceBlock_.getColour());
+     }
     }
   }
 };


### PR DESCRIPTION
### Resolves

Issue #783 -  Opening dropdown in a block in the flyout and switching categories causes js error - [link](https://github.com/LLK/scratch-blocks/issues/783)

### Proposed Changes

This checks if `this.sourceBlock_` is real before checking `this.sourceBlock_.isShadow()`.

### Reason for Changes

This prevents the error `TypeError: this.sourceBlock_ is null`, which prevents the stage from being panned after it is triggered.

### Test Coverage

I don't see what tests are needed. Upon using `npm install` to recompile, doing the steps that would replicate the error instead work as intended.
