### PR TITLE
fix separators in flyouts in toolboxes with categories

### DIFF
--- a/core/toolbox.js
+++ b/core/toolbox.js
@@ -535,6 +535,7 @@ Blockly.Toolbox.Category.prototype.parseContents_ = function(domTree) {
       case 'SHADOW':
       case 'LABEL':
       case 'BUTTON':
+      case 'SEP':
       case 'TEXT':
         this.contents_.push(child);
         break;


### PR DESCRIPTION
### Resolves
Fixes #894

### Proposed Changes

Adds parsing of SEP tags in toolbox.js

### Reason for Changes

The flyout code can handle separators, but the toolbox code was stripping them out.

