### PR TITLE
Fix #826 by forcing a re-render of the field when the text input is d…

### DIFF
--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -489,7 +489,8 @@ Blockly.FieldTextInput.prototype.widgetDispose_ = function() {
       }
     }
     thisField.setText(text);
-    thisField.sourceBlock_.rendered && thisField.sourceBlock_.render();
+    // Rerender the field now that the text has changed.
+    thisField.sourceBlock_.rendered && thisField.render_();
     Blockly.unbindEvent_(htmlInput.onKeyDownWrapper_);
     Blockly.unbindEvent_(htmlInput.onKeyUpWrapper_);
     Blockly.unbindEvent_(htmlInput.onKeyPressWrapper_);


### PR DESCRIPTION
…isposed.  Rendering the whole block does not necessarily cause the field to render.

### Resolves

https://github.com/LLK/scratch-blocks/issues/826

### Proposed Changes

Render the field text input when the user is done editing a text input since the new text has been set.
