### PR TITLE
Fix updateToolbox

### DIFF
--- a/core/toolbox.js
+++ b/core/toolbox.js
@@ -372,6 +372,9 @@ Blockly.Toolbox.CategoryMenu.prototype.populate = function(domTree) {
     return;
   }
 
+  // Remove old categories
+  this.dispose();
+  this.createDom();
   var categories = [];
   // Find actual categories from the DOM tree.
   for (var i = 0, child; child = domTree.childNodes[i]; i++) {

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1438,7 +1438,6 @@ Blockly.WorkspaceSvg.prototype.updateToolbox = function(tree) {
     }
     this.options.languageTree = tree;
     this.toolbox_.populate_(tree);
-    this.toolbox_.addColour_();
   } else {
     if (!this.flyout_) {
       throw 'Existing toolbox has categories.  Can\'t change mode.';
@@ -1446,6 +1445,7 @@ Blockly.WorkspaceSvg.prototype.updateToolbox = function(tree) {
     this.options.languageTree = tree;
     this.flyout_.show(tree.childNodes);
   }
+  this.toolbox_.position();
 };
 
 /**


### PR DESCRIPTION
I think this method broke in a merge.  We are recreating the category DOM element on init, but this seems to be the simplest solution for now.

Thanks to @rachel-fenichel for helping fix it.
