### PR TITLE
fixed scroll position calculation

### DIFF
--- a/core/scrollbar.js
+++ b/core/scrollbar.js
@@ -572,7 +572,7 @@ Blockly.Scrollbar.prototype.resizeContentVertical = function(hostMetrics) {
   var handleLength = hostMetrics.viewHeight * this.ratio_;
   this.setHandleLength_(Math.max(0, handleLength));
 
-  var handlePosition = (hostMetrics.viewTop - hostMetrics.contentTop) *
+  var handlePosition = (hostMetrics.viewTop) *
       this.ratio_;
   this.setHandlePosition(this.constrainHandle_(handlePosition));
 };


### PR DESCRIPTION
this will fix [this issue in scratch-gui](https://github.com/LLK/scratch-gui/issues/163)
viewtop itself is enough to determine the top of scrollbar.
substracting contentTop will cause the scrollBar nudging up a little
every time the workspace is refreshed.

### Resolves

_What Github issue does this resolve (please include link)?_

### Proposed Changes

_Describe what this Pull Request does_

### Reason for Changes

_Explain why these changes should be made_

### Test Coverage

_Please show how you have added tests to cover your changes_
