### PR TITLE
Copy entire stack on duplicate

### DIFF
--- a/core/blockly.js
+++ b/core/blockly.js
@@ -292,9 +292,9 @@ Blockly.terminateDrag_ = function() {
  */
 Blockly.copy_ = function(block) {
   var xmlBlock = Blockly.Xml.blockToDom(block);
-  if (Blockly.dragMode_ != Blockly.DRAG_FREE) {
-    Blockly.Xml.deleteNext(xmlBlock);
-  }
+  // if (Blockly.dragMode_ != Blockly.DRAG_FREE) {
+  //   Blockly.Xml.deleteNext(xmlBlock);
+  // }
   // Encode start position in XML.
   var xy = block.getRelativeToSurfaceXY();
   xmlBlock.setAttribute('x', block.RTL ? -xy.x : xy.x);

--- a/core/blockly.js
+++ b/core/blockly.js
@@ -292,9 +292,6 @@ Blockly.terminateDrag_ = function() {
  */
 Blockly.copy_ = function(block) {
   var xmlBlock = Blockly.Xml.blockToDom(block);
-  // if (Blockly.dragMode_ != Blockly.DRAG_FREE) {
-  //   Blockly.Xml.deleteNext(xmlBlock);
-  // }
   // Encode start position in XML.
   var xy = block.getRelativeToSurfaceXY();
   xmlBlock.setAttribute('x', block.RTL ? -xy.x : xy.x);


### PR DESCRIPTION
Instead of copying a single block, copy the entire stack of connected blocks. Fixes https://github.com/LLK/scratch-blocks/issues/823 by @rachel-fenichel's final suggestion of just removing the `if` block. I left it in there commented out because I thought it would make upstream merges easier, but @thisandagain I'm not sure if that is the right way. 

Pinning the new blocks to the cursor is still open in https://github.com/LLK/scratch-blocks/issues/828