### PR TITLE
Fit Context Menu Height to Menu

### DIFF
--- a/core/contextmenu.js
+++ b/core/contextmenu.js
@@ -46,6 +46,7 @@ Blockly.ContextMenu.currentBlock = null;
  * @param {boolean} rtl True if RTL, false if LTR.
  */
 Blockly.ContextMenu.show = function(e, options, rtl) {
+  var menuHeight = 0;
   Blockly.WidgetDiv.show(Blockly.ContextMenu, rtl, null);
   if (!options.length) {
     Blockly.ContextMenu.hide();
@@ -104,8 +105,11 @@ Blockly.ContextMenu.show = function(e, options, rtl) {
       x -= menuSize.width;
     }
   }
-  Blockly.WidgetDiv.position(x, y, windowSize, scrollOffset, rtl);
-
+  menu.children_.forEach(function(element) {
+    menuHeight += element.element_.clientHeight;
+  });
+  Blockly.WidgetDiv.position(x, y, {height: menuHeight, width: windowSize}, scrollOffset, rtl);
+  
   menu.setAllowAutoFocus(true);
   // 1ms delay is required for focusing on context menus because some other
   // mouse event is still waiting in the queue and clears focus.


### PR DESCRIPTION
### Resolves

Resolves LLK/scratch-gui#111

### Proposed Changes

Calculate div height from as the sum of the heights of all the menu items instead of passing the window height.

### Reason for Changes

Making the menu fit the content prevents scroll bar creation. Possible exception at the very bottom of the screen, but that should be fixed by limiting x & y in a different pull request.

### Test Coverage

None added.