### PR TITLE
Empty the categories array on dispose

### DIFF
--- a/core/toolbox.js
+++ b/core/toolbox.js
@@ -409,6 +409,7 @@ Blockly.Toolbox.CategoryMenu.prototype.dispose = function() {
   for (var i = 0, category; category = this.categories_[i]; i++) {
     category.dispose();
   }
+  this.categories_ = [];
   if (this.table) {
     goog.dom.removeNode(this.table);
     this.table = null;


### PR DESCRIPTION
### Resolves

Resolves https://github.com/LLK/scratch-blocks/issues/883

### Proposed Changes

Set categories_ to the empty array

### Reason for Changes

The categories were getting disposed individually, but the array elements were not being cleared, which caused an error.