### PR TITLE
Fix borders around the panels

### DIFF
--- a/core/css.js
+++ b/core/css.js
@@ -187,6 +187,7 @@ Blockly.Css.CONTENT = [
     'height: 100%;',
     'position: relative;',
     'overflow: hidden;', /* So blocks in drag surface disappear at edges */
+    'border: 1px solid #ddd;',
   '}',
 
   '.blocklyNonSelectable {',
@@ -439,6 +440,7 @@ Blockly.Css.CONTENT = [
   '.blocklyFlyout {',
     'position: absolute;',
     'z-index: 20;',
+    'border-right: 1px solid #ddd',
   '}',
   '.blocklyFlyoutButton {',
     'fill: #888;',
@@ -528,11 +530,6 @@ Blockly.Css.CONTENT = [
     'text-align: center;',
     'color: $colour_text;',
     'font-weight: 500;',
-  '}',
-
-  '.blocklyMainBackground {',
-    'stroke-width: 1;',
-    'stroke: #c6c6c6;',  /* Equates to #ddd due to border being off-pixel. */
   '}',
 
   '.blocklyMutatorBackground {',
@@ -641,6 +638,9 @@ Blockly.Css.CONTENT = [
     'position: absolute;',
     'font-family: "Helvetica Neue", Helvetica, sans-serif;',
     'z-index: 40;', /* so blocks go over toolbox when dragging */
+    'box-sizing: content-box;',
+    'border-right: 1px solid #ddd;',
+    'border-bottom: 1px solid #ddd;',
   '}',
 
   '.blocklyTreeRoot {',


### PR DESCRIPTION
Fix the wonky borders to correspond more closely with the mocks. 

Old
<img width="1031" alt="screen shot 2017-03-09 at 3 30 05 pm" src="https://cloud.githubusercontent.com/assets/654102/23769556/cd7f877e-04dd-11e7-979c-54bc88e1dfab.png">

New
<img width="1047" alt="screen shot 2017-03-09 at 3 35 14 pm" src="https://cloud.githubusercontent.com/assets/654102/23769631/0a2f1c66-04de-11e7-9ab8-54fa4b23df43.png">
