### PR TITLE
Fix hat block spacing

### DIFF
--- a/core/flyout_vertical.js
+++ b/core/flyout_vertical.js
@@ -421,7 +421,7 @@ Blockly.VerticalFlyout.prototype.layout_ = function(contents, gaps) {
 
       this.addBlockListeners_(root, block, rect);
 
-      cursorY += blockHW.height + gaps[i];
+      cursorY += blockHW.height + gaps[i] + (block.startHat_ ? Blockly.BlockSvg.START_HAT_HEIGHT : 0);
     } else if (item.type == 'button') {
       var button = item.button;
       var buttonSvg = button.createDom();


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_
Fixes https://github.com/LLK/scratch-blocks/issues/838
### Proposed Changes

_Describe what this Pull Request does_
Adds `Blockly.BlockSvg.START_HAT_HEIGHT` to the y offset in the flyout `layout` method for hat blocks. This offset was being added to the top, but not to the y offset for the bottom, squishing blocks together.

### Reason for Changes

_Explain why these changes should be made_
Bug reported https://github.com/LLK/scratch-blocks/issues/838

Incidentally this problem actually already existed, it just wasn't as obvious because of the previous large spacing. You can tell looking back before the margin that something wasn't right:
![screen shot 2017-03-13 at 9 43 36 am](https://cloud.githubusercontent.com/assets/654102/23856982/e7efecb0-07d1-11e7-8096-45d548b9e16f.png)

### Test Coverage

Here are some before/after screenshots:
Before
![screen shot 2017-03-13 at 9 42 33 am](https://cloud.githubusercontent.com/assets/654102/23856993/f6cc026e-07d1-11e7-8057-e2f7953351fe.png)

After
![screen shot 2017-03-13 at 9 41 23 am](https://cloud.githubusercontent.com/assets/654102/23857002/fecbfea6-07d1-11e7-8401-3ef775c4918a.png)

