### PR TITLE
Give persistent block ids to variables in the flyout

### DIFF
--- a/core/variables.js
+++ b/core/variables.js
@@ -132,6 +132,7 @@ Blockly.Variables.flyoutCategory = function(workspace) {
       var block = goog.dom.createDom('block');
       block.setAttribute('type', 'data_variable');
       block.setAttribute('gap', 8);
+      block.setAttribute('id', 'VAR_' + variableModelList[i].name);
 
       var field = goog.dom.createDom('field', null, variableModelList[i].name);
       field.setAttribute('name', 'VARIABLE');


### PR DESCRIPTION
### Resolves

Persists the monitoring state of variables between flyout refreshes

### Proposed Changes

Give a persistent id to each variable block in the flyout

### Reason for Changes

Otherwise, the variable blocks get a new id each time the category is switched to/from, and the monitor checkboxes become unchecked (since they are keyed by flyout block id).
