### PR TITLE
Set checkbox state after creating a variable through the prompt

### DIFF
--- a/core/flyout_vertical.js
+++ b/core/flyout_vertical.js
@@ -546,13 +546,12 @@ Blockly.VerticalFlyout.prototype.createCheckbox_ = function(block, cursorX,
  * @private
  */
 Blockly.VerticalFlyout.prototype.checkboxClicked_ = function(checkboxObj) {
-  var context = this;
   return function(e) {
-    context.setCheckboxState(checkboxObj.block.id, !checkboxObj.clicked);
+    this.setCheckboxState(checkboxObj.block.id, !checkboxObj.clicked);
     // This event has been handled.  No need to bubble up to the document.
     e.stopPropagation();
     e.preventDefault();
-  };
+  }.bind(this);
 };
 
 /**

--- a/core/flyout_vertical.js
+++ b/core/flyout_vertical.js
@@ -546,24 +546,42 @@ Blockly.VerticalFlyout.prototype.createCheckbox_ = function(block, cursorX,
  * @private
  */
 Blockly.VerticalFlyout.prototype.checkboxClicked_ = function(checkboxObj) {
+  var context = this;
   return function(e) {
-    var oldValue = checkboxObj.clicked;
-    var newValue = !oldValue;
-    checkboxObj.clicked = newValue;
-
-    if (checkboxObj.clicked) {
-      Blockly.utils.addClass((checkboxObj.svgRoot), 'checked');
-    } else {
-      Blockly.utils.removeClass((checkboxObj.svgRoot), 'checked');
-    }
-
-    Blockly.Events.fire(new Blockly.Events.Change(
-        checkboxObj.block, 'checkbox', null, oldValue, newValue));
-
+    context.setCheckboxState(checkboxObj.block.id, !checkboxObj.clicked);
     // This event has been handled.  No need to bubble up to the document.
     e.stopPropagation();
     e.preventDefault();
   };
+};
+
+/**
+ * Set the state of a checkbox by block ID.
+ * @param {string} blockId ID of the block whose checkbox should be set
+ * @param {boolean} value Value to set the checkbox to.
+ * @public
+ */
+Blockly.VerticalFlyout.prototype.setCheckboxState = function(blockId, value) {
+  for (var i = 0; i < this.checkboxes_.length; i++) {
+    var checkboxObj = this.checkboxes_[i];
+    if (checkboxObj.block.id === blockId) {
+      if (checkboxObj.clicked === value) return;
+
+      var oldValue = checkboxObj.clicked;
+      checkboxObj.clicked = value;
+
+      if (checkboxObj.clicked) {
+        Blockly.utils.addClass((checkboxObj.svgRoot), 'checked');
+      } else {
+        Blockly.utils.removeClass((checkboxObj.svgRoot), 'checked');
+      }
+
+      Blockly.Events.fire(new Blockly.Events.Change(
+          checkboxObj.block, 'checkbox', null, oldValue, value));
+
+      return;
+    }
+  }
 };
 
 /**

--- a/core/variables.js
+++ b/core/variables.js
@@ -381,7 +381,14 @@ Blockly.Variables.createVariable = function(workspace, opt_callback) {
                 });
           }
           else {
-            workspace.createVariable(text);
+            var variable = workspace.createVariable(text);
+
+            var fl = workspace.getFlyout();
+            var variableBlockId = 'VAR_' + variable.name;
+            if (fl.setCheckboxState) {
+              fl.setCheckboxState(variableBlockId, true);
+            }
+
             if (opt_callback) {
               opt_callback(text);
             }

--- a/core/variables.js
+++ b/core/variables.js
@@ -383,10 +383,10 @@ Blockly.Variables.createVariable = function(workspace, opt_callback) {
           else {
             var variable = workspace.createVariable(text);
 
-            var fl = workspace.getFlyout();
+            var flyout = workspace.getFlyout();
             var variableBlockId = 'VAR_' + variable.name;
-            if (fl.setCheckboxState) {
-              fl.setCheckboxState(variableBlockId, true);
+            if (flyout.setCheckboxState) {
+              flyout.setCheckboxState(variableBlockId, true);
             }
 
             if (opt_callback) {


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_
Fixes https://github.com/LLK/scratch-blocks/issues/911

### Proposed Changes

_Describe what this Pull Request does_
Set the checkbox state after a variable has been created through the prompt flow. This will both set the checkbox correctly and emit an event so the VM can create a monitor.

### Reason for Changes

_Explain why these changes should be made_
https://github.com/LLK/scratch-blocks/issues/911

![variable-checked](https://cloud.githubusercontent.com/assets/654102/26732941/5528f0de-4787-11e7-93db-e7aa83f37f44.gif)

---

This is a pretty temporary hack to make this work for our playtests. Doesn't seem like the right way going forward, but we will need to rethink a fair amount about how monitors work to get this to work correctly. 