### PR TITLE
Fix disappearing dropdown

### DIFF
--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1016,9 +1016,6 @@ Blockly.WorkspaceSvg.prototype.isDeleteArea = function(e) {
  * @private
  */
 Blockly.WorkspaceSvg.prototype.onMouseDown_ = function(e) {
-  // TODO (fenichel): Move this to gesture.
-  Blockly.DropDownDiv.hide();
-
   var gesture = this.getGesture(e);
   if (gesture) {
     gesture.handleWsStart(e, this);


### PR DESCRIPTION
### Resolves

Fixes #901 

### Proposed Changes

Gets rid of a spurious dropdownDiv.hide();

### Reason for Changes

That's being done in gesture by calling hideChaff

### Test Coverage

