### PR TITLE
Use extensions to share color and shape between some blocks

### DIFF
--- a/blocks_vertical/control.js
+++ b/blocks_vertical/control.js
@@ -24,6 +24,7 @@ goog.provide('Blockly.Blocks.control');
 
 goog.require('Blockly.Blocks');
 goog.require('Blockly.Colours');
+goog.require('Blockly.ScratchBlocks.VerticalExtensions');
 
 
 Blockly.Blocks['control_forever'] = {
@@ -58,9 +59,7 @@ Blockly.Blocks['control_forever'] = {
       "inputsInline": true,
       "previousStatement": null,
       "category": Blockly.Categories.control,
-      "colour": Blockly.Colours.control.primary,
-      "colourSecondary": Blockly.Colours.control.secondary,
-      "colourTertiary": Blockly.Colours.control.tertiary
+      "extensions": ["colours_control"]
     });
   }
 };
@@ -100,13 +99,8 @@ Blockly.Blocks['control_repeat'] = {
           "flip_rtl": true
         }
       ],
-      "inputsInline": true,
-      "previousStatement": null,
-      "nextStatement": null,
       "category": Blockly.Categories.control,
-      "colour": Blockly.Colours.control.primary,
-      "colourSecondary": Blockly.Colours.control.secondary,
-      "colourTertiary": Blockly.Colours.control.tertiary
+      "extensions": ["colours_control", "shape_statement"]
     });
   }
 };
@@ -134,13 +128,8 @@ Blockly.Blocks['control_if'] = {
           "name": "SUBSTACK"
         }
       ],
-      "inputsInline": true,
-      "previousStatement": null,
-      "nextStatement": null,
       "category": Blockly.Categories.control,
-      "colour": Blockly.Colours.control.primary,
-      "colourSecondary": Blockly.Colours.control.secondary,
-      "colourTertiary": Blockly.Colours.control.tertiary
+      "extensions": ["colours_control", "shape_statement"]
     });
   }
 };
@@ -176,13 +165,8 @@ Blockly.Blocks['control_if_else'] = {
           "name": "SUBSTACK2"
         }
       ],
-      "inputsInline": true,
-      "previousStatement": null,
-      "nextStatement": null,
       "category": Blockly.Categories.control,
-      "colour": Blockly.Colours.control.primary,
-      "colourSecondary": Blockly.Colours.control.secondary,
-      "colourTertiary": Blockly.Colours.control.tertiary
+      "extensions": ["colours_control", "shape_statement"]
     });
   }
 };
@@ -248,13 +232,8 @@ Blockly.Blocks['control_wait'] = {
           "name": "DURATION"
         }
       ],
-      "inputsInline": true,
-      "previousStatement": null,
-      "nextStatement": null,
       "category": Blockly.Categories.control,
-      "colour": Blockly.Colours.control.primary,
-      "colourSecondary": Blockly.Colours.control.secondary,
-      "colourTertiary": Blockly.Colours.control.tertiary
+      "extensions": ["colours_control", "shape_statement"]
     });
   }
 };
@@ -274,13 +253,8 @@ Blockly.Blocks['control_wait_until'] = {
           "check": "Boolean"
         }
       ],
-      "inputsInline": true,
-      "previousStatement": null,
-      "nextStatement": null,
       "category": Blockly.Categories.control,
-      "colour": Blockly.Colours.control.primary,
-      "colourSecondary": Blockly.Colours.control.secondary,
-      "colourTertiary": Blockly.Colours.control.tertiary
+      "extensions": ["colours_control", "shape_statement"]
     });
   }
 };
@@ -318,13 +292,8 @@ Blockly.Blocks['control_repeat_until'] = {
           "flip_rtl": true
         }
       ],
-      "inputsInline": true,
-      "previousStatement": null,
-      "nextStatement": null,
       "category": Blockly.Categories.control,
-      "colour": Blockly.Colours.control.primary,
-      "colourSecondary": Blockly.Colours.control.secondary,
-      "colourTertiary": Blockly.Colours.control.tertiary
+      "extensions": ["colours_control", "shape_statement"]
     });
   }
 };
@@ -343,9 +312,7 @@ Blockly.Blocks['control_start_as_clone'] = {
       "inputsInline": true,
       "nextStatement": null,
       "category": Blockly.Categories.control,
-      "colour": Blockly.Colours.control.primary,
-      "colourSecondary": Blockly.Colours.control.secondary,
-      "colourTertiary": Blockly.Colours.control.tertiary
+      "extensions": ["colours_control"]
     });
   }
 };
@@ -371,9 +338,7 @@ Blockly.Blocks['control_create_clone_of_menu'] = {
         "inputsInline": true,
         "output": "String",
         "outputShape": Blockly.OUTPUT_SHAPE_ROUND,
-        "colour": Blockly.Colours.control.secondary,
-        "colourSecondary": Blockly.Colours.control.secondary,
-        "colourTertiary": Blockly.Colours.control.tertiary
+        "extensions": ["colours_control"]
       });
   }
 };
@@ -393,13 +358,8 @@ Blockly.Blocks['control_create_clone_of'] = {
           "name": "CLONE_OPTION"
         }
       ],
-      "inputsInline": true,
-      "previousStatement": null,
-      "nextStatement": null,
       "category": Blockly.Categories.control,
-      "colour": Blockly.Colours.control.primary,
-      "colourSecondary": Blockly.Colours.control.secondary,
-      "colourTertiary": Blockly.Colours.control.tertiary
+      "extensions": ["colours_control", "shape_statement"]
     });
   }
 };
@@ -417,9 +377,7 @@ Blockly.Blocks['control_delete_this_clone'] = {
       "inputsInline": true,
       "previousStatement": null,
       "category": Blockly.Categories.control,
-      "colour": Blockly.Colours.control.primary,
-      "colourSecondary": Blockly.Colours.control.secondary,
-      "colourTertiary": Blockly.Colours.control.tertiary
+      "extensions": ["colours_control"]
     });
   }
 };

--- a/blocks_vertical/data.js
+++ b/blocks_vertical/data.js
@@ -26,6 +26,7 @@ goog.provide('Blockly.Constants.Data');
 goog.require('Blockly.Blocks');
 goog.require('Blockly.Colours');
 goog.require('Blockly.constants');
+goog.require('Blockly.ScratchBlocks.VerticalExtensions');
 
 
 Blockly.Blocks['data_variablemenu'] = {
@@ -69,13 +70,10 @@ Blockly.Blocks['data_variable'] = {
         }
       ],
       "category": Blockly.Categories.data,
-      "colour": Blockly.Colours.data.primary,
-      "colourSecondary": Blockly.Colours.data.secondary,
-      "colourTertiary": Blockly.Colours.data.tertiary,
       "output": "String",
       "outputShape": Blockly.OUTPUT_SHAPE_ROUND,
       "checkboxInFlyout": true,
-      "extensions": ["contextMenu_getVariableBlock"]
+      "extensions": ["contextMenu_getVariableBlock", "colours_data"]
     });
   }
 };
@@ -98,12 +96,8 @@ Blockly.Blocks['data_setvariableto'] = {
           "name": "VALUE"
         }
       ],
-      "previousStatement": null,
-      "nextStatement": null,
       "category": Blockly.Categories.data,
-      "colour": Blockly.Colours.data.primary,
-      "colourSecondary": Blockly.Colours.data.secondary,
-      "colourTertiary": Blockly.Colours.data.tertiary
+      "extensions": ["colours_data", "shape_statement"]
     });
   }
 };
@@ -126,12 +120,8 @@ Blockly.Blocks['data_changevariableby'] = {
           "name": "VALUE"
         }
       ],
-      "previousStatement": null,
-      "nextStatement": null,
       "category": Blockly.Categories.data,
-      "colour": Blockly.Colours.data.primary,
-      "colourSecondary": Blockly.Colours.data.secondary,
-      "colourTertiary": Blockly.Colours.data.tertiary
+      "extensions": ["colours_data", "shape_statement"]
     });
   }
 };
@@ -201,9 +191,7 @@ Blockly.Blocks['data_listcontents'] = {
         }
       ],
       "category": Blockly.Categories.data,
-      "colour": Blockly.Colours.data.primary,
-      "colourSecondary": Blockly.Colours.data.secondary,
-      "colourTertiary": Blockly.Colours.data.tertiary,
+      "extensions": ["colours_data"],
       "output": "String",
       "outputShape": Blockly.OUTPUT_SHAPE_ROUND,
       "checkboxInFlyout": true
@@ -289,12 +277,8 @@ Blockly.Blocks['data_addtolist'] = {
           "name": "LIST"
         }
       ],
-      "previousStatement": null,
-      "nextStatement": null,
       "category": Blockly.Categories.data,
-      "colour": Blockly.Colours.data.primary,
-      "colourSecondary": Blockly.Colours.data.secondary,
-      "colourTertiary": Blockly.Colours.data.tertiary
+      "extensions": ["colours_data", "shape_statement"]
     });
   }
 };
@@ -317,12 +301,8 @@ Blockly.Blocks['data_deleteoflist'] = {
           "name": "LIST"
         }
       ],
-      "previousStatement": null,
-      "nextStatement": null,
       "category": Blockly.Categories.data,
-      "colour": Blockly.Colours.data.primary,
-      "colourSecondary": Blockly.Colours.data.secondary,
-      "colourTertiary": Blockly.Colours.data.tertiary
+      "extensions": ["colours_data", "shape_statement"]
     });
   }
 };
@@ -349,12 +329,8 @@ Blockly.Blocks['data_insertatlist'] = {
           "name": "LIST"
         }
       ],
-      "previousStatement": null,
-      "nextStatement": null,
       "category": Blockly.Categories.data,
-      "colour": Blockly.Colours.data.primary,
-      "colourSecondary": Blockly.Colours.data.secondary,
-      "colourTertiary": Blockly.Colours.data.tertiary
+      "extensions": ["colours_data", "shape_statement"]
     });
   }
 };
@@ -381,12 +357,8 @@ Blockly.Blocks['data_replaceitemoflist'] = {
           "name": "ITEM"
         }
       ],
-      "previousStatement": null,
-      "nextStatement": null,
       "category": Blockly.Categories.data,
-      "colour": Blockly.Colours.data.primary,
-      "colourSecondary": Blockly.Colours.data.secondary,
-      "colourTertiary": Blockly.Colours.data.tertiary
+      "extensions": ["colours_data", "shape_statement"]
     });
   }
 };
@@ -411,9 +383,7 @@ Blockly.Blocks['data_itemoflist'] = {
       ],
       "output": null,
       "category": Blockly.Categories.data,
-      "colour": Blockly.Colours.data.primary,
-      "colourSecondary": Blockly.Colours.data.secondary,
-      "colourTertiary": Blockly.Colours.data.tertiary,
+      "extensions": ["colours_data"],
       "outputShape": Blockly.OUTPUT_SHAPE_ROUND
     });
   }
@@ -435,9 +405,7 @@ Blockly.Blocks['data_lengthoflist'] = {
       ],
       "output": "Number",
       "category": Blockly.Categories.data,
-      "colour": Blockly.Colours.data.primary,
-      "colourSecondary": Blockly.Colours.data.secondary,
-      "colourTertiary": Blockly.Colours.data.tertiary,
+      "extensions": ["colours_data"],
       "outputShape": Blockly.OUTPUT_SHAPE_ROUND
     });
   }
@@ -464,9 +432,7 @@ Blockly.Blocks['data_listcontainsitem'] = {
       "output": "Boolean",
       "outputShape": Blockly.OUTPUT_SHAPE_HEXAGONAL,
       "category": Blockly.Categories.data,
-      "colour": Blockly.Colours.data.primary,
-      "colourSecondary": Blockly.Colours.data.secondary,
-      "colourTertiary": Blockly.Colours.data.tertiary
+      "extensions": ["colours_data"]
     });
   }
 };
@@ -485,12 +451,8 @@ Blockly.Blocks['data_showlist'] = {
           "name": "LIST"
         }
       ],
-      "previousStatement": null,
-      "nextStatement": null,
       "category": Blockly.Categories.data,
-      "colour": Blockly.Colours.data.primary,
-      "colourSecondary": Blockly.Colours.data.secondary,
-      "colourTertiary": Blockly.Colours.data.tertiary
+      "extensions": ["colours_data", "shape_statement"]
     });
   }
 };
@@ -509,12 +471,8 @@ Blockly.Blocks['data_hidelist'] = {
           "name": "LIST"
         }
       ],
-      "previousStatement": null,
-      "nextStatement": null,
       "category": Blockly.Categories.data,
-      "colour": Blockly.Colours.data.primary,
-      "colourSecondary": Blockly.Colours.data.secondary,
-      "colourTertiary": Blockly.Colours.data.tertiary
+      "extensions": ["colours_data", "shape_statement"]
     });
   }
 };

--- a/blocks_vertical/sound.js
+++ b/blocks_vertical/sound.js
@@ -25,6 +25,7 @@ goog.provide('Blockly.Blocks.sound');
 goog.require('Blockly.Blocks');
 goog.require('Blockly.Colours');
 goog.require('Blockly.constants');
+goog.require('Blockly.ScratchBlocks.VerticalExtensions');
 
 Blockly.Blocks['sound_sounds_menu'] = {
   /**
@@ -77,13 +78,8 @@ Blockly.Blocks['sound_play'] = {
           "name": "SOUND_MENU"
         }
       ],
-      "inputsInline": true,
-      "previousStatement": null,
-      "nextStatement": null,
       "category": Blockly.Categories.sound,
-      "colour": Blockly.Colours.sounds.primary,
-      "colourSecondary": Blockly.Colours.sounds.secondary,
-      "colourTertiary": Blockly.Colours.sounds.tertiary
+      "extensions": ["colours_sounds", "shape_statement"]
     });
   }
 };
@@ -102,12 +98,7 @@ Blockly.Blocks['sound_playuntildone'] = {
           "name": "SOUND_MENU"
         }
       ],
-      "inputsInline": true,
-      "previousStatement": null,
-      "nextStatement": null,
-      "colour": Blockly.Colours.sounds.primary,
-      "colourSecondary": Blockly.Colours.sounds.secondary,
-      "colourTertiary": Blockly.Colours.sounds.tertiary
+      "extensions": ["colours_sounds", "shape_statement"]
     });
   }
 };
@@ -120,12 +111,8 @@ Blockly.Blocks['sound_stopallsounds'] = {
   init: function() {
     this.jsonInit({
       "message0": "stop all sounds",
-      "previousStatement": null,
-      "nextStatement": null,
       "category": Blockly.Categories.sound,
-      "colour": Blockly.Colours.sounds.primary,
-      "colourSecondary": Blockly.Colours.sounds.secondary,
-      "colourTertiary": Blockly.Colours.sounds.tertiary
+      "extensions": ["colours_sounds", "shape_statement"]
     });
   }
 };
@@ -193,12 +180,8 @@ Blockly.Blocks['sound_playdrumforbeats'] = {
           "name": "BEATS"
         }
       ],
-      "previousStatement": null,
-      "nextStatement": null,
       "category": Blockly.Categories.sound,
-      "colour": Blockly.Colours.sounds.primary,
-      "colourSecondary": Blockly.Colours.sounds.secondary,
-      "colourTertiary": Blockly.Colours.sounds.tertiary
+      "extensions": ["colours_sounds", "shape_statement"]
     });
   }
 };
@@ -217,12 +200,8 @@ Blockly.Blocks['sound_restforbeats'] = {
           "name": "BEATS"
         }
       ],
-      "previousStatement": null,
-      "nextStatement": null,
       "category": Blockly.Categories.sound,
-      "colour": Blockly.Colours.sounds.primary,
-      "colourSecondary": Blockly.Colours.sounds.secondary,
-      "colourTertiary": Blockly.Colours.sounds.tertiary
+      "extensions": ["colours_sounds", "shape_statement"]
     });
   }
 };
@@ -245,12 +224,8 @@ Blockly.Blocks['sound_playnoteforbeats'] = {
           "name": "BEATS"
         }
       ],
-      "previousStatement": null,
-      "nextStatement": null,
       "category": Blockly.Categories.sound,
-      "colour": Blockly.Colours.sounds.primary,
-      "colourSecondary": Blockly.Colours.sounds.secondary,
-      "colourTertiary": Blockly.Colours.sounds.tertiary
+      "extensions": ["colours_sounds", "shape_statement"]
     });
   }
 };
@@ -283,11 +258,7 @@ Blockly.Blocks['sound_seteffectto'] = {
           "name": "VALUE"
         }
       ],
-      "previousStatement": null,
-      "nextStatement": null,
-      "colour": Blockly.Colours.sounds.primary,
-      "colourSecondary": Blockly.Colours.sounds.secondary,
-      "colourTertiary": Blockly.Colours.sounds.tertiary
+      "extensions": ["colours_sounds", "shape_statement"]
     });
   }
 };
@@ -312,11 +283,7 @@ Blockly.Blocks['sound_changeeffectby'] = {
           "name": "VALUE"
         }
       ],
-      "previousStatement": null,
-      "nextStatement": null,
-      "colour": Blockly.Colours.sounds.primary,
-      "colourSecondary": Blockly.Colours.sounds.secondary,
-      "colourTertiary": Blockly.Colours.sounds.tertiary
+      "extensions": ["colours_sounds", "shape_statement"]
     });
   }
 };
@@ -329,11 +296,7 @@ Blockly.Blocks['sound_cleareffects'] = {
   init: function() {
     this.jsonInit({
       "message0": "clear sound effects",
-      "previousStatement": null,
-      "nextStatement": null,
-      "colour": Blockly.Colours.sounds.primary,
-      "colourSecondary": Blockly.Colours.sounds.secondary,
-      "colourTertiary": Blockly.Colours.sounds.tertiary
+      "extensions": ["colours_sounds", "shape_statement"]
     });
   }
 };
@@ -400,12 +363,8 @@ Blockly.Blocks['sound_setinstrumentto'] = {
           "name": "INSTRUMENT"
         }
       ],
-      "previousStatement": null,
-      "nextStatement": null,
       "category": Blockly.Categories.sound,
-      "colour": Blockly.Colours.sounds.primary,
-      "colourSecondary": Blockly.Colours.sounds.secondary,
-      "colourTertiary": Blockly.Colours.sounds.tertiary
+      "extensions": ["colours_sounds", "shape_statement"]
     });
   }
 };
@@ -424,12 +383,8 @@ Blockly.Blocks['sound_changevolumeby'] = {
           "name": "VOLUME"
         }
       ],
-      "previousStatement": null,
-      "nextStatement": null,
       "category": Blockly.Categories.sound,
-      "colour": Blockly.Colours.sounds.primary,
-      "colourSecondary": Blockly.Colours.sounds.secondary,
-      "colourTertiary": Blockly.Colours.sounds.tertiary
+      "extensions": ["colours_sounds", "shape_statement"]
     });
   }
 };
@@ -448,12 +403,8 @@ Blockly.Blocks['sound_setvolumeto'] = {
           "name": "VOLUME"
         }
       ],
-      "previousStatement": null,
-      "nextStatement": null,
       "category": Blockly.Categories.sound,
-      "colour": Blockly.Colours.sounds.primary,
-      "colourSecondary": Blockly.Colours.sounds.secondary,
-      "colourTertiary": Blockly.Colours.sounds.tertiary
+      "extensions": ["colours_sounds", "shape_statement"]
     });
   }
 };
@@ -467,9 +418,7 @@ Blockly.Blocks['sound_volume'] = {
     this.jsonInit({
       "message0": "volume",
       "category": Blockly.Categories.sound,
-      "colour": Blockly.Colours.sounds.primary,
-      "colourSecondary": Blockly.Colours.sounds.secondary,
-      "colourTertiary": Blockly.Colours.sounds.tertiary,
+      "extensions": ["colours_sounds"],
       "output": "Number",
       "outputShape": Blockly.OUTPUT_SHAPE_ROUND,
       "checkboxInFlyout": true
@@ -491,12 +440,8 @@ Blockly.Blocks['sound_changetempoby'] = {
           "name": "TEMPO"
         }
       ],
-      "previousStatement": null,
-      "nextStatement": null,
       "category": Blockly.Categories.sound,
-      "colour": Blockly.Colours.sounds.primary,
-      "colourSecondary": Blockly.Colours.sounds.secondary,
-      "colourTertiary": Blockly.Colours.sounds.tertiary
+      "extensions": ["colours_sounds", "shape_statement"]
     });
   }
 };
@@ -515,12 +460,8 @@ Blockly.Blocks['sound_settempotobpm'] = {
           "name": "TEMPO"
         }
       ],
-      "previousStatement": null,
-      "nextStatement": null,
       "category": Blockly.Categories.sound,
-      "colour": Blockly.Colours.sounds.primary,
-      "colourSecondary": Blockly.Colours.sounds.secondary,
-      "colourTertiary": Blockly.Colours.sounds.tertiary
+      "extensions": ["colours_sounds", "shape_statement"]
     });
   }
 };
@@ -534,9 +475,7 @@ Blockly.Blocks['sound_tempo'] = {
     this.jsonInit({
       "message0": "tempo",
       "category": Blockly.Categories.sound,
-      "colour": Blockly.Colours.sounds.primary,
-      "colourSecondary": Blockly.Colours.sounds.secondary,
-      "colourTertiary": Blockly.Colours.sounds.tertiary,
+      "extensions": ["colours_sounds"],
       "output": "Number",
       "outputShape": Blockly.OUTPUT_SHAPE_ROUND,
       "checkboxInFlyout": true

--- a/blocks_vertical/vertical_extensions.js
+++ b/blocks_vertical/vertical_extensions.js
@@ -1,0 +1,60 @@
+/**
+ * @license
+ * Visual Blocks Editor
+ *
+ * Copyright 2017 Google Inc.
+ * https://developers.google.com/blockly/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+goog.provide('Blockly.ScratchBlocks.VerticalExtensions');
+
+goog.require('Blockly.Colours');
+goog.require('Blockly.constants');
+goog.require('Blockly.Extensions');
+
+
+Blockly.ScratchBlocks.VerticalExtensions.colourHelper = function(category) {
+  return function() {
+    var colours = Blockly.Colours[category];
+    this.setColourFromRawValues_(colours.primary, colours.secondary,
+        colours.tertiary);
+  };
+};
+
+/**
+ * Extension to make a block fit into a stack of statements, regardless of its
+ * inputs.  That means the block should have a previous connection and a next
+ * connection and have inline inputs.
+ */
+Blockly.ScratchBlocks.VerticalExtensions.SHAPE_STATEMENT = function() {
+  this.setInputsInline(true);
+  this.setPreviousStatement(true, null);
+  this.setNextStatement(true, null);
+};
+
+
+Blockly.Extensions.register('colours_control',
+    Blockly.ScratchBlocks.VerticalExtensions.colourHelper("control"));
+
+Blockly.Extensions.register('colours_data',
+    Blockly.ScratchBlocks.VerticalExtensions.colourHelper("data"));
+
+Blockly.Extensions.register('colours_sounds',
+    Blockly.ScratchBlocks.VerticalExtensions.colourHelper("sounds"));
+
+Blockly.Extensions.register('shape_statement',
+    Blockly.ScratchBlocks.VerticalExtensions.SHAPE_STATEMENT);

--- a/build.py
+++ b/build.py
@@ -244,6 +244,8 @@ class Gen_compressed(threading.Thread):
     # Add Blockly.Colours for use of centralized colour bank
     filenames.append(os.path.join("core", "colours.js"))
     filenames.append(os.path.join("core", "constants.js"))
+    # Add Blockly.Extensions for use of Blockly's extensions framework.
+    filenames.append(os.path.join("core", "extensions.js"))
     for filename in filenames:
       f = open(filename)
       params.append(("js_code", "".join(f.readlines())))

--- a/core/block.js
+++ b/core/block.js
@@ -1124,18 +1124,7 @@ Blockly.Block.prototype.jsonInit = function(json) {
 
   // Set basic properties of block.
   if (json['colour'] !== undefined) {
-    // TODO: Consider a helper function here.
-    var rawValue = json['colour'];
-    var primary = goog.isString(rawValue) ?
-        Blockly.utils.replaceMessageReferences(rawValue) : rawValue;
-    rawValue = json['colourSecondary'];
-    var secondary = goog.isString(rawValue) ?
-        Blockly.utils.replaceMessageReferences(rawValue) : rawValue;
-    rawValue = json['colourTertiary'];
-    var tertiary = goog.isString(rawValue) ?
-        Blockly.utils.replaceMessageReferences(rawValue) : rawValue;
-
-    this.setColour(primary, secondary, tertiary);
+    this.setColourFromJson_(json);
   }
 
   // Interpolate the message blocks.
@@ -1228,6 +1217,39 @@ Blockly.Block.prototype.mixin = function(mixinObj, opt_disableCheck) {
     }
   }
   goog.mixin(this, mixinObj);
+};
+
+/**
+ * Set the colour of the block from strings or string table references.
+ * @param {string|?} primary Primary colour, which may be a string that contains
+ *     string table references.
+ * @param {string|?} secondary Secondary colour, which may be a string that
+ *     contains string table references.
+ * @param {string|?} tertiary Tertiary colour, which may be a string that
+ *     contains string table references.
+ * @private
+ */
+Blockly.Block.prototype.setColourFromRawValues_ = function(primary, secondary,
+    tertiary) {
+  primary = goog.isString(primary) ?
+      Blockly.utils.replaceMessageReferences(primary) : primary;
+  secondary = goog.isString(secondary) ?
+      Blockly.utils.replaceMessageReferences(secondary) : secondary;
+  tertiary = goog.isString(tertiary) ?
+      Blockly.utils.replaceMessageReferences(tertiary) : tertiary;
+
+  this.setColour(primary, secondary, tertiary);
+};
+
+/**
+ * Set the colour of the block from JSON, replacing message references as
+ * needed.
+ * @param {!Object} json Structured data describing the block.
+ * @private
+ */
+Blockly.Block.prototype.setColourFromJson_ = function(json) {
+  this.setColourFromRawValues_(json['colour'], json['colourSecondary'],
+      json['colourTertiary']);
 };
 
 /**

--- a/tests/vertical_playground.html
+++ b/tests/vertical_playground.html
@@ -8,6 +8,7 @@
 
     <script src="../blockly_uncompressed_vertical.js"></script>
     <script src="../msg/messages.js"></script>
+    <script src="../blocks_vertical/vertical_extensions.js"></script>
     <script src="../blocks_common/math.js"></script>
     <script src="../blocks_common/text.js"></script>
     <script src="../blocks_common/colour.js"></script>


### PR DESCRIPTION
This is an example of how to use Blockly's extensions framework to share common block attributes.  In this case I'm using it for colors for a few categories, as well as for statement blocks.

I'm sure I didn't do the greatest job on naming.  I'm happy to change the extension names (and even the extension file + namespace) to the scratchier names.

