### PR TITLE
Fix click targets on single-field blocks

### DIFF
--- a/core/field.js
+++ b/core/field.js
@@ -179,7 +179,7 @@ Blockly.Field.prototype.init = function() {
   this.render_();
   this.size_.width = 0;
   this.mouseDownWrapper_ =
-      Blockly.bindEventWithChecks_(this.fieldGroup_, 'mousedown', this,
+      Blockly.bindEventWithChecks_(this.getClickTarget_(), 'mousedown', this,
       this.onMouseDown_);
 };
 


### PR DESCRIPTION
### Resolves

Fixes #920 
### Proposed Changes

Reverts the change to this line: https://github.com/LLK/scratch-blocks/commit/6275e1137c9be43ff8a94dcf8139196cb384e657#diff-393b262d7ed6406aa328f2e57e089e5fR182

### Reason for Changes

Blocks with single fields should have the entire field as the click target.  That behaviour was explicitly added in [this commit](https://github.com/LLK/scratch-blocks/commit/4daf3cd16fbe11d52f18c590e4b5b2972ef6534a) and accidentally removed in the new dragging code.
