### PR TITLE
Add styled monitor checkboxes

### DIFF
--- a/core/css.js
+++ b/core/css.js
@@ -1036,11 +1036,20 @@ Blockly.Css.CONTENT = [
   '}',
 
   '.blocklyFlyoutCheckbox {',
-    'fill: red;',
+    'fill: white;',
+    'stroke: #c8c8c8;',
   '}',
 
   '.blocklyFlyoutCheckbox.checked {',
-    'fill: blue;',
+    'fill: ' + Blockly.Colours.motion.primary + ';',
+    'stroke: ' + Blockly.Colours.motion.tertiary + ';',
+  '}',
+
+  '.blocklyFlyoutCheckboxPath {',
+    'stroke: white;',
+    'stroke-width: 3;',
+    'stroke-linecap: round;',
+    'stroke-linejoin: round;',
   '}',
 
   '.scratchCategoryMenu {',

--- a/core/flyout_vertical.js
+++ b/core/flyout_vertical.js
@@ -88,6 +88,13 @@ Blockly.VerticalFlyout.prototype.DEFAULT_WIDTH = 250;
 Blockly.VerticalFlyout.prototype.CHECKBOX_SIZE = 20;
 
 /**
+ * Size of the checkbox corner radius
+ * @type {number}
+ * @const
+ */
+Blockly.VerticalFlyout.prototype.CHECKBOX_CORNER_RADIUS = 5;
+
+/**
  * Space above and around the checkbox.
  * @type {number}
  * @const
@@ -483,19 +490,31 @@ Blockly.VerticalFlyout.prototype.createCheckbox_ = function(block, cursorX,
      cursorY, blockHW) {
   var svgRoot = block.getSvgRoot();
   var extraSpace = this.CHECKBOX_SIZE + this.CHECKBOX_MARGIN;
-  var checkboxRect = Blockly.utils.createSvgElement('rect',
+
+  var checkboxGroup = Blockly.utils.createSvgElement('g',
     {
       'class': 'blocklyFlyoutCheckbox',
+      'transform': 'translate(' +
+        (this.RTL ? this.getWidth() / this.workspace_.scale - extraSpace : cursorX) +
+        ', ' + (cursorY + blockHW.height / 2 - this.CHECKBOX_SIZE / 2) + ')'
+    }, null);
+  Blockly.utils.createSvgElement('rect',
+    {
       'height': this.CHECKBOX_SIZE,
       'width': this.CHECKBOX_SIZE,
-      'x': this.RTL ? this.getWidth() / this.workspace_.scale - extraSpace :
-          cursorX,
-      'y': cursorY + blockHW.height / 2 -
-          this.CHECKBOX_SIZE / 2
-    }, null);
-  var checkboxObj = {svgRoot: checkboxRect, clicked: false, block: block};
+      'rx': this.CHECKBOX_CORNER_RADIUS,
+      'ry': this.CHECKBOX_CORNER_RADIUS
+    }, checkboxGroup);
+  Blockly.utils.createSvgElement('path',
+    {
+      'class': 'blocklyFlyoutCheckboxPath',
+      'd': 'M ' + this.CHECKBOX_SIZE / 4 + ' ' + this.CHECKBOX_SIZE / 2 +
+        'L ' + 5 * this.CHECKBOX_SIZE / 12 + ' ' + 2 * this.CHECKBOX_SIZE / 3 +
+        'L ' + 3 * this.CHECKBOX_SIZE / 4 + ' ' + this.CHECKBOX_SIZE / 3
+    }, checkboxGroup);
+  var checkboxObj = {svgRoot: checkboxGroup, clicked: false, block: block};
   block.flyoutCheckbox = checkboxObj;
-  this.workspace_.getCanvas().insertBefore(checkboxRect, svgRoot);
+  this.workspace_.getCanvas().insertBefore(checkboxGroup, svgRoot);
   this.checkboxes_.push(checkboxObj);
 };
 

--- a/core/flyout_vertical.js
+++ b/core/flyout_vertical.js
@@ -88,6 +88,19 @@ Blockly.VerticalFlyout.prototype.DEFAULT_WIDTH = 250;
 Blockly.VerticalFlyout.prototype.CHECKBOX_SIZE = 20;
 
 /**
+ * SVG path data for checkmark in checkbox.
+ * @type {string}
+ * @const
+ */
+Blockly.VerticalFlyout.prototype.CHECKMARK_PATH =
+    'M' + Blockly.VerticalFlyout.prototype.CHECKBOX_SIZE / 4 +
+    ' ' + Blockly.VerticalFlyout.prototype.CHECKBOX_SIZE / 2 +
+    'L' + 5 * Blockly.VerticalFlyout.prototype.CHECKBOX_SIZE / 12 +
+    ' ' + 2 * Blockly.VerticalFlyout.prototype.CHECKBOX_SIZE / 3 +
+    'L' + 3 * Blockly.VerticalFlyout.prototype.CHECKBOX_SIZE / 4 +
+    ' ' + Blockly.VerticalFlyout.prototype.CHECKBOX_SIZE / 3;
+
+/**
  * Size of the checkbox corner radius
  * @type {number}
  * @const
@@ -490,13 +503,12 @@ Blockly.VerticalFlyout.prototype.createCheckbox_ = function(block, cursorX,
      cursorY, blockHW) {
   var svgRoot = block.getSvgRoot();
   var extraSpace = this.CHECKBOX_SIZE + this.CHECKBOX_MARGIN;
-
+  var width = this.RTL ? this.getWidth() / this.workspace_.scale - extraSpace : cursorX;
+  var height = cursorY + blockHW.height / 2 - this.CHECKBOX_SIZE / 2;
   var checkboxGroup = Blockly.utils.createSvgElement('g',
     {
       'class': 'blocklyFlyoutCheckbox',
-      'transform': 'translate(' +
-        (this.RTL ? this.getWidth() / this.workspace_.scale - extraSpace : cursorX) +
-        ', ' + (cursorY + blockHW.height / 2 - this.CHECKBOX_SIZE / 2) + ')'
+      'transform': 'translate(' + width + ', ' + height + ')'
     }, null);
   Blockly.utils.createSvgElement('rect',
     {
@@ -508,9 +520,7 @@ Blockly.VerticalFlyout.prototype.createCheckbox_ = function(block, cursorX,
   Blockly.utils.createSvgElement('path',
     {
       'class': 'blocklyFlyoutCheckboxPath',
-      'd': 'M ' + this.CHECKBOX_SIZE / 4 + ' ' + this.CHECKBOX_SIZE / 2 +
-        'L ' + 5 * this.CHECKBOX_SIZE / 12 + ' ' + 2 * this.CHECKBOX_SIZE / 3 +
-        'L ' + 3 * this.CHECKBOX_SIZE / 4 + ' ' + this.CHECKBOX_SIZE / 3
+      'd': this.CHECKMARK_PATH
     }, checkboxGroup);
   var checkboxObj = {svgRoot: checkboxGroup, clicked: false, block: block};
   block.flyoutCheckbox = checkboxObj;

--- a/core/flyout_vertical.js
+++ b/core/flyout_vertical.js
@@ -437,7 +437,7 @@ Blockly.VerticalFlyout.prototype.layout_ = function(contents, gaps) {
       block.moveBy(moveX,
           cursorY + (block.startHat_ ? Blockly.BlockSvg.START_HAT_HEIGHT : 0));
 
-      var rect = this.createRect_(block, moveX, cursorY, blockHW, i);
+      var rect = this.createRect_(block, this.RTL ? moveX - blockHW.width : moveX, cursorY, blockHW, i);
 
       this.addBlockListeners_(root, block, rect);
 


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-blocks/issues/524

### Proposed Changes

_Describe what this Pull Request does_

Styles the checkboxes to look like https://github.com/LLK/scratch-blocks/issues/524 says they should look.

---
<img width="266" alt="screen shot 2017-04-19 at 3 12 29 pm" src="https://cloud.githubusercontent.com/assets/654102/25197632/b6c40c4e-2512-11e7-885c-0c0062621845.png">

![checking-boxes](https://cloud.githubusercontent.com/assets/654102/25197636/bac2707e-2512-11e7-84f3-134dc15cd26a.gif)


@rachel-fenichel This is the first time for me in the scratch-blocks code, so I'm just trying to get a handle on the coding style and stuff. Let me know if you have any feedback! Specifically I wasn't sure if there was a better way to create a group of SVG elements.