### PR TITLE
Fix #912

### DIFF
--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -768,9 +768,9 @@ Blockly.WorkspaceSvg.prototype.setVisible = function(isVisible) {
   }
   if (isVisible) {
     this.render();
-    if (this.toolbox_) {
-      this.toolbox_.position();
-    }
+    // The window may have changed size while the workspace was hidden.
+    // Resize recalculates scrollbar position, delete areas, etc.
+    this.resize();
   } else {
     Blockly.hideChaff(true);
     Blockly.DropDownDiv.hideWithoutAnimation();


### PR DESCRIPTION
### Resolves

Fixes #912 
### Proposed Changes

Resizes the workspace when making it visible, in addition to rendering all of the blocks.

### Reason for Changes

Calling resize on the workspace will also reposition and resize the flyout, toolbox, etc.  Otherwise they could get out of sync if the workspace changed size while hidden.

As a followup, we may want to store isVisible on the workspace and skip many of the resize steps if the workspace is not visible.
