### PR TITLE
Don't attempt to give the flyout negative height

### DIFF
--- a/core/flyout_vertical.js
+++ b/core/flyout_vertical.js
@@ -237,7 +237,7 @@ Blockly.VerticalFlyout.prototype.setMetrics_ = function(xyRatio) {
   this.workspace_.translate(this.workspace_.scrollX + metrics.absoluteLeft,
       this.workspace_.scrollY + metrics.absoluteTop);
 
-  this.clipRect_.setAttribute('height', metrics.viewHeight + 'px');
+  this.clipRect_.setAttribute('height', Math.max(0, metrics.viewHeight) + 'px');
   this.clipRect_.setAttribute('width', metrics.viewWidth + 'px');
 };
 
@@ -269,7 +269,7 @@ Blockly.VerticalFlyout.prototype.position = function() {
   }
 
   // Record the height for Blockly.Flyout.getMetrics_
-  this.height_ = targetWorkspaceMetrics.viewHeight - y;
+  this.height_ = Math.max(0, targetWorkspaceMetrics.viewHeight - y);
 
   this.setBackgroundPath_(this.width_, this.height_);
 


### PR DESCRIPTION
### Resolves

Fixes #782

### Proposed Changes

See bug report. The flyout subtracts some measurements to decide how much space it has. If the window is too small, it tries setting the element to <0px tall. In this case it should be safe to just set it to 0.