### PR TITLE
Fixed when block palette scroll up a little

### DIFF
--- a/core/flyout_vertical.js
+++ b/core/flyout_vertical.js
@@ -188,7 +188,7 @@ Blockly.VerticalFlyout.prototype.getMetrics_ = function() {
     viewWidth: viewWidth,
     contentHeight: optionBox.height * this.workspace_.scale + 2 * this.MARGIN,
     contentWidth: optionBox.width * this.workspace_.scale + 2 * this.MARGIN,
-    viewTop: -this.workspace_.scrollY,
+    viewTop: -this.workspace_.scrollY + optionBox.y,
     viewLeft: -this.workspace_.scrollX,
     contentTop: optionBox.y,
     contentLeft: optionBox.x,


### PR DESCRIPTION
this will fix [this issue in scratch-gui](https://github.com/LLK/scratch-gui/issues/163)
when calculating viewTop of the flyout, the top margin of the box content
needs to be taken account, otherwise the scrollBar nudging up a little
every time the workspace is refreshed.


