### PR TITLE
Fix allUsedVariables not returning non-predefined variables

### DIFF
--- a/core/variables.js
+++ b/core/variables.js
@@ -65,7 +65,7 @@ Blockly.Variables.allUsedVariables = function(root) {
       for (var y = 0; y < blockVariables.length; y++) {
         var varName = blockVariables[y];
         // Variable name may be null if the block is only half-built.
-        if (varName && !varName.toLowerCase() == ignorableName) {
+        if (varName && varName.toLowerCase() != ignorableName) {
           variableHash[varName.toLowerCase()] = varName;
         }
       }


### PR DESCRIPTION
### Resolves

#837 

### Proposed Changes

Correctly return variables in Blockly.Variables.allUsedVariables.

### Reason for Changes

Fixed a bug that caused an if condition to always return false.

### Test Coverage

N/A
