### PR TITLE
Do not accept an input for some drop-down menus

### DIFF
--- a/blocks_vertical/default_toolbox.js
+++ b/blocks_vertical/default_toolbox.js
@@ -196,9 +196,6 @@ Blockly.Blocks.defaultToolbox = '<xml id="toolbox-categories" style="display: no
       '</value>'+
     '</block>'+
     '<block type="looks_changeeffectby">'+
-      '<value name="EFFECT">'+
-        '<shadow type="looks_effectmenu"></shadow>'+
-      '</value>'+
       '<value name="CHANGE">'+
         '<shadow type="math_number">'+
           '<field name="NUM">10</field>'+
@@ -206,9 +203,6 @@ Blockly.Blocks.defaultToolbox = '<xml id="toolbox-categories" style="display: no
       '</value>'+
     '</block>'+
     '<block type="looks_seteffectto">'+
-      '<value name="EFFECT">'+
-        '<shadow type="looks_effectmenu"></shadow>'+
-      '</value>'+
       '<value name="VALUE">'+
         '<shadow type="math_number">'+
           '<field name="NUM">10</field>'+
@@ -289,23 +283,17 @@ Blockly.Blocks.defaultToolbox = '<xml id="toolbox-categories" style="display: no
         '<shadow type="sound_instruments_menu"></shadow>' +
       '</value>' +
     '</block>'+
-    '<block type="sound_seteffectto">' +
-      '<value name="EFFECT">' +
-        '<shadow type="sound_effects_menu"></shadow>' +
-      '</value>' +
-      '<value name="VALUE">' +
-        '<shadow type="math_number">'+
-          '<field name="NUM">100</field>'+
-        '</shadow>'+
-      '</value>' +
-    '</block>' +
     '<block type="sound_changeeffectby">' +
-      '<value name="EFFECT">' +
-        '<shadow type="sound_effects_menu"></shadow>' +
-      '</value>' +
       '<value name="VALUE">' +
         '<shadow type="math_number">'+
           '<field name="NUM">10</field>'+
+        '</shadow>'+
+      '</value>' +
+    '</block>' +
+    '<block type="sound_seteffectto">' +
+      '<value name="VALUE">' +
+        '<shadow type="math_number">'+
+          '<field name="NUM">100</field>'+
         '</shadow>'+
       '</value>' +
     '</block>' +
@@ -741,9 +729,6 @@ Blockly.Blocks.defaultToolbox = '<xml id="toolbox-categories" style="display: no
       '</value>'+
     '</block>'+
     '<block type="operator_mathop">'+
-      '<value name="OPERATOR">'+
-        '<shadow type="operator_mathop_menu"></shadow>'+
-      '</value>'+
       '<value name="NUM">'+
         '<shadow type="math_number">'+
           '<field name="NUM"></field>'+

--- a/blocks_vertical/default_toolbox.js
+++ b/blocks_vertical/default_toolbox.js
@@ -128,11 +128,7 @@ Blockly.Blocks.defaultToolbox = '<xml id="toolbox-categories" style="display: no
       '</value>'+
     '</block>'+
     '<block type="motion_ifonedgebounce"></block>'+
-    '<block type="motion_setrotationstyle">'+
-      '<value name="STYLE">'+
-        '<shadow type="motion_setrotationstyle_menu"></shadow>'+
-      '</value>'+
-    '</block>'+
+    '<block type="motion_setrotationstyle"></block>'+
     '<block type="motion_xposition"></block>'+
     '<block type="motion_yposition"></block>'+
     '<block type="motion_direction"></block>'+

--- a/blocks_vertical/looks.js
+++ b/blocks_vertical/looks.js
@@ -169,39 +169,15 @@ Blockly.Blocks['looks_hide'] = {
   }
 };
 
-Blockly.Blocks['looks_effectmenu'] = {
-  /**
-   * Graphic effects drop-down menu.
-   * @this Blockly.Block
-   */
-  init: function() {
-    this.jsonInit(
-      {
-        "message0": "%1",
-        "args0": [
-          {
-            "type": "field_dropdown",
-            "name": "EFFECT",
-            "options": [
-              ['color', 'COLOR'],
-              ['fisheye', 'FISHEYE'],
-              ['whirl', 'WHIRL'],
-              ['pixelate', 'PIXELATE'],
-              ['mosaic', 'MOSAIC'],
-              ['brightness', 'BRIGHTNESS'],
-              ['ghost', 'GHOST']
-            ]
-          }
-        ],
-        "inputsInline": true,
-        "output": "String",
-        "colour": Blockly.Colours.looks.secondary,
-        "colourSecondary": Blockly.Colours.looks.secondary,
-        "colourTertiary": Blockly.Colours.looks.tertiary,
-        "outputShape": Blockly.OUTPUT_SHAPE_ROUND
-      });
-  }
-};
+Blockly.Blocks['looks_effect_menu_options'] = [
+  ['color', 'COLOR'],
+  ['fisheye', 'FISHEYE'],
+  ['whirl', 'WHIRL'],
+  ['pixelate', 'PIXELATE'],
+  ['mosaic', 'MOSAIC'],
+  ['brightness', 'BRIGHTNESS'],
+  ['ghost', 'GHOST']
+];
 
 Blockly.Blocks['looks_changeeffectby'] = {
   /**
@@ -213,8 +189,9 @@ Blockly.Blocks['looks_changeeffectby'] = {
       "message0": "change effect %1 by %2",
       "args0": [
         {
-          "type": "input_value",
-          "name": "EFFECT"
+          "type": "field_dropdown",
+          "name": "EFFECT",
+          "options": Blockly.Blocks['looks_effect_menu_options']
         },
         {
           "type": "input_value",
@@ -242,8 +219,9 @@ Blockly.Blocks['looks_seteffectto'] = {
       "message0": "set effect %1 to %2",
       "args0": [
         {
-          "type": "input_value",
-          "name": "EFFECT"
+          "type": "field_dropdown",
+          "name": "EFFECT",
+          "options": Blockly.Blocks['looks_effect_menu_options']
         },
         {
           "type": "input_value",

--- a/blocks_vertical/motion.js
+++ b/blocks_vertical/motion.js
@@ -426,36 +426,6 @@ Blockly.Blocks['motion_ifonedgebounce'] = {
   }
 };
 
-Blockly.Blocks['motion_setrotationstyle_menu'] = {
-  /**
-   * Rotation style drop-down menu.
-   * @this Blockly.Block
-   */
-  init: function() {
-    this.jsonInit(
-      {
-        "message0": "%1",
-        "args0": [
-          {
-            "type": "field_dropdown",
-            "name": "STYLE",
-            "options": [
-              ['left-right', 'left-right'],
-              ['don\'t rotate', 'don\'t rotate'],
-              ['all around', 'all around']
-            ]
-          }
-        ],
-        "inputsInline": true,
-        "output": "String",
-        "colour": Blockly.Colours.motion.secondary,
-        "colourSecondary": Blockly.Colours.motion.secondary,
-        "colourTertiary": Blockly.Colours.motion.tertiary,
-        "outputShape": Blockly.OUTPUT_SHAPE_ROUND
-      });
-  }
-};
-
 Blockly.Blocks['motion_setrotationstyle'] = {
   /**
    * Block to set rotation style.
@@ -466,8 +436,13 @@ Blockly.Blocks['motion_setrotationstyle'] = {
       "message0": "set rotation style %1",
       "args0": [
         {
-          "type": "input_value",
-          "name": "STYLE"
+          "type": "field_dropdown",
+          "name": "STYLE",
+          "options": [
+            ['left-right', 'left-right'],
+            ['don\'t rotate', 'don\'t rotate'],
+            ['all around', 'all around']
+          ]
         }
       ],
       "previousStatement": null,

--- a/blocks_vertical/operators.js
+++ b/blocks_vertical/operators.js
@@ -491,15 +491,15 @@ Blockly.Blocks['operator_round'] = {
   }
 };
 
-Blockly.Blocks['operator_mathop_menu'] = {
+Blockly.Blocks['operator_mathop'] = {
   /**
-   * Math ops drop-down menu.
+   * Block for "advanced" math ops on a number.
    * @this Blockly.Block
    */
   init: function() {
     this.jsonInit(
       {
-        "message0": "%1",
+        "message0": "%1 of %2",
         "args0": [
           {
             "type": "field_dropdown",
@@ -520,31 +520,6 @@ Blockly.Blocks['operator_mathop_menu'] = {
               ['e ^', 'e ^'],
               ['10 ^', '10 ^']
             ]
-          }
-        ],
-        "inputsInline": true,
-        "output": "String",
-        "colour": Blockly.Colours.operators.secondary,
-        "colourSecondary": Blockly.Colours.operators.secondary,
-        "colourTertiary": Blockly.Colours.operators.tertiary,
-        "outputShape": Blockly.OUTPUT_SHAPE_ROUND
-      });
-  }
-};
-
-Blockly.Blocks['operator_mathop'] = {
-  /**
-   * Block for "advanced" math ops on a number.
-   * @this Blockly.Block
-   */
-  init: function() {
-    this.jsonInit(
-      {
-        "message0": "%1 of %2",
-        "args0": [
-          {
-            "type": "input_value",
-            "name": "OPERATOR"
           },
           {
             "type": "input_value",

--- a/blocks_vertical/sound.js
+++ b/blocks_vertical/sound.js
@@ -26,7 +26,6 @@ goog.require('Blockly.Blocks');
 goog.require('Blockly.Colours');
 goog.require('Blockly.constants');
 
-
 Blockly.Blocks['sound_sounds_menu'] = {
   /**
    * Sound effects drop-down menu.
@@ -256,38 +255,14 @@ Blockly.Blocks['sound_playnoteforbeats'] = {
   }
 };
 
-Blockly.Blocks['sound_effects_menu'] = {
-  /**
-   * Sound effects drop-down menu.
-   * @this Blockly.Block
-   */
-  init: function() {
-    this.jsonInit(
-      {
-        "message0": "%1",
-        "args0": [
-          {
-            "type": "field_dropdown",
-            "name": "EFFECT",
-            "options": [
-              ['pitch', 'PITCH'],
-              ['pan left/right', 'PAN'],
-              ['echo', 'ECHO'],
-              ['reverb', 'REVERB'],
-              ['fuzz', 'FUZZ'],
-              ['robot', 'ROBOT']
-            ]
-          }
-        ],
-        "inputsInline": true,
-        "output": "String",
-        "colour": Blockly.Colours.sounds.secondary,
-        "colourSecondary": Blockly.Colours.sounds.secondary,
-        "colourTertiary": Blockly.Colours.sounds.tertiary,
-        "outputShape": Blockly.OUTPUT_SHAPE_ROUND
-      });
-  }
-};
+Blockly.Blocks['sound_effects_menu_options'] = [
+  ['pitch', 'PITCH'],
+  ['pan left/right', 'PAN'],
+  ['echo', 'ECHO'],
+  ['reverb', 'REVERB'],
+  ['fuzz', 'FUZZ'],
+  ['robot', 'ROBOT']
+];
 
 Blockly.Blocks['sound_seteffectto'] = {
   /**
@@ -299,8 +274,9 @@ Blockly.Blocks['sound_seteffectto'] = {
       "message0": "set effect %1 to %2",
       "args0": [
         {
-          "type": "input_value",
-          "name": "EFFECT"
+          "type": "field_dropdown",
+          "name": "EFFECT",
+          "options": Blockly.Blocks['sound_effects_menu_options']
         },
         {
           "type": "input_value",
@@ -327,8 +303,9 @@ Blockly.Blocks['sound_changeeffectby'] = {
       "message0": "change effect %1 by %2",
       "args0": [
         {
-          "type": "input_value",
-          "name": "EFFECT"
+          "type": "field_dropdown",
+          "name": "EFFECT",
+          "options": Blockly.Blocks['sound_effects_menu_options']
         },
         {
           "type": "input_value",
@@ -351,7 +328,7 @@ Blockly.Blocks['sound_cleareffects'] = {
    */
   init: function() {
     this.jsonInit({
-      "message0": "clear audio effects",
+      "message0": "clear sound effects",
       "previousStatement": null,
       "nextStatement": null,
       "colour": Blockly.Colours.sounds.primary,


### PR DESCRIPTION
### Resolves

GH-827

### Proposed Changes

- Removes the ability to accept an input from some drop-down menus
    - `motion_setrotationstyle`
    - `looks_changeeffectby `
    - `looks_seteffectto`
    - `sound_changeeffectby`
    - `sound_seteffectto `
    - `operator_mathop`
- Reorder sound effects blocks to match graphic effects sort order
- Minor adjustment to sound effects "clear" block language