### PR TITLE
Use one mousemove handler and remove it when an angle is selected by …

### DIFF
--- a/core/field_angle.js
+++ b/core/field_angle.js
@@ -143,7 +143,7 @@ Blockly.FieldAngle.prototype.showEditor_ = function() {
     'height': (Blockly.FieldAngle.HALF * 2) + 'px',
     'width': (Blockly.FieldAngle.HALF * 2) + 'px'
   }, div);
-  var circle = Blockly.utils.createSvgElement('circle', {
+  Blockly.utils.createSvgElement('circle', {
     'cx': Blockly.FieldAngle.HALF, 'cy': Blockly.FieldAngle.HALF,
     'r': Blockly.FieldAngle.RADIUS,
     'class': 'blocklyAngleCircle'

--- a/core/field_angle.js
+++ b/core/field_angle.js
@@ -115,11 +115,8 @@ Blockly.FieldAngle.prototype.dispose_ = function() {
     if (thisField.clickWrapper_) {
       Blockly.unbindEvent_(thisField.clickWrapper_);
     }
-    if (thisField.moveWrapper1_) {
-      Blockly.unbindEvent_(thisField.moveWrapper1_);
-    }
-    if (thisField.moveWrapper2_) {
-      Blockly.unbindEvent_(thisField.moveWrapper2_);
+    if (thisField.moveWrapper_) {
+      Blockly.unbindEvent_(thisField.moveWrapper_);
     }
   };
 };
@@ -184,12 +181,10 @@ Blockly.FieldAngle.prototype.showEditor_ = function() {
       Blockly.bindEvent_(svg, 'click', this, function() {
         Blockly.WidgetDiv.hide();
         Blockly.DropDownDiv.hide();
+        Blockly.unbindEvent_(this.moveWrapper_);
       });
-  this.moveWrapper1_ =
-      Blockly.bindEvent_(circle, 'mousemove', this, this.onMouseMove);
-  this.moveWrapper2_ =
-      Blockly.bindEvent_(this.gauge_, 'mousemove', this,
-      this.onMouseMove);
+  this.moveWrapper_ =
+      Blockly.bindEvent_(svg, 'mousemove', this, this.onMouseMove);
   this.updateGraph_();
 };
 


### PR DESCRIPTION
…clicking.

### Resolves

https://github.com/LLK/scratch-blocks/issues/843

### Proposed Changes

Remove the mouse move listener when an angle is picked by clicking.

### Reason for Changes

The selection element shouldn't be interactive after clicking.

### Test Coverage


