### PR TITLE
Fixed a bug that context menu goes outside the script region

### DIFF
--- a/core/css.js
+++ b/core/css.js
@@ -815,7 +815,6 @@ Blockly.Css.CONTENT = [
     'position: absolute;',
     'overflow-y: auto;',
     'overflow-x: hidden;',
-    'max-height: 100%;',
     'z-index: 20000;',  /* Arbitrary, but some apps depend on it... */
   '}',
 


### PR DESCRIPTION
fixed a bug that context menu goes outside the script region, causing the scrollbar showing up.

### Resolves

scratch-gui [issue 111](https://github.com/LLK/scratch-gui/issues/111)

### Proposed Changes

removed unnecessary max-height style in the context menu (right-click menu)

### Reason for Changes

This is because in Blockly, the position of context menu is determined by its height + the mouse y position (see core/contextmenu.js:98);

That means if the menu is showing below the bottom of the screen,
it will jump upwards instead.

When this max-height is in effect, it prevents Blockly to calculate the actual height of the menu with menu items.

