### PR TITLE
Fix #922

### DIFF
--- a/core/block.js
+++ b/core/block.js
@@ -433,6 +433,14 @@ Blockly.Block.prototype.getNextBlock = function() {
 };
 
 /**
+ * Return the previous statement block directly connected to this block.
+ * @return {Blockly.Block} The previous statement block or null.
+ */
+Blockly.Block.prototype.getPreviousBlock = function() {
+  return this.previousConnection && this.previousConnection.targetBlock();
+};
+
+/**
  * Return the connection on the first statement input on this block, or null if
  * there are none.
  * @return {Blockly.Connection} The first statement connection or null.


### PR DESCRIPTION
### Resolves

Fixes #922 

### Proposed Changes
Explicitly check that the candidate connection is the first in the stack besides the insertion marker, rather than relying on the presence of the insertion marker to say that this is a good connection.
I'm not convinced that this is the correct solution, since there's still a ton of code for this check.  I think it is a functional solution.

### Reason for Changes
![image](https://user-images.githubusercontent.com/13686399/26859462-b6246766-4aec-11e7-8ae1-7bcac214ccab.png)

The bug was happening when dragging a stack of two or more statement blocks (in this case, the `show` and `clear` blocks) over a stack of two or more statement blocks (in this case, the `stop all sounds` and `if on edge, bounce` blocks).  Scratch allows the last statement block in a dragging stack to connect in front of the first statement block in a stationary stack, and I broke the logic for that check.

The previous connection of the `show` block would try to connect to the next connection of the `stop all sounds` block.  This was legal, so an insertion marker would appear between the `stop all sounds` block and the `if on edge, bounce` block.

On the next mouse move, the code would check whether the last connection in the dragging stack (the next connection on the `clear` block) could connect to anything nearby.  The nearest available connection would be the previous connection of the `if on edge, bounce` block.  There was already an insertion marker there, so the old code said that the connection must be valid.  But the insertion marker was there based on the `show` block, not the `clear` block, and therefore had nothing to do with the validity of the connection.  It wasn't enough to check whether the connected block is an insertion marker--I had to also check whether that insertion marker was the first block in the stack.

Here's the old code:
```
if (candidate.targetConnection) {
          // If the other side of this connection is the active insertion marker
          // connection, we've obviously already decided that this is a good
          // connection.
          if (candidate.targetBlock().isInsertionMarker()) {
            return true;
          } else {
            return false;
          }
        }
```

Before my new dragging it checked for the insertion marker connection, rather than the insertion marker block:
```
if (candidate.targetConnection) {
          // If the other side of this connection is the active insertion marker
          // connection, we've obviously already decided that this is a good
          // connection.
          if (candidate.targetConnection ==
              Blockly.insertionMarkerConnection_) {
            return true;
          } else {
            return false;
          }
        }
```

My new code hid away the details of the insertion marker, but in this case I hid them too well.