### PR TITLE
[Issue-796] adding undefined check before trying to position category…

### DIFF
--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1475,15 +1475,13 @@ Blockly.WorkspaceSvg.prototype.updateToolbox = function(tree) {
     }
     this.options.languageTree = tree;
     this.toolbox_.populate_(tree);
+    this.toolbox_.position();
   } else {
     if (!this.flyout_) {
       throw 'Existing toolbox has categories.  Can\'t change mode.';
     }
     this.options.languageTree = tree;
     this.flyout_.show(tree.childNodes);
-  }
-  if (this.toolbox_) {
-    this.toolbox_.position();
   }
 };
 

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1482,7 +1482,9 @@ Blockly.WorkspaceSvg.prototype.updateToolbox = function(tree) {
     this.options.languageTree = tree;
     this.flyout_.show(tree.childNodes);
   }
-  this.toolbox_.position();
+  if (this.toolbox_) {
+    this.toolbox_.position();
+  }
 };
 
 /**


### PR DESCRIPTION
Adding a check for undefined for the case when no categories are defined in the toolbox and updateToolbox is called. 

### Resolves

This resolves issue 796: https://github.com/LLK/scratch-blocks/issues/796
This issue was introduced in this PR: https://github.com/LLK/scratch-blocks/pull/793

### Proposed Changes

Adding an undefined check before attempting to call position() on this.toolbox_, which only exists in the case that the toolbox has categories.

### Reason for Changes

To avoid a console error.

### Test Coverage

No tests added as its fixing existing functionality. 

### Questions

Any naming conventions around branch naming? Should I use bugfix/* next time? Seems this doesn't matter though. 
I am also NOT including a post-compiled version of the lib as I see other PR's don't do this.
Also wondering if I need to link this PR to the original issue somehow, or if github somehow magically does this. 