### PR TITLE
Add back variables

### DIFF
--- a/blocks_vertical/default_toolbox.js
+++ b/blocks_vertical/default_toolbox.js
@@ -341,6 +341,8 @@ Blockly.Blocks.defaultToolbox = '<xml id="toolbox-categories" style="display: no
       '</value>'+
     '</block>'+
   '</category>'+
+  '<category name="Data" colour="#FF8C1A" secondaryColour="#DB6E00" custom="VARIABLE">' +
+  '</category>' +
   '<category name="Events" colour="#FFD500" secondaryColour="#CC9900">'+
     '<block type="event_whenflagclicked"></block>'+
     '<block type="event_whenkeypressed">'+

--- a/core/css.js
+++ b/core/css.js
@@ -440,17 +440,26 @@ Blockly.Css.CONTENT = [
     'position: absolute;',
     'z-index: 20;',
   '}',
+
   '.blocklyFlyoutButton {',
-    'fill: #888;',
-    'cursor: default;',
+    'fill: none;',
+  '}',
+
+  '.blocklyFlyoutButtonBackground {',
+      'stroke: #c6c6c6;',
+  '}',
+
+  '.blocklyFlyoutButton .blocklyText {',
+    'fill: $colour_text;',
   '}',
 
   '.blocklyFlyoutButtonShadow {',
-    'fill: #666;',
+    'fill: none;',
   '}',
 
   '.blocklyFlyoutButton:hover {',
-    'fill: #aaa;',
+    'fill: white;',
+    'cursor: pointer;',
   '}',
 
   '.blocklyFlyoutLabel {',

--- a/core/flyout_button.js
+++ b/core/flyout_button.js
@@ -101,7 +101,7 @@ Blockly.FlyoutButton = function(workspace, targetWorkspace, xml, isLabel) {
 /**
  * The margin around the text in the button.
  */
-Blockly.FlyoutButton.MARGIN = 5;
+Blockly.FlyoutButton.MARGIN = 40;
 
 /**
  * The width of the button's rect.
@@ -113,7 +113,7 @@ Blockly.FlyoutButton.prototype.width = 0;
  * The height of the button's rect.
  * @type {number}
  */
-Blockly.FlyoutButton.prototype.height = 0;
+Blockly.FlyoutButton.prototype.height = 40; // Can't be computed like the width
 
 /**
  * Create the button elements.
@@ -150,7 +150,6 @@ Blockly.FlyoutButton.prototype.createDom = function() {
 
   this.width = svgText.getComputedTextLength() +
       2 * Blockly.FlyoutButton.MARGIN;
-  this.height = 20;  // Can't compute it :(
 
   if (!this.isLabel_) {
     shadow.setAttribute('width', this.width);
@@ -159,8 +158,10 @@ Blockly.FlyoutButton.prototype.createDom = function() {
   rect.setAttribute('width', this.width);
   rect.setAttribute('height', this.height);
 
+  svgText.setAttribute('text-anchor', 'middle');
+  svgText.setAttribute('alignment-baseline', 'central');
   svgText.setAttribute('x', this.width / 2);
-  svgText.setAttribute('y', this.height - Blockly.FlyoutButton.MARGIN);
+  svgText.setAttribute('y', this.height / 2);
 
   this.updateTransform_();
   return this.svgGroup_;


### PR DESCRIPTION
Adds back the data category with variable blocks and restyles the button for adding variables.

The "new variable" creation prompt will be handled through the GUI, so it isn't part of this.

![screen shot 2017-04-20 at 1 37 32 pm](https://cloud.githubusercontent.com/assets/654102/25244455/d559321c-25ce-11e7-8cf7-916b21b7731c.png)

