### PR TITLE
Do not duplicate IDs on paste

### DIFF
--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -901,14 +901,30 @@ Blockly.WorkspaceSvg.prototype.paste = function(xmlBlock) {
   Blockly.Events.disable();
   try {
     var block = Blockly.Xml.domToBlock(xmlBlock, this);
-    // Rerender to get around problem with IE and Edge not measuring text
-    // correctly when it is hidden.
-    if (goog.userAgent.IE || goog.userAgent.EDGE) {
-      var blocks = block.getDescendants();
-      for (var i = blocks.length - 1; i >= 0; i--) {
-        blocks[i].render(false);
+
+    var blocks = block.getDescendants();
+    for (var i = blocks.length - 1; i >= 0; i--) {
+      var descendant = blocks[i];
+
+      // Scratch-specific: Give shadow dom new IDs to prevent duplicating on paste
+      for(var j = 0; j < descendant.inputList.length; j++) {
+        if (descendant.inputList[j].connection) {
+          var connection = descendant.inputList[j].connection;
+          if (connection && connection.getShadowDom()) {
+            var shadowDom = connection.getShadowDom();
+            shadowDom.setAttribute('id', Blockly.utils.genUid());
+            connection.setShadowDom(shadowDom);
+          }
+        }
+      }
+
+      // Rerender to get around problem with IE and Edge not measuring text
+      // correctly when it is hidden.
+      if (goog.userAgent.IE || goog.userAgent.EDGE) {
+        descendant.render(false);
       }
     }
+
     // Move the duplicate to original position.
     var blockX = parseInt(xmlBlock.getAttribute('x'), 10);
     var blockY = parseInt(xmlBlock.getAttribute('y'), 10);

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -910,8 +910,8 @@ Blockly.WorkspaceSvg.prototype.paste = function(xmlBlock) {
       for(var j = 0; j < descendant.inputList.length; j++) {
         if (descendant.inputList[j].connection) {
           var connection = descendant.inputList[j].connection;
-          if (connection && connection.getShadowDom()) {
-            var shadowDom = connection.getShadowDom();
+          var shadowDom = connection.getShadowDom();
+          if (shadowDom) {
             shadowDom.setAttribute('id', Blockly.utils.genUid());
             connection.setShadowDom(shadowDom);
           }

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -907,9 +907,9 @@ Blockly.WorkspaceSvg.prototype.paste = function(xmlBlock) {
       var descendant = blocks[i];
 
       // Scratch-specific: Give shadow dom new IDs to prevent duplicating on paste
-      for(var j = 0; j < descendant.inputList.length; j++) {
-        if (descendant.inputList[j].connection) {
-          var connection = descendant.inputList[j].connection;
+      for (var j = 0; j < descendant.inputList.length; j++) {
+        var connection = descendant.inputList[j].connection;
+        if (connection) {
           var shadowDom = connection.getShadowDom();
           if (shadowDom) {
             shadowDom.setAttribute('id', Blockly.utils.genUid());


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_
In response to https://github.com/LLK/scratch-blocks/issues/926 and fixing https://github.com/LLK/scratch-vm/issues/589 and https://github.com/LLK/scratch-vm/issues/590

@rschamp and I spent a while trying to figure this out. Here is what is going on, and why we chose this (temporary) solution.

### Background
#### How scratch-blocks treats shadows
Blockly "deletes" shadows when they are obscured, sending a delete event and disposing of the model. However, the shadow is serialized for possible later use. If/when the obscuring block is removed, the shadow is deserialized, given a new ID if needed, and reinstated in the model. 

#### How scratch-vm treats shadows
Scratch-vm treats shadows as regular blocks. They are stored (by id) in a target-specific block cache, where they can be acted on by create, move and delete events. The block input stores a reference to both a `shadow` id and a `block` id, both to be retrieved from the block cache. If there is both a `shadow` and a `block` on the input, and they are different, it is an obscured shadow. When blocks are deleted, the blocks connected to their inputs (both "real" blocks and shadow blocks) are deleted. 

#### Where the trouble comes from
These two models _would_ be functionally equivalent if not for one thing: because Blockly does not consider an obscured shadow block a "real" block, it does not give it a new ID when it is duplicated (that happens when the shadow is eventually revealed). See  https://github.com/LLK/scratch-blocks/issues/926 for further description.

---

@rschamp and I tried several things to try to make the VMs model of processing events, but were not able to without a full refactor of the way shadow blocks are dealt with. I'd like to have a more full conversation with the team offline about when/if that will be required (I have some reservations about making the vm work the way scratch-blocks does). 

---

### Proposed Changes

This change rewrites the shadow IDs on paste by reaching into each block connection and setting the id attribute using `genUid`. (The rearrangement of the IE/Edge fix is just coincidental, saving a separate loop through the blocks on paste). 

I marked the change `Scratch-specific` to aid in future merging.

We tried to confirmed this fixes all of the bugs relating to blocks disappearing from the VM.

---

@rachel-fenichel and @RoboErikG thanks for talking to us about this offline and doing some investigation. I know this isn't the answer that you noted in https://github.com/LLK/scratch-blocks/issues/926. If this seems like a kosher thing to do, I think it would be best to merge this and than do a deeper dive a bit later on into bringing the vm more in line with blockly. 