### PR TITLE
Reduce block margin

### DIFF
--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -219,7 +219,7 @@ Blockly.Flyout.prototype.DRAG_RADIUS = 10;
  * @type {number}
  * @const
  */
-Blockly.Flyout.prototype.MARGIN = 12;
+Blockly.Flyout.prototype.MARGIN = 4;
 
 /**
  * Gap between items in horizontal flyouts. Can be overridden with the "sep"

--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -219,7 +219,7 @@ Blockly.Flyout.prototype.DRAG_RADIUS = 10;
  * @type {number}
  * @const
  */
-Blockly.Flyout.prototype.MARGIN = 4;
+Blockly.Flyout.prototype.MARGIN = 12;
 
 /**
  * Gap between items in horizontal flyouts. Can be overridden with the "sep"
@@ -233,7 +233,7 @@ Blockly.Flyout.prototype.GAP_X = Blockly.Flyout.prototype.MARGIN * 3;
  * element.
  * @const {number}
  */
-Blockly.Flyout.prototype.GAP_Y = Blockly.Flyout.prototype.MARGIN * 3;
+Blockly.Flyout.prototype.GAP_Y = Blockly.Flyout.prototype.MARGIN;
 
 /**
  * Top/bottom padding between scrollbar and edge of flyout background.


### PR DESCRIPTION
<img width="758" alt="screen shot 2017-03-09 at 4 26 30 pm" src="https://cloud.githubusercontent.com/assets/654102/23772080/a9d38456-04e7-11e7-812b-58bb9b7c1eb4.png">

Compare with old
<img width="564" alt="12-default" src="https://cloud.githubusercontent.com/assets/654102/23772081/ab7ca1f2-04e7-11e7-901c-e326fe5e74f9.png">

---
Fixes https://github.com/LLK/scratch-gui/issues/164

Checked in on this with @jwzimmer and @carljbowman, they 👍 