### PR TITLE
Initialize local scrollX variable.

### DIFF
--- a/core/flyout_vertical.js
+++ b/core/flyout_vertical.js
@@ -616,6 +616,7 @@ Blockly.VerticalFlyout.prototype.placeNewBlock_ = function(originBlock) {
   // If the flyout is on the right side, (0, 0) in the flyout is offset to
   // the right of (0, 0) in the main workspace.  Add an offset to take that
   // into account.
+  var scrollX = 0;
   if (this.toolboxPosition_ == Blockly.TOOLBOX_AT_RIGHT) {
     scrollX = targetMetrics.viewWidth - this.width_;
     // Scale the scroll (getSvgXY_ did not do this).


### PR DESCRIPTION
We were using a local scrollX variable in the vertical flyout without initializing it.
https://github.com/LLK/scratch-blocks/commit/2ea8bc21d284d35800c2be0f01a62f460d035357 commented out the initialization a while back and probably didn't mean to.

I found this because the closure compiler complained about it.

@rachel-fenichel, I'm happy to remove the line above where your commit commented out the original initialization but wanted to check why you left it there first.