### PR TITLE
Use blockly extensions for more block definitions

### DIFF
--- a/blocks_vertical/control.js
+++ b/blocks_vertical/control.js
@@ -56,10 +56,8 @@ Blockly.Blocks['control_forever'] = {
           "flip_rtl": true
         }
       ],
-      "inputsInline": true,
-      "previousStatement": null,
       "category": Blockly.Categories.control,
-      "extensions": ["colours_control"]
+      "extensions": ["colours_control", "shape_end"]
     });
   }
 };
@@ -309,10 +307,8 @@ Blockly.Blocks['control_start_as_clone'] = {
       "message0": "when I start as a clone",
       "args0": [
       ],
-      "inputsInline": true,
-      "nextStatement": null,
       "category": Blockly.Categories.control,
-      "extensions": ["colours_control"]
+      "extensions": ["colours_control", "shape_hat"]
     });
   }
 };
@@ -374,10 +370,8 @@ Blockly.Blocks['control_delete_this_clone'] = {
       "message0": "delete this clone",
       "args0": [
       ],
-      "inputsInline": true,
-      "previousStatement": null,
       "category": Blockly.Categories.control,
-      "extensions": ["colours_control"]
+      "extensions": ["colours_control", "shape_end"]
     });
   }
 };

--- a/blocks_vertical/control.js
+++ b/blocks_vertical/control.js
@@ -331,10 +331,7 @@ Blockly.Blocks['control_create_clone_of_menu'] = {
             ]
           }
         ],
-        "inputsInline": true,
-        "output": "String",
-        "outputShape": Blockly.OUTPUT_SHAPE_ROUND,
-        "extensions": ["colours_control"]
+        "extensions": ["colours_control", "output_string"]
       });
   }
 };

--- a/blocks_vertical/data.js
+++ b/blocks_vertical/data.js
@@ -44,12 +44,10 @@ Blockly.Blocks['data_variablemenu'] = {
             "name": "VARIABLE"
           }
         ],
-        "inputsInline": true,
-        "output": "String",
         "colour": Blockly.Colours.data.secondary,
         "colourSecondary": Blockly.Colours.data.secondary,
         "colourTertiary": Blockly.Colours.data.tertiary,
-        "outputShape": Blockly.OUTPUT_SHAPE_ROUND
+        "extensions": ["output_string"]
       });
   }
 };
@@ -70,10 +68,8 @@ Blockly.Blocks['data_variable'] = {
         }
       ],
       "category": Blockly.Categories.data,
-      "output": "String",
-      "outputShape": Blockly.OUTPUT_SHAPE_ROUND,
       "checkboxInFlyout": true,
-      "extensions": ["contextMenu_getVariableBlock", "colours_data"]
+      "extensions": ["contextMenu_getVariableBlock", "colours_data", "output_string"]
     });
   }
 };
@@ -191,9 +187,7 @@ Blockly.Blocks['data_listcontents'] = {
         }
       ],
       "category": Blockly.Categories.data,
-      "extensions": ["colours_data"],
-      "output": "String",
-      "outputShape": Blockly.OUTPUT_SHAPE_ROUND,
+      "extensions": ["colours_data", "output_string"],
       "checkboxInFlyout": true
     });
   }
@@ -221,10 +215,9 @@ Blockly.Blocks['data_listindexall'] = {
           ]
         }
       ],
-      "output": "String",
       "category": Blockly.Categories.data,
-      "outputShape": Blockly.OUTPUT_SHAPE_ROUND,
-      "colour": Blockly.Colours.textField
+      "colour": Blockly.Colours.textField,
+      "extensions": ["output_string"]
     });
   }
 };
@@ -403,10 +396,8 @@ Blockly.Blocks['data_lengthoflist'] = {
           "name": "LIST"
         }
       ],
-      "output": "Number",
       "category": Blockly.Categories.data,
-      "extensions": ["colours_data"],
-      "outputShape": Blockly.OUTPUT_SHAPE_ROUND
+      "extensions": ["colours_data", "output_number"]
     });
   }
 };
@@ -429,10 +420,8 @@ Blockly.Blocks['data_listcontainsitem'] = {
           "name": "ITEM"
         }
       ],
-      "output": "Boolean",
-      "outputShape": Blockly.OUTPUT_SHAPE_HEXAGONAL,
       "category": Blockly.Categories.data,
-      "extensions": ["colours_data"]
+      "extensions": ["colours_data", "output_boolean"]
     });
   }
 };

--- a/blocks_vertical/data.js
+++ b/blocks_vertical/data.js
@@ -244,10 +244,9 @@ Blockly.Blocks['data_listindexrandom'] = {
           ]
         }
       ],
-      "output": "String",
       "category": Blockly.Categories.data,
-      "outputShape": Blockly.OUTPUT_SHAPE_ROUND,
-      "colour": Blockly.Colours.textField
+      "colour": Blockly.Colours.textField,
+      "extensions": ["output_string"]
     });
   }
 };

--- a/blocks_vertical/event.js
+++ b/blocks_vertical/event.js
@@ -25,6 +25,7 @@ goog.provide('Blockly.Blocks.event');
 goog.require('Blockly.Blocks');
 goog.require('Blockly.Colours');
 goog.require('Blockly.constants');
+goog.require('Blockly.ScratchBlocks.VerticalExtensions');
 
 
 Blockly.Blocks['event_whenflagclicked'] = {

--- a/blocks_vertical/event.js
+++ b/blocks_vertical/event.js
@@ -162,12 +162,10 @@ Blockly.Blocks['event_broadcast_menu'] = {
             ]
           }
         ],
-        "inputsInline": true,
-        "output": "String",
         "colour": Blockly.Colours.event.secondary,
         "colourSecondary": Blockly.Colours.event.secondary,
         "colourTertiary": Blockly.Colours.event.tertiary,
-        "outputShape": Blockly.OUTPUT_SHAPE_ROUND
+        "extensions": ["output_string"]
       });
   }
 };

--- a/blocks_vertical/event.js
+++ b/blocks_vertical/event.js
@@ -46,12 +46,8 @@ Blockly.Blocks['event_whenflagclicked'] = {
           "flip_rtl": true
         }
       ],
-      "inputsInline": true,
-      "nextStatement": null,
       "category": Blockly.Categories.event,
-      "colour": Blockly.Colours.event.primary,
-      "colourSecondary": Blockly.Colours.event.secondary,
-      "colourTertiary": Blockly.Colours.event.tertiary
+      "extensions": ["colours_event", "shape_hat"]
     });
   }
 };
@@ -64,12 +60,8 @@ Blockly.Blocks['event_whenthisspriteclicked'] = {
   init: function() {
     this.jsonInit({
       "message0": "when this sprite clicked",
-      "inputsInline": true,
-      "nextStatement": null,
       "category": Blockly.Categories.event,
-      "colour": Blockly.Colours.event.primary,
-      "colourSecondary": Blockly.Colours.event.secondary,
-      "colourTertiary": Blockly.Colours.event.tertiary
+      "extensions": ["colours_event", "shape_hat"]
     });
   }
 };
@@ -94,12 +86,8 @@ Blockly.Blocks['event_whenbroadcastreceived'] = {
           ]
         }
       ],
-      "inputsInline": true,
-      "nextStatement": null,
       "category": Blockly.Categories.event,
-      "colour": Blockly.Colours.event.primary,
-      "colourSecondary": Blockly.Colours.event.secondary,
-      "colourTertiary": Blockly.Colours.event.tertiary
+      "extensions": ["colours_event", "shape_hat"]
     });
   }
 };
@@ -121,12 +109,8 @@ Blockly.Blocks['event_whenbackdropswitchesto'] = {
           ]
         }
       ],
-      "inputsInline": true,
-      "nextStatement": null,
       "category": Blockly.Categories.event,
-      "colour": Blockly.Colours.event.primary,
-      "colourSecondary": Blockly.Colours.event.secondary,
-      "colourTertiary": Blockly.Colours.event.tertiary
+      "extensions": ["colours_event", "shape_hat"]
     });
   }
 };
@@ -152,12 +136,8 @@ Blockly.Blocks['event_whengreaterthan'] = {
           "name": "VALUE"
         }
       ],
-      "inputsInline": true,
-      "nextStatement": null,
       "category": Blockly.Categories.event,
-      "colour": Blockly.Colours.event.primary,
-      "colourSecondary": Blockly.Colours.event.secondary,
-      "colourTertiary": Blockly.Colours.event.tertiary
+      "extensions": ["colours_event", "shape_hat"]
     });
   }
 };
@@ -207,13 +187,8 @@ Blockly.Blocks['event_broadcast'] = {
           "name": "BROADCAST_OPTION"
         }
       ],
-      "inputsInline": true,
-      "previousStatement": null,
-      "nextStatement": null,
       "category": Blockly.Categories.event,
-      "colour": Blockly.Colours.event.primary,
-      "colourSecondary": Blockly.Colours.event.secondary,
-      "colourTertiary": Blockly.Colours.event.tertiary
+      "extensions": ["colours_event", "shape_statement"]
     });
   }
 };
@@ -232,13 +207,8 @@ Blockly.Blocks['event_broadcastandwait'] = {
           "name": "BROADCAST_OPTION"
         }
       ],
-      "inputsInline": true,
-      "previousStatement": null,
-      "nextStatement": null,
       "category": Blockly.Categories.event,
-      "colour": Blockly.Colours.event.primary,
-      "colourSecondary": Blockly.Colours.event.secondary,
-      "colourTertiary": Blockly.Colours.event.tertiary
+      "extensions": ["colours_event", "shape_statement"]
     });
   }
 };
@@ -302,12 +272,8 @@ Blockly.Blocks['event_whenkeypressed'] = {
           ]
         }
       ],
-      "inputsInline": true,
-      "nextStatement": null,
       "category": Blockly.Categories.event,
-      "colour": Blockly.Colours.event.primary,
-      "colourSecondary": Blockly.Colours.event.secondary,
-      "colourTertiary": Blockly.Colours.event.tertiary
+      "extensions": ["colours_event", "shape_hat"]
     });
   }
 };

--- a/blocks_vertical/looks.js
+++ b/blocks_vertical/looks.js
@@ -45,12 +45,8 @@ Blockly.Blocks['looks_sayforsecs'] = {
           "name": "SECS"
         }
       ],
-      "previousStatement": null,
-      "nextStatement": null,
       "category": Blockly.Categories.looks,
-      "colour": Blockly.Colours.looks.primary,
-      "colourSecondary": Blockly.Colours.looks.secondary,
-      "colourTertiary": Blockly.Colours.looks.tertiary
+      "extensions": ["colours_looks", "shape_statement"]
     });
   }
 };
@@ -69,12 +65,8 @@ Blockly.Blocks['looks_say'] = {
           "name": "MESSAGE"
         }
       ],
-      "previousStatement": null,
-      "nextStatement": null,
       "category": Blockly.Categories.looks,
-      "colour": Blockly.Colours.looks.primary,
-      "colourSecondary": Blockly.Colours.looks.secondary,
-      "colourTertiary": Blockly.Colours.looks.tertiary
+      "extensions": ["colours_looks", "shape_statement"]
     });
   }
 };
@@ -97,12 +89,8 @@ Blockly.Blocks['looks_thinkforsecs'] = {
           "name": "SECS"
         }
       ],
-      "previousStatement": null,
-      "nextStatement": null,
       "category": Blockly.Categories.looks,
-      "colour": Blockly.Colours.looks.primary,
-      "colourSecondary": Blockly.Colours.looks.secondary,
-      "colourTertiary": Blockly.Colours.looks.tertiary
+      "extensions": ["colours_looks", "shape_statement"]
     });
   }
 };
@@ -121,12 +109,8 @@ Blockly.Blocks['looks_think'] = {
           "name": "MESSAGE"
         }
       ],
-      "previousStatement": null,
-      "nextStatement": null,
       "category": Blockly.Categories.looks,
-      "colour": Blockly.Colours.looks.primary,
-      "colourSecondary": Blockly.Colours.looks.secondary,
-      "colourTertiary": Blockly.Colours.looks.tertiary
+      "extensions": ["colours_looks", "shape_statement"]
     });
   }
 };
@@ -140,12 +124,8 @@ Blockly.Blocks['looks_show'] = {
     this.jsonInit(
       {
         "message0": "show",
-        "previousStatement": null,
-        "nextStatement": null,
         "category": Blockly.Categories.looks,
-        "colour": Blockly.Colours.looks.primary,
-        "colourSecondary": Blockly.Colours.looks.secondary,
-        "colourTertiary": Blockly.Colours.looks.tertiary
+        "extensions": ["colours_looks", "shape_statement"]
       });
   }
 };
@@ -159,12 +139,8 @@ Blockly.Blocks['looks_hide'] = {
     this.jsonInit(
       {
         "message0": "hide",
-        "previousStatement": null,
-        "nextStatement": null,
         "category": Blockly.Categories.looks,
-        "colour": Blockly.Colours.looks.primary,
-        "colourSecondary": Blockly.Colours.looks.secondary,
-        "colourTertiary": Blockly.Colours.looks.tertiary
+        "extensions": ["colours_looks", "shape_statement"]
       });
   }
 };
@@ -198,13 +174,8 @@ Blockly.Blocks['looks_changeeffectby'] = {
           "name": "CHANGE"
         }
       ],
-      "inputsInline": true,
-      "previousStatement": null,
-      "nextStatement": null,
       "category": Blockly.Categories.looks,
-      "colour": Blockly.Colours.looks.primary,
-      "colourSecondary": Blockly.Colours.looks.secondary,
-      "colourTertiary": Blockly.Colours.looks.tertiary
+      "extensions": ["colours_looks", "shape_statement"]
     });
   }
 };
@@ -228,13 +199,8 @@ Blockly.Blocks['looks_seteffectto'] = {
           "name": "VALUE"
         }
       ],
-      "inputsInline": true,
-      "previousStatement": null,
-      "nextStatement": null,
       "category": Blockly.Categories.looks,
-      "colour": Blockly.Colours.looks.primary,
-      "colourSecondary": Blockly.Colours.looks.secondary,
-      "colourTertiary": Blockly.Colours.looks.tertiary
+      "extensions": ["colours_looks", "shape_statement"]
     });
   }
 };
@@ -247,12 +213,8 @@ Blockly.Blocks['looks_cleargraphiceffects'] = {
   init: function() {
     this.jsonInit({
       "message0": "clear graphic effects",
-      "previousStatement": null,
-      "nextStatement": null,
       "category": Blockly.Categories.looks,
-      "colour": Blockly.Colours.looks.primary,
-      "colourSecondary": Blockly.Colours.looks.secondary,
-      "colourTertiary": Blockly.Colours.looks.tertiary
+      "extensions": ["colours_looks", "shape_statement"]
     });
   }
 };
@@ -271,12 +233,8 @@ Blockly.Blocks['looks_changesizeby'] = {
           "name": "CHANGE"
         }
       ],
-      "previousStatement": null,
-      "nextStatement": null,
       "category": Blockly.Categories.looks,
-      "colour": Blockly.Colours.looks.primary,
-      "colourSecondary": Blockly.Colours.looks.secondary,
-      "colourTertiary": Blockly.Colours.looks.tertiary
+      "extensions": ["colours_looks", "shape_statement"]
     });
   }
 };
@@ -295,12 +253,8 @@ Blockly.Blocks['looks_setsizeto'] = {
           "name": "SIZE"
         }
       ],
-      "previousStatement": null,
-      "nextStatement": null,
       "category": Blockly.Categories.looks,
-      "colour": Blockly.Colours.looks.primary,
-      "colourSecondary": Blockly.Colours.looks.secondary,
-      "colourTertiary": Blockly.Colours.looks.tertiary
+      "extensions": ["colours_looks", "shape_statement"]
     });
   }
 };
@@ -314,12 +268,10 @@ Blockly.Blocks['looks_size'] = {
     this.jsonInit({
       "message0": "size",
       "category": Blockly.Categories.looks,
-      "colour": Blockly.Colours.looks.primary,
-      "colourSecondary": Blockly.Colours.looks.secondary,
-      "colourTertiary": Blockly.Colours.looks.tertiary,
       "output": "Number",
       "outputShape": Blockly.OUTPUT_SHAPE_ROUND,
-      "checkboxInFlyout": true
+      "checkboxInFlyout": true,
+      "extensions": ["colours_looks"]
     });
   }
 };
@@ -367,13 +319,8 @@ Blockly.Blocks['looks_switchcostumeto'] = {
           "name": "COSTUME"
         }
       ],
-      "inputsInline": true,
-      "previousStatement": null,
-      "nextStatement": null,
       "category": Blockly.Categories.looks,
-      "colour": Blockly.Colours.looks.primary,
-      "colourSecondary": Blockly.Colours.looks.secondary,
-      "colourTertiary": Blockly.Colours.looks.tertiary
+      "extensions": ["colours_looks", "shape_statement"]
     });
   }
 };
@@ -387,12 +334,8 @@ Blockly.Blocks['looks_nextcostume'] = {
     this.jsonInit(
       {
         "message0": "next costume",
-        "previousStatement": null,
-        "nextStatement": null,
         "category": Blockly.Categories.looks,
-        "colour": Blockly.Colours.looks.primary,
-        "colourSecondary": Blockly.Colours.looks.secondary,
-        "colourTertiary": Blockly.Colours.looks.tertiary
+        "extensions": ["colours_looks", "shape_statement"]
       });
   }
 };
@@ -411,13 +354,8 @@ Blockly.Blocks['looks_switchbackdropto'] = {
           "name": "BACKDROP"
         }
       ],
-      "inputsInline": true,
-      "previousStatement": null,
-      "nextStatement": null,
       "category": Blockly.Categories.looks,
-      "colour": Blockly.Colours.looks.primary,
-      "colourSecondary": Blockly.Colours.looks.secondary,
-      "colourTertiary": Blockly.Colours.looks.tertiary
+      "extensions": ["colours_looks", "shape_statement"]
     });
   }
 };
@@ -459,12 +397,8 @@ Blockly.Blocks['looks_gotofront'] = {
     this.jsonInit(
       {
         "message0": "go to front",
-        "previousStatement": null,
-        "nextStatement": null,
         "category": Blockly.Categories.looks,
-        "colour": Blockly.Colours.looks.primary,
-        "colourSecondary": Blockly.Colours.looks.secondary,
-        "colourTertiary": Blockly.Colours.looks.tertiary
+        "extensions": ["colours_looks", "shape_statement"]
       });
   }
 };
@@ -483,13 +417,8 @@ Blockly.Blocks['looks_gobacklayers'] = {
           "name": "NUM"
         }
       ],
-      "inputsInline": true,
-      "previousStatement": null,
-      "nextStatement": null,
       "category": Blockly.Categories.looks,
-      "colour": Blockly.Colours.looks.primary,
-      "colourSecondary": Blockly.Colours.looks.secondary,
-      "colourTertiary": Blockly.Colours.looks.tertiary
+      "extensions": ["colours_looks", "shape_statement"]
     });
   }
 };
@@ -503,12 +432,10 @@ Blockly.Blocks['looks_backdropname'] = {
     this.jsonInit({
       "message0": "backdrop name",
       "category": Blockly.Categories.looks,
-      "colour": Blockly.Colours.looks.primary,
-      "colourSecondary": Blockly.Colours.looks.secondary,
-      "colourTertiary": Blockly.Colours.looks.tertiary,
       "output": "Number",
       "outputShape": Blockly.OUTPUT_SHAPE_ROUND,
-      "checkboxInFlyout": true
+      "checkboxInFlyout": true,
+      "extensions": ["colours_looks"]
     });
   }
 };
@@ -522,12 +449,10 @@ Blockly.Blocks['looks_costumeorder'] = {
     this.jsonInit({
       "message0": "costume #",
       "category": Blockly.Categories.looks,
-      "colour": Blockly.Colours.looks.primary,
-      "colourSecondary": Blockly.Colours.looks.secondary,
-      "colourTertiary": Blockly.Colours.looks.tertiary,
       "output": "Number",
       "outputShape": Blockly.OUTPUT_SHAPE_ROUND,
-      "checkboxInFlyout": true
+      "checkboxInFlyout": true,
+      "extensions": ["colours_looks"]
     });
   }
 };
@@ -541,12 +466,10 @@ Blockly.Blocks['looks_backdroporder'] = {
     this.jsonInit({
       "message0": "backdrop #",
       "category": Blockly.Categories.looks,
-      "colour": Blockly.Colours.looks.primary,
-      "colourSecondary": Blockly.Colours.looks.secondary,
-      "colourTertiary": Blockly.Colours.looks.tertiary,
       "output": "Number",
       "outputShape": Blockly.OUTPUT_SHAPE_ROUND,
-      "checkboxInFlyout": true
+      "checkboxInFlyout": true,
+      "extensions": ["colours_looks"]
     });
   }
 };
@@ -565,13 +488,8 @@ Blockly.Blocks['looks_switchbackdroptoandwait'] = {
           "name": "BACKDROP"
         }
       ],
-      "inputsInline": true,
-      "previousStatement": null,
-      "nextStatement": null,
       "category": Blockly.Categories.looks,
-      "colour": Blockly.Colours.looks.primary,
-      "colourSecondary": Blockly.Colours.looks.secondary,
-      "colourTertiary": Blockly.Colours.looks.tertiary
+      "extensions": ["colours_looks", "shape_statement"]
     });
   }
 };
@@ -585,12 +503,8 @@ Blockly.Blocks['looks_nextbackdrop'] = {
     this.jsonInit(
       {
         "message0": "next backdrop",
-        "previousStatement": null,
-        "nextStatement": null,
         "category": Blockly.Categories.looks,
-        "colour": Blockly.Colours.looks.primary,
-        "colourSecondary": Blockly.Colours.looks.secondary,
-        "colourTertiary": Blockly.Colours.looks.tertiary
+        "extensions": ["colours_looks", "shape_statement"]
       });
   }
 };

--- a/blocks_vertical/looks.js
+++ b/blocks_vertical/looks.js
@@ -25,6 +25,7 @@ goog.provide('Blockly.Blocks.looks');
 goog.require('Blockly.Blocks');
 goog.require('Blockly.Colours');
 goog.require('Blockly.constants');
+goog.require('Blockly.ScratchBlocks.VerticalExtensions');
 
 
 Blockly.Blocks['looks_sayforsecs'] = {

--- a/blocks_vertical/looks.js
+++ b/blocks_vertical/looks.js
@@ -268,10 +268,8 @@ Blockly.Blocks['looks_size'] = {
     this.jsonInit({
       "message0": "size",
       "category": Blockly.Categories.looks,
-      "output": "Number",
-      "outputShape": Blockly.OUTPUT_SHAPE_ROUND,
       "checkboxInFlyout": true,
-      "extensions": ["colours_looks"]
+      "extensions": ["colours_looks", "output_number"]
     });
   }
 };
@@ -295,12 +293,10 @@ Blockly.Blocks['looks_costume'] = {
             ]
           }
         ],
-        "inputsInline": true,
-        "output": "String",
         "colour": Blockly.Colours.looks.secondary,
         "colourSecondary": Blockly.Colours.looks.secondary,
         "colourTertiary": Blockly.Colours.looks.tertiary,
-        "outputShape": Blockly.OUTPUT_SHAPE_ROUND
+        "extensions": ["output_string"]
       });
   }
 };
@@ -378,12 +374,10 @@ Blockly.Blocks['looks_backdrops'] = {
           ]
         }
       ],
-      "inputsInline": true,
-      "output": "String",
       "colour": Blockly.Colours.looks.secondary,
       "colourSecondary": Blockly.Colours.looks.secondary,
       "colourTertiary": Blockly.Colours.looks.tertiary,
-      "outputShape": Blockly.OUTPUT_SHAPE_ROUND
+      "extensions": ["output_string"]
     });
   }
 };
@@ -432,10 +426,8 @@ Blockly.Blocks['looks_backdropname'] = {
     this.jsonInit({
       "message0": "backdrop name",
       "category": Blockly.Categories.looks,
-      "output": "Number",
-      "outputShape": Blockly.OUTPUT_SHAPE_ROUND,
       "checkboxInFlyout": true,
-      "extensions": ["colours_looks"]
+      "extensions": ["colours_looks", "output_number"]
     });
   }
 };
@@ -449,10 +441,8 @@ Blockly.Blocks['looks_costumeorder'] = {
     this.jsonInit({
       "message0": "costume #",
       "category": Blockly.Categories.looks,
-      "output": "Number",
-      "outputShape": Blockly.OUTPUT_SHAPE_ROUND,
       "checkboxInFlyout": true,
-      "extensions": ["colours_looks"]
+      "extensions": ["colours_looks", "output_number"]
     });
   }
 };
@@ -466,10 +456,8 @@ Blockly.Blocks['looks_backdroporder'] = {
     this.jsonInit({
       "message0": "backdrop #",
       "category": Blockly.Categories.looks,
-      "output": "Number",
-      "outputShape": Blockly.OUTPUT_SHAPE_ROUND,
       "checkboxInFlyout": true,
-      "extensions": ["colours_looks"]
+      "extensions": ["colours_looks", "output_number"]
     });
   }
 };

--- a/blocks_vertical/motion.js
+++ b/blocks_vertical/motion.js
@@ -137,12 +137,10 @@ Blockly.Blocks['motion_pointtowards_menu'] = {
             ]
           }
         ],
-        "inputsInline": true,
-        "output": "String",
         "colour": Blockly.Colours.motion.secondary,
         "colourSecondary": Blockly.Colours.motion.secondary,
         "colourTertiary": Blockly.Colours.motion.tertiary,
-        "outputShape": Blockly.OUTPUT_SHAPE_ROUND
+        "extensions": ["output_string"]
       });
   }
 };
@@ -186,12 +184,10 @@ Blockly.Blocks['motion_goto_menu'] = {
             ]
           }
         ],
-        "inputsInline": true,
-        "output": "String",
         "colour": Blockly.Colours.motion.secondary,
         "colourSecondary": Blockly.Colours.motion.secondary,
         "colourTertiary": Blockly.Colours.motion.tertiary,
-        "outputShape": Blockly.OUTPUT_SHAPE_ROUND
+        "extensions": ["output_string"]
       });
   }
 };
@@ -395,11 +391,9 @@ Blockly.Blocks['motion_xposition'] = {
   init: function() {
     this.jsonInit({
       "message0": "x position",
-      "output": "Number",
-      "outputShape": Blockly.OUTPUT_SHAPE_ROUND,
       "category": Blockly.Categories.motion,
       "checkboxInFlyout": true,
-      "extensions": ["colours_motion"]
+      "extensions": ["colours_motion", "output_number"]
     });
   }
 };
@@ -412,11 +406,9 @@ Blockly.Blocks['motion_yposition'] = {
   init: function() {
     this.jsonInit({
       "message0": "y position",
-      "output": "Number",
-      "outputShape": Blockly.OUTPUT_SHAPE_ROUND,
       "category": Blockly.Categories.motion,
       "checkboxInFlyout": true,
-      "extensions": ["colours_motion"]
+      "extensions": ["colours_motion", "output_number"]
     });
   }
 };
@@ -429,11 +421,9 @@ Blockly.Blocks['motion_direction'] = {
   init: function() {
     this.jsonInit({
       "message0": "direction",
-      "output": "Number",
-      "outputShape": Blockly.OUTPUT_SHAPE_ROUND,
       "category": Blockly.Categories.motion,
       "checkboxInFlyout": true,
-      "extensions": ["colours_motion"]
+      "extensions": ["colours_motion", "output_number"]
     });
   }
 };

--- a/blocks_vertical/motion.js
+++ b/blocks_vertical/motion.js
@@ -25,6 +25,7 @@ goog.provide('Blockly.Blocks.motion');
 goog.require('Blockly.Blocks');
 goog.require('Blockly.Colours');
 goog.require('Blockly.constants');
+goog.require('Blockly.ScratchBlocks.VerticalExtensions');
 
 
 Blockly.Blocks['motion_movesteps'] = {

--- a/blocks_vertical/motion.js
+++ b/blocks_vertical/motion.js
@@ -41,13 +41,8 @@ Blockly.Blocks['motion_movesteps'] = {
           "name": "STEPS"
         }
       ],
-      "inputsInline": true,
-      "previousStatement": null,
-      "nextStatement": null,
       "category": Blockly.Categories.motion,
-      "colour": Blockly.Colours.motion.primary,
-      "colourSecondary": Blockly.Colours.motion.secondary,
-      "colourTertiary": Blockly.Colours.motion.tertiary
+      "extensions": ["colours_motion", "shape_statement"]
     });
   }
 };
@@ -72,13 +67,8 @@ Blockly.Blocks['motion_turnright'] = {
           "name": "DEGREES"
         }
       ],
-      "inputsInline": true,
-      "previousStatement": null,
-      "nextStatement": null,
       "category": Blockly.Categories.motion,
-      "colour": Blockly.Colours.motion.primary,
-      "colourSecondary": Blockly.Colours.motion.secondary,
-      "colourTertiary": Blockly.Colours.motion.tertiary
+      "extensions": ["colours_motion", "shape_statement"]
     });
   }
 };
@@ -103,13 +93,8 @@ Blockly.Blocks['motion_turnleft'] = {
           "name": "DEGREES"
         }
       ],
-      "inputsInline": true,
-      "previousStatement": null,
-      "nextStatement": null,
       "category": Blockly.Categories.motion,
-      "colour": Blockly.Colours.motion.primary,
-      "colourSecondary": Blockly.Colours.motion.secondary,
-      "colourTertiary": Blockly.Colours.motion.tertiary
+      "extensions": ["colours_motion", "shape_statement"]
     });
   }
 };
@@ -128,13 +113,8 @@ Blockly.Blocks['motion_pointindirection'] = {
           "name": "DIRECTION"
         }
       ],
-      "inputsInline": true,
-      "previousStatement": null,
-      "nextStatement": null,
       "category": Blockly.Categories.motion,
-      "colour": Blockly.Colours.motion.primary,
-      "colourSecondary": Blockly.Colours.motion.secondary,
-      "colourTertiary": Blockly.Colours.motion.tertiary
+      "extensions": ["colours_motion", "shape_statement"]
     });
   }
 };
@@ -181,13 +161,8 @@ Blockly.Blocks['motion_pointtowards'] = {
           "name": "TOWARDS"
         }
       ],
-      "inputsInline": true,
-      "previousStatement": null,
-      "nextStatement": null,
       "category": Blockly.Categories.motion,
-      "colour": Blockly.Colours.motion.primary,
-      "colourSecondary": Blockly.Colours.motion.secondary,
-      "colourTertiary": Blockly.Colours.motion.tertiary
+      "extensions": ["colours_motion", "shape_statement"]
     });
   }
 };
@@ -239,13 +214,8 @@ Blockly.Blocks['motion_gotoxy'] = {
           "name": "Y"
         }
       ],
-      "inputsInline": true,
-      "previousStatement": null,
-      "nextStatement": null,
       "category": Blockly.Categories.motion,
-      "colour": Blockly.Colours.motion.primary,
-      "colourSecondary": Blockly.Colours.motion.secondary,
-      "colourTertiary": Blockly.Colours.motion.tertiary
+      "extensions": ["colours_motion", "shape_statement"]
     });
   }
 };
@@ -264,13 +234,8 @@ Blockly.Blocks['motion_goto'] = {
           "name": "TO"
         }
       ],
-      "inputsInline": true,
-      "previousStatement": null,
-      "nextStatement": null,
       "category": Blockly.Categories.motion,
-      "colour": Blockly.Colours.motion.primary,
-      "colourSecondary": Blockly.Colours.motion.secondary,
-      "colourTertiary": Blockly.Colours.motion.tertiary
+      "extensions": ["colours_motion", "shape_statement"]
     });
   }
 };
@@ -297,13 +262,8 @@ Blockly.Blocks['motion_glidesecstoxy'] = {
           "name": "Y"
         }
       ],
-      "inputsInline": true,
-      "previousStatement": null,
-      "nextStatement": null,
       "category": Blockly.Categories.motion,
-      "colour": Blockly.Colours.motion.primary,
-      "colourSecondary": Blockly.Colours.motion.secondary,
-      "colourTertiary": Blockly.Colours.motion.tertiary
+      "extensions": ["colours_motion", "shape_statement"]
     });
   }
 };
@@ -322,13 +282,8 @@ Blockly.Blocks['motion_changexby'] = {
           "name": "DX"
         }
       ],
-      "inputsInline": true,
-      "previousStatement": null,
-      "nextStatement": null,
       "category": Blockly.Categories.motion,
-      "colour": Blockly.Colours.motion.primary,
-      "colourSecondary": Blockly.Colours.motion.secondary,
-      "colourTertiary": Blockly.Colours.motion.tertiary
+      "extensions": ["colours_motion", "shape_statement"]
     });
   }
 };
@@ -347,13 +302,8 @@ Blockly.Blocks['motion_setx'] = {
           "name": "X"
         }
       ],
-      "inputsInline": true,
-      "previousStatement": null,
-      "nextStatement": null,
       "category": Blockly.Categories.motion,
-      "colour": Blockly.Colours.motion.primary,
-      "colourSecondary": Blockly.Colours.motion.secondary,
-      "colourTertiary": Blockly.Colours.motion.tertiary
+      "extensions": ["colours_motion", "shape_statement"]
     });
   }
 };
@@ -372,13 +322,8 @@ Blockly.Blocks['motion_changeyby'] = {
           "name": "DY"
         }
       ],
-      "inputsInline": true,
-      "previousStatement": null,
-      "nextStatement": null,
       "category": Blockly.Categories.motion,
-      "colour": Blockly.Colours.motion.primary,
-      "colourSecondary": Blockly.Colours.motion.secondary,
-      "colourTertiary": Blockly.Colours.motion.tertiary
+      "extensions": ["colours_motion", "shape_statement"]
     });
   }
 };
@@ -397,13 +342,8 @@ Blockly.Blocks['motion_sety'] = {
           "name": "Y"
         }
       ],
-      "inputsInline": true,
-      "previousStatement": null,
-      "nextStatement": null,
       "category": Blockly.Categories.motion,
-      "colour": Blockly.Colours.motion.primary,
-      "colourSecondary": Blockly.Colours.motion.secondary,
-      "colourTertiary": Blockly.Colours.motion.tertiary
+      "extensions": ["colours_motion", "shape_statement"]
     });
   }
 };
@@ -416,12 +356,8 @@ Blockly.Blocks['motion_ifonedgebounce'] = {
   init: function() {
     this.jsonInit({
       "message0": "if on edge, bounce",
-      "previousStatement": null,
-      "nextStatement": null,
       "category": Blockly.Categories.motion,
-      "colour": Blockly.Colours.motion.primary,
-      "colourSecondary": Blockly.Colours.motion.secondary,
-      "colourTertiary": Blockly.Colours.motion.tertiary
+      "extensions": ["colours_motion", "shape_statement"]
     });
   }
 };
@@ -445,12 +381,8 @@ Blockly.Blocks['motion_setrotationstyle'] = {
           ]
         }
       ],
-      "previousStatement": null,
-      "nextStatement": null,
       "category": Blockly.Categories.motion,
-      "colour": Blockly.Colours.motion.primary,
-      "colourSecondary": Blockly.Colours.motion.secondary,
-      "colourTertiary": Blockly.Colours.motion.tertiary
+      "extensions": ["colours_motion", "shape_statement"]
     });
   }
 };
@@ -466,10 +398,8 @@ Blockly.Blocks['motion_xposition'] = {
       "output": "Number",
       "outputShape": Blockly.OUTPUT_SHAPE_ROUND,
       "category": Blockly.Categories.motion,
-      "colour": Blockly.Colours.motion.primary,
-      "colourSecondary": Blockly.Colours.motion.secondary,
-      "colourTertiary": Blockly.Colours.motion.tertiary,
-      "checkboxInFlyout": true
+      "checkboxInFlyout": true,
+      "extensions": ["colours_motion"]
     });
   }
 };
@@ -485,10 +415,8 @@ Blockly.Blocks['motion_yposition'] = {
       "output": "Number",
       "outputShape": Blockly.OUTPUT_SHAPE_ROUND,
       "category": Blockly.Categories.motion,
-      "colour": Blockly.Colours.motion.primary,
-      "colourSecondary": Blockly.Colours.motion.secondary,
-      "colourTertiary": Blockly.Colours.motion.tertiary,
-      "checkboxInFlyout": true
+      "checkboxInFlyout": true,
+      "extensions": ["colours_motion"]
     });
   }
 };
@@ -504,10 +432,8 @@ Blockly.Blocks['motion_direction'] = {
       "output": "Number",
       "outputShape": Blockly.OUTPUT_SHAPE_ROUND,
       "category": Blockly.Categories.motion,
-      "colour": Blockly.Colours.motion.primary,
-      "colourSecondary": Blockly.Colours.motion.secondary,
-      "colourTertiary": Blockly.Colours.motion.tertiary,
-      "checkboxInFlyout": true
+      "checkboxInFlyout": true,
+      "extensions": ["colours_motion"]
     });
   }
 };

--- a/blocks_vertical/operators.js
+++ b/blocks_vertical/operators.js
@@ -25,6 +25,7 @@ goog.provide('Blockly.Blocks.operators');
 goog.require('Blockly.Blocks');
 goog.require('Blockly.Colours');
 goog.require('Blockly.constants');
+goog.require('Blockly.ScratchBlocks.VerticalExtensions');
 
 
 Blockly.Blocks['operator_add'] = {

--- a/blocks_vertical/operators.js
+++ b/blocks_vertical/operators.js
@@ -46,11 +46,8 @@ Blockly.Blocks['operator_add'] = {
             "name": "NUM2"
           }
         ],
-        "inputsInline": true,
-        "output": "Number",
         "category": Blockly.Categories.operators,
-        "outputShape": Blockly.OUTPUT_SHAPE_ROUND,
-        "extensions": ["colours_operators"]
+        "extensions": ["colours_operators", "output_number"]
       });
   }
 };
@@ -74,11 +71,8 @@ Blockly.Blocks['operator_subtract'] = {
             "name": "NUM2"
           }
         ],
-        "inputsInline": true,
-        "output": "Number",
         "category": Blockly.Categories.operators,
-        "outputShape": Blockly.OUTPUT_SHAPE_ROUND,
-        "extensions": ["colours_operators"]
+        "extensions": ["colours_operators", "output_number"]
       });
   }
 };
@@ -102,11 +96,8 @@ Blockly.Blocks['operator_multiply'] = {
             "name": "NUM2"
           }
         ],
-        "inputsInline": true,
-        "output": "Number",
         "category": Blockly.Categories.operators,
-        "outputShape": Blockly.OUTPUT_SHAPE_ROUND,
-        "extensions": ["colours_operators"]
+        "extensions": ["colours_operators", "output_number"]
       });
   }
 };
@@ -130,11 +121,8 @@ Blockly.Blocks['operator_divide'] = {
             "name": "NUM2"
           }
         ],
-        "inputsInline": true,
-        "output": "Number",
         "category": Blockly.Categories.operators,
-        "outputShape": Blockly.OUTPUT_SHAPE_ROUND,
-        "extensions": ["colours_operators"]
+        "extensions": ["colours_operators", "output_number"]
       });
   }
 };
@@ -158,11 +146,8 @@ Blockly.Blocks['operator_random'] = {
             "name": "TO"
           }
         ],
-        "inputsInline": true,
-        "output": "Number",
         "category": Blockly.Categories.operators,
-        "outputShape": Blockly.OUTPUT_SHAPE_ROUND,
-        "extensions": ["colours_operators"]
+        "extensions": ["colours_operators", "output_number"]
       });
   }
 };
@@ -185,11 +170,8 @@ Blockly.Blocks['operator_lt'] = {
           "name": "OPERAND2"
         }
       ],
-      "inputsInline": true,
-      "output": "Boolean",
       "category": Blockly.Categories.operators,
-      "outputShape": Blockly.OUTPUT_SHAPE_HEXAGONAL,
-      "extensions": ["colours_operators"]
+      "extensions": ["colours_operators", "output_boolean"]
     });
   }
 };
@@ -212,11 +194,8 @@ Blockly.Blocks['operator_equals'] = {
           "name": "OPERAND2"
         }
       ],
-      "inputsInline": true,
-      "output": "Boolean",
       "category": Blockly.Categories.operators,
-      "outputShape": Blockly.OUTPUT_SHAPE_HEXAGONAL,
-      "extensions": ["colours_operators"]
+      "extensions": ["colours_operators", "output_boolean"]
     });
   }
 };
@@ -239,11 +218,8 @@ Blockly.Blocks['operator_gt'] = {
           "name": "OPERAND2"
         }
       ],
-      "inputsInline": true,
-      "output": "Boolean",
       "category": Blockly.Categories.operators,
-      "outputShape": Blockly.OUTPUT_SHAPE_HEXAGONAL,
-      "extensions": ["colours_operators"]
+      "extensions": ["colours_operators", "output_boolean"]
     });
   }
 };
@@ -268,11 +244,8 @@ Blockly.Blocks['operator_and'] = {
           "check": "Boolean"
         }
       ],
-      "inputsInline": true,
-      "output": "Boolean",
       "category": Blockly.Categories.operators,
-      "outputShape": Blockly.OUTPUT_SHAPE_HEXAGONAL,
-      "extensions": ["colours_operators"]
+      "extensions": ["colours_operators", "output_boolean"]
     });
   }
 };
@@ -297,11 +270,8 @@ Blockly.Blocks['operator_or'] = {
           "check": "Boolean"
         }
       ],
-      "inputsInline": true,
-      "output": "Boolean",
       "category": Blockly.Categories.operators,
-      "outputShape": Blockly.OUTPUT_SHAPE_HEXAGONAL,
-      "extensions": ["colours_operators"]
+      "extensions": ["colours_operators", "output_boolean"]
     });
   }
 };
@@ -321,11 +291,8 @@ Blockly.Blocks['operator_not'] = {
           "check": "Boolean"
         }
       ],
-      "inputsInline": true,
-      "output": "Boolean",
       "category": Blockly.Categories.operators,
-      "outputShape": Blockly.OUTPUT_SHAPE_HEXAGONAL,
-      "extensions": ["colours_operators"]
+      "extensions": ["colours_operators", "output_boolean"]
     });
   }
 };
@@ -348,11 +315,8 @@ Blockly.Blocks['operator_join'] = {
           "name": "STRING2"
         }
       ],
-      "inputsInline": true,
-      "output": "String",
       "category": Blockly.Categories.operators,
-      "outputShape": Blockly.OUTPUT_SHAPE_ROUND,
-      "extensions": ["colours_operators"]
+      "extensions": ["colours_operators", "output_string"]
     });
   }
 };
@@ -375,11 +339,8 @@ Blockly.Blocks['operator_letter_of'] = {
           "name": "STRING"
         }
       ],
-      "inputsInline": true,
-      "output": "String",
       "category": Blockly.Categories.operators,
-      "outputShape": Blockly.OUTPUT_SHAPE_ROUND,
-      "extensions": ["colours_operators"]
+      "extensions": ["colours_operators", "output_string"]
     });
   }
 };
@@ -398,11 +359,8 @@ Blockly.Blocks['operator_length'] = {
           "name": "STRING"
         }
       ],
-      "inputsInline": true,
-      "output": "Number",
       "category": Blockly.Categories.operators,
-      "outputShape": Blockly.OUTPUT_SHAPE_ROUND,
-      "extensions": ["colours_operators"]
+      "extensions": ["colours_operators", "output_string"]
     });
   }
 };
@@ -426,11 +384,8 @@ Blockly.Blocks['operator_mod'] = {
             "name": "NUM2"
           }
         ],
-        "inputsInline": true,
-        "output": "Number",
         "category": Blockly.Categories.operators,
-        "outputShape": Blockly.OUTPUT_SHAPE_ROUND,
-        "extensions": ["colours_operators"]
+        "extensions": ["colours_operators", "output_number"]
       });
   }
 };
@@ -450,11 +405,8 @@ Blockly.Blocks['operator_round'] = {
             "name": "NUM"
           }
         ],
-        "inputsInline": true,
-        "output": "Number",
         "category": Blockly.Categories.operators,
-        "outputShape": Blockly.OUTPUT_SHAPE_ROUND,
-        "extensions": ["colours_operators"]
+        "extensions": ["colours_operators", "output_number"]
       });
   }
 };
@@ -494,11 +446,8 @@ Blockly.Blocks['operator_mathop'] = {
             "name": "NUM"
           }
         ],
-        "inputsInline": true,
-        "output": "Number",
         "category": Blockly.Categories.operators,
-        "outputShape": Blockly.OUTPUT_SHAPE_ROUND,
-        "extensions": ["colours_operators"]
+        "extensions": ["colours_operators", "output_number"]
       });
   }
 };

--- a/blocks_vertical/operators.js
+++ b/blocks_vertical/operators.js
@@ -49,10 +49,8 @@ Blockly.Blocks['operator_add'] = {
         "inputsInline": true,
         "output": "Number",
         "category": Blockly.Categories.operators,
-        "colour": Blockly.Colours.operators.primary,
-        "colourSecondary": Blockly.Colours.operators.secondary,
-        "colourTertiary": Blockly.Colours.operators.tertiary,
-        "outputShape": Blockly.OUTPUT_SHAPE_ROUND
+        "outputShape": Blockly.OUTPUT_SHAPE_ROUND,
+        "extensions": ["colours_operators"]
       });
   }
 };
@@ -79,10 +77,8 @@ Blockly.Blocks['operator_subtract'] = {
         "inputsInline": true,
         "output": "Number",
         "category": Blockly.Categories.operators,
-        "colour": Blockly.Colours.operators.primary,
-        "colourSecondary": Blockly.Colours.operators.secondary,
-        "colourTertiary": Blockly.Colours.operators.tertiary,
-        "outputShape": Blockly.OUTPUT_SHAPE_ROUND
+        "outputShape": Blockly.OUTPUT_SHAPE_ROUND,
+        "extensions": ["colours_operators"]
       });
   }
 };
@@ -109,10 +105,8 @@ Blockly.Blocks['operator_multiply'] = {
         "inputsInline": true,
         "output": "Number",
         "category": Blockly.Categories.operators,
-        "colour": Blockly.Colours.operators.primary,
-        "colourSecondary": Blockly.Colours.operators.secondary,
-        "colourTertiary": Blockly.Colours.operators.tertiary,
-        "outputShape": Blockly.OUTPUT_SHAPE_ROUND
+        "outputShape": Blockly.OUTPUT_SHAPE_ROUND,
+        "extensions": ["colours_operators"]
       });
   }
 };
@@ -139,10 +133,8 @@ Blockly.Blocks['operator_divide'] = {
         "inputsInline": true,
         "output": "Number",
         "category": Blockly.Categories.operators,
-        "colour": Blockly.Colours.operators.primary,
-        "colourSecondary": Blockly.Colours.operators.secondary,
-        "colourTertiary": Blockly.Colours.operators.tertiary,
-        "outputShape": Blockly.OUTPUT_SHAPE_ROUND
+        "outputShape": Blockly.OUTPUT_SHAPE_ROUND,
+        "extensions": ["colours_operators"]
       });
   }
 };
@@ -169,10 +161,8 @@ Blockly.Blocks['operator_random'] = {
         "inputsInline": true,
         "output": "Number",
         "category": Blockly.Categories.operators,
-        "colour": Blockly.Colours.operators.primary,
-        "colourSecondary": Blockly.Colours.operators.secondary,
-        "colourTertiary": Blockly.Colours.operators.tertiary,
-        "outputShape": Blockly.OUTPUT_SHAPE_ROUND
+        "outputShape": Blockly.OUTPUT_SHAPE_ROUND,
+        "extensions": ["colours_operators"]
       });
   }
 };
@@ -198,10 +188,8 @@ Blockly.Blocks['operator_lt'] = {
       "inputsInline": true,
       "output": "Boolean",
       "category": Blockly.Categories.operators,
-      "colour": Blockly.Colours.operators.primary,
-      "colourSecondary": Blockly.Colours.operators.secondary,
-      "colourTertiary": Blockly.Colours.operators.tertiary,
-      "outputShape": Blockly.OUTPUT_SHAPE_HEXAGONAL
+      "outputShape": Blockly.OUTPUT_SHAPE_HEXAGONAL,
+      "extensions": ["colours_operators"]
     });
   }
 };
@@ -227,10 +215,8 @@ Blockly.Blocks['operator_equals'] = {
       "inputsInline": true,
       "output": "Boolean",
       "category": Blockly.Categories.operators,
-      "colour": Blockly.Colours.operators.primary,
-      "colourSecondary": Blockly.Colours.operators.secondary,
-      "colourTertiary": Blockly.Colours.operators.tertiary,
-      "outputShape": Blockly.OUTPUT_SHAPE_HEXAGONAL
+      "outputShape": Blockly.OUTPUT_SHAPE_HEXAGONAL,
+      "extensions": ["colours_operators"]
     });
   }
 };
@@ -256,10 +242,8 @@ Blockly.Blocks['operator_gt'] = {
       "inputsInline": true,
       "output": "Boolean",
       "category": Blockly.Categories.operators,
-      "colour": Blockly.Colours.operators.primary,
-      "colourSecondary": Blockly.Colours.operators.secondary,
-      "colourTertiary": Blockly.Colours.operators.tertiary,
-      "outputShape": Blockly.OUTPUT_SHAPE_HEXAGONAL
+      "outputShape": Blockly.OUTPUT_SHAPE_HEXAGONAL,
+      "extensions": ["colours_operators"]
     });
   }
 };
@@ -287,10 +271,8 @@ Blockly.Blocks['operator_and'] = {
       "inputsInline": true,
       "output": "Boolean",
       "category": Blockly.Categories.operators,
-      "colour": Blockly.Colours.operators.primary,
-      "colourSecondary": Blockly.Colours.operators.secondary,
-      "colourTertiary": Blockly.Colours.operators.tertiary,
-      "outputShape": Blockly.OUTPUT_SHAPE_HEXAGONAL
+      "outputShape": Blockly.OUTPUT_SHAPE_HEXAGONAL,
+      "extensions": ["colours_operators"]
     });
   }
 };
@@ -318,10 +300,8 @@ Blockly.Blocks['operator_or'] = {
       "inputsInline": true,
       "output": "Boolean",
       "category": Blockly.Categories.operators,
-      "colour": Blockly.Colours.operators.primary,
-      "colourSecondary": Blockly.Colours.operators.secondary,
-      "colourTertiary": Blockly.Colours.operators.tertiary,
-      "outputShape": Blockly.OUTPUT_SHAPE_HEXAGONAL
+      "outputShape": Blockly.OUTPUT_SHAPE_HEXAGONAL,
+      "extensions": ["colours_operators"]
     });
   }
 };
@@ -344,10 +324,8 @@ Blockly.Blocks['operator_not'] = {
       "inputsInline": true,
       "output": "Boolean",
       "category": Blockly.Categories.operators,
-      "colour": Blockly.Colours.operators.primary,
-      "colourSecondary": Blockly.Colours.operators.secondary,
-      "colourTertiary": Blockly.Colours.operators.tertiary,
-      "outputShape": Blockly.OUTPUT_SHAPE_HEXAGONAL
+      "outputShape": Blockly.OUTPUT_SHAPE_HEXAGONAL,
+      "extensions": ["colours_operators"]
     });
   }
 };
@@ -373,10 +351,8 @@ Blockly.Blocks['operator_join'] = {
       "inputsInline": true,
       "output": "String",
       "category": Blockly.Categories.operators,
-      "colour": Blockly.Colours.operators.primary,
-      "colourSecondary": Blockly.Colours.operators.secondary,
-      "colourTertiary": Blockly.Colours.operators.tertiary,
-      "outputShape": Blockly.OUTPUT_SHAPE_ROUND
+      "outputShape": Blockly.OUTPUT_SHAPE_ROUND,
+      "extensions": ["colours_operators"]
     });
   }
 };
@@ -402,10 +378,8 @@ Blockly.Blocks['operator_letter_of'] = {
       "inputsInline": true,
       "output": "String",
       "category": Blockly.Categories.operators,
-      "colour": Blockly.Colours.operators.primary,
-      "colourSecondary": Blockly.Colours.operators.secondary,
-      "colourTertiary": Blockly.Colours.operators.tertiary,
-      "outputShape": Blockly.OUTPUT_SHAPE_ROUND
+      "outputShape": Blockly.OUTPUT_SHAPE_ROUND,
+      "extensions": ["colours_operators"]
     });
   }
 };
@@ -427,10 +401,8 @@ Blockly.Blocks['operator_length'] = {
       "inputsInline": true,
       "output": "Number",
       "category": Blockly.Categories.operators,
-      "colour": Blockly.Colours.operators.primary,
-      "colourSecondary": Blockly.Colours.operators.secondary,
-      "colourTertiary": Blockly.Colours.operators.tertiary,
-      "outputShape": Blockly.OUTPUT_SHAPE_ROUND
+      "outputShape": Blockly.OUTPUT_SHAPE_ROUND,
+      "extensions": ["colours_operators"]
     });
   }
 };
@@ -457,10 +429,8 @@ Blockly.Blocks['operator_mod'] = {
         "inputsInline": true,
         "output": "Number",
         "category": Blockly.Categories.operators,
-        "colour": Blockly.Colours.operators.primary,
-        "colourSecondary": Blockly.Colours.operators.secondary,
-        "colourTertiary": Blockly.Colours.operators.tertiary,
-        "outputShape": Blockly.OUTPUT_SHAPE_ROUND
+        "outputShape": Blockly.OUTPUT_SHAPE_ROUND,
+        "extensions": ["colours_operators"]
       });
   }
 };
@@ -483,10 +453,8 @@ Blockly.Blocks['operator_round'] = {
         "inputsInline": true,
         "output": "Number",
         "category": Blockly.Categories.operators,
-        "colour": Blockly.Colours.operators.primary,
-        "colourSecondary": Blockly.Colours.operators.secondary,
-        "colourTertiary": Blockly.Colours.operators.tertiary,
-        "outputShape": Blockly.OUTPUT_SHAPE_ROUND
+        "outputShape": Blockly.OUTPUT_SHAPE_ROUND,
+        "extensions": ["colours_operators"]
       });
   }
 };
@@ -529,10 +497,8 @@ Blockly.Blocks['operator_mathop'] = {
         "inputsInline": true,
         "output": "Number",
         "category": Blockly.Categories.operators,
-        "colour": Blockly.Colours.operators.primary,
-        "colourSecondary": Blockly.Colours.operators.secondary,
-        "colourTertiary": Blockly.Colours.operators.tertiary,
-        "outputShape": Blockly.OUTPUT_SHAPE_ROUND
+        "outputShape": Blockly.OUTPUT_SHAPE_ROUND,
+        "extensions": ["colours_operators"]
       });
   }
 };

--- a/blocks_vertical/pen.js
+++ b/blocks_vertical/pen.js
@@ -25,6 +25,7 @@ goog.provide('Blockly.Blocks.pen');
 goog.require('Blockly.Blocks');
 goog.require('Blockly.Colours');
 goog.require('Blockly.constants');
+goog.require('Blockly.ScratchBlocks.VerticalExtensions');
 
 
 Blockly.Blocks['pen_clear'] = {

--- a/blocks_vertical/pen.js
+++ b/blocks_vertical/pen.js
@@ -35,12 +35,8 @@ Blockly.Blocks['pen_clear'] = {
   init: function() {
     this.jsonInit({
       "message0": "clear",
-      "previousStatement": null,
-      "nextStatement": null,
       "category": Blockly.Categories.pen,
-      "colour": Blockly.Colours.pen.primary,
-      "colourSecondary": Blockly.Colours.pen.secondary,
-      "colourTertiary": Blockly.Colours.pen.tertiary
+      "extensions": ["colours_pen", "shape_statement"]
     });
   }
 };
@@ -53,12 +49,8 @@ Blockly.Blocks['pen_stamp'] = {
   init: function() {
     this.jsonInit({
       "message0": "stamp",
-      "previousStatement": null,
-      "nextStatement": null,
       "category": Blockly.Categories.pen,
-      "colour": Blockly.Colours.pen.primary,
-      "colourSecondary": Blockly.Colours.pen.secondary,
-      "colourTertiary": Blockly.Colours.pen.tertiary
+      "extensions": ["colours_pen", "shape_statement"]
     });
   }
 };
@@ -71,12 +63,8 @@ Blockly.Blocks['pen_pendown'] = {
   init: function() {
     this.jsonInit({
       "message0": "pen down",
-      "previousStatement": null,
-      "nextStatement": null,
       "category": Blockly.Categories.pen,
-      "colour": Blockly.Colours.pen.primary,
-      "colourSecondary": Blockly.Colours.pen.secondary,
-      "colourTertiary": Blockly.Colours.pen.tertiary
+      "extensions": ["colours_pen", "shape_statement"]
     });
   }
 };
@@ -89,12 +77,8 @@ Blockly.Blocks['pen_penup'] = {
   init: function() {
     this.jsonInit({
       "message0": "pen up",
-      "previousStatement": null,
-      "nextStatement": null,
       "category": Blockly.Categories.pen,
-      "colour": Blockly.Colours.pen.primary,
-      "colourSecondary": Blockly.Colours.pen.secondary,
-      "colourTertiary": Blockly.Colours.pen.tertiary
+      "extensions": ["colours_pen", "shape_statement"]
     });
   }
 };
@@ -113,12 +97,8 @@ Blockly.Blocks['pen_setpencolortocolor'] = {
           "name": "COLOR"
         }
       ],
-      "previousStatement": null,
-      "nextStatement": null,
       "category": Blockly.Categories.pen,
-      "colour": Blockly.Colours.pen.primary,
-      "colourSecondary": Blockly.Colours.pen.secondary,
-      "colourTertiary": Blockly.Colours.pen.tertiary
+      "extensions": ["colours_pen", "shape_statement"]
     });
   }
 };
@@ -137,12 +117,8 @@ Blockly.Blocks['pen_changepencolorby'] = {
           "name": "COLOR"
         }
       ],
-      "previousStatement": null,
-      "nextStatement": null,
       "category": Blockly.Categories.pen,
-      "colour": Blockly.Colours.pen.primary,
-      "colourSecondary": Blockly.Colours.pen.secondary,
-      "colourTertiary": Blockly.Colours.pen.tertiary
+      "extensions": ["colours_pen", "shape_statement"]
     });
   }
 };
@@ -161,12 +137,8 @@ Blockly.Blocks['pen_setpencolortonum'] = {
           "name": "COLOR"
         }
       ],
-      "previousStatement": null,
-      "nextStatement": null,
       "category": Blockly.Categories.pen,
-      "colour": Blockly.Colours.pen.primary,
-      "colourSecondary": Blockly.Colours.pen.secondary,
-      "colourTertiary": Blockly.Colours.pen.tertiary
+      "extensions": ["colours_pen", "shape_statement"]
     });
   }
 };
@@ -185,12 +157,8 @@ Blockly.Blocks['pen_changepenshadeby'] = {
           "name": "SHADE"
         }
       ],
-      "previousStatement": null,
-      "nextStatement": null,
       "category": Blockly.Categories.pen,
-      "colour": Blockly.Colours.pen.primary,
-      "colourSecondary": Blockly.Colours.pen.secondary,
-      "colourTertiary": Blockly.Colours.pen.tertiary
+      "extensions": ["colours_pen", "shape_statement"]
     });
   }
 };
@@ -209,12 +177,8 @@ Blockly.Blocks['pen_setpenshadeto'] = {
           "name": "SHADE"
         }
       ],
-      "previousStatement": null,
-      "nextStatement": null,
       "category": Blockly.Categories.pen,
-      "colour": Blockly.Colours.pen.primary,
-      "colourSecondary": Blockly.Colours.pen.secondary,
-      "colourTertiary": Blockly.Colours.pen.tertiary
+      "extensions": ["colours_pen", "shape_statement"]
     });
   }
 };
@@ -233,12 +197,8 @@ Blockly.Blocks['pen_changepensizeby'] = {
           "name": "SIZE"
         }
       ],
-      "previousStatement": null,
-      "nextStatement": null,
       "category": Blockly.Categories.pen,
-      "colour": Blockly.Colours.pen.primary,
-      "colourSecondary": Blockly.Colours.pen.secondary,
-      "colourTertiary": Blockly.Colours.pen.tertiary
+      "extensions": ["colours_pen", "shape_statement"]
     });
   }
 };
@@ -257,12 +217,8 @@ Blockly.Blocks['pen_setpensizeto'] = {
           "name": "SIZE"
         }
       ],
-      "previousStatement": null,
-      "nextStatement": null,
       "category": Blockly.Categories.pen,
-      "colour": Blockly.Colours.pen.primary,
-      "colourSecondary": Blockly.Colours.pen.secondary,
-      "colourTertiary": Blockly.Colours.pen.tertiary
+      "extensions": ["colours_pen", "shape_statement"]
     });
   }
 };

--- a/blocks_vertical/sensing.js
+++ b/blocks_vertical/sensing.js
@@ -25,6 +25,7 @@ goog.provide('Blockly.Blocks.sensing');
 goog.require('Blockly.Blocks');
 goog.require('Blockly.Colours');
 goog.require('Blockly.constants');
+goog.require('Blockly.ScratchBlocks.VerticalExtensions');
 
 
 Blockly.Blocks['sensing_touchingobject'] = {

--- a/blocks_vertical/sensing.js
+++ b/blocks_vertical/sensing.js
@@ -41,13 +41,8 @@ Blockly.Blocks['sensing_touchingobject'] = {
           "name": "TOUCHINGOBJECTMENU"
         }
       ],
-      "inputsInline": true,
-      "output": "Boolean",
       "category": Blockly.Categories.sensing,
-      "colour": Blockly.Colours.sensing.primary,
-      "colourSecondary": Blockly.Colours.sensing.secondary,
-      "colourTertiary": Blockly.Colours.sensing.tertiary,
-      "outputShape": Blockly.OUTPUT_SHAPE_HEXAGONAL
+      "extensions": ["colours_sensing", "output_boolean"]
     });
   }
 };
@@ -71,12 +66,10 @@ Blockly.Blocks['sensing_touchingobjectmenu'] = {
             ]
           }
         ],
-        "inputsInline": true,
-        "output": "String",
         "colour": Blockly.Colours.sensing.secondary,
         "colourSecondary": Blockly.Colours.sensing.secondary,
         "colourTertiary": Blockly.Colours.sensing.tertiary,
-        "outputShape": Blockly.OUTPUT_SHAPE_ROUND
+        "extensions": ["output_string"]
       });
   }
 };
@@ -95,13 +88,8 @@ Blockly.Blocks['sensing_touchingcolor'] = {
           "name": "COLOR"
         }
       ],
-      "inputsInline": true,
-      "output": "Boolean",
       "category": Blockly.Categories.sensing,
-      "colour": Blockly.Colours.sensing.primary,
-      "colourSecondary": Blockly.Colours.sensing.secondary,
-      "colourTertiary": Blockly.Colours.sensing.tertiary,
-      "outputShape": Blockly.OUTPUT_SHAPE_HEXAGONAL
+      "extensions": ["colours_sensing", "output_boolean"]
     });
   }
 };
@@ -124,13 +112,8 @@ Blockly.Blocks['sensing_coloristouchingcolor'] = {
           "name": "COLOR2"
         }
       ],
-      "inputsInline": true,
-      "output": "Boolean",
       "category": Blockly.Categories.sensing,
-      "colour": Blockly.Colours.sensing.primary,
-      "colourSecondary": Blockly.Colours.sensing.secondary,
-      "colourTertiary": Blockly.Colours.sensing.tertiary,
-      "outputShape": Blockly.OUTPUT_SHAPE_HEXAGONAL
+      "extensions": ["colours_sensing", "output_boolean"]
     });
   }
 };
@@ -150,11 +133,7 @@ Blockly.Blocks['sensing_distanceto'] = {
         }
       ],
       "category": Blockly.Categories.sensing,
-      "colour": Blockly.Colours.sensing.primary,
-      "colourSecondary": Blockly.Colours.sensing.secondary,
-      "colourTertiary": Blockly.Colours.sensing.tertiary,
-      "output": "Number",
-      "outputShape": Blockly.OUTPUT_SHAPE_ROUND
+      "extensions": ["colours_sensing", "output_number"]
     });
   }
 };
@@ -204,9 +183,7 @@ Blockly.Blocks['sensing_askandwait'] = {
       "previousStatement": null,
       "nextStatement": null,
       "category": Blockly.Categories.sensing,
-      "colour": Blockly.Colours.sensing.primary,
-      "colourSecondary": Blockly.Colours.sensing.secondary,
-      "colourTertiary": Blockly.Colours.sensing.tertiary
+      "extensions": ["colours_sensing"]
     });
   }
 };
@@ -220,12 +197,10 @@ Blockly.Blocks['sensing_answer'] = {
     this.jsonInit({
       "message0": "answer",
       "category": Blockly.Categories.sensing,
-      "colour": Blockly.Colours.sensing.primary,
-      "colourSecondary": Blockly.Colours.sensing.secondary,
-      "colourTertiary": Blockly.Colours.sensing.tertiary,
       "output": "Number",
       "outputShape": Blockly.OUTPUT_SHAPE_ROUND,
-      "checkboxInFlyout": true
+      "checkboxInFlyout": true,
+      "extensions": ["colours_sensing"]
     });
   }
 };
@@ -244,13 +219,8 @@ Blockly.Blocks['sensing_keypressed'] = {
           "name": "KEY_OPTION"
         }
       ],
-      "inputsInline": true,
-      "output": "Boolean",
       "category": Blockly.Categories.sensing,
-      "colour": Blockly.Colours.sensing.primary,
-      "colourSecondary": Blockly.Colours.sensing.secondary,
-      "colourTertiary": Blockly.Colours.sensing.tertiary,
-      "outputShape": Blockly.OUTPUT_SHAPE_HEXAGONAL
+      "extensions": ["colours_sensing", "output_boolean"]
     });
   }
 };
@@ -332,13 +302,8 @@ Blockly.Blocks['sensing_mousedown'] = {
   init: function() {
     this.jsonInit({
       "message0": "mouse down?",
-      "inputsInline": true,
-      "output": "Boolean",
       "category": Blockly.Categories.sensing,
-      "colour": Blockly.Colours.sensing.primary,
-      "colourSecondary": Blockly.Colours.sensing.secondary,
-      "colourTertiary": Blockly.Colours.sensing.tertiary,
-      "outputShape": Blockly.OUTPUT_SHAPE_HEXAGONAL
+      "extensions": ["colours_sensing", "output_boolean"]
     });
   }
 };
@@ -352,11 +317,7 @@ Blockly.Blocks['sensing_mousex'] = {
     this.jsonInit({
       "message0": "mouse x",
       "category": Blockly.Categories.sensing,
-      "colour": Blockly.Colours.sensing.primary,
-      "colourSecondary": Blockly.Colours.sensing.secondary,
-      "colourTertiary": Blockly.Colours.sensing.tertiary,
-      "output": "Number",
-      "outputShape": Blockly.OUTPUT_SHAPE_ROUND
+      "extensions": ["colours_sensing", "output_number"]
     });
   }
 };
@@ -370,11 +331,7 @@ Blockly.Blocks['sensing_mousey'] = {
     this.jsonInit({
       "message0": "mouse y",
       "category": Blockly.Categories.sensing,
-      "colour": Blockly.Colours.sensing.primary,
-      "colourSecondary": Blockly.Colours.sensing.secondary,
-      "colourTertiary": Blockly.Colours.sensing.tertiary,
-      "output": "Number",
-      "outputShape": Blockly.OUTPUT_SHAPE_ROUND
+      "extensions": ["colours_sensing", "output_number"]
     });
   }
 };
@@ -388,12 +345,8 @@ Blockly.Blocks['sensing_loudness'] = {
     this.jsonInit({
       "message0": "loudness",
       "category": Blockly.Categories.sensing,
-      "colour": Blockly.Colours.sensing.primary,
-      "colourSecondary": Blockly.Colours.sensing.secondary,
-      "colourTertiary": Blockly.Colours.sensing.tertiary,
-      "output": "Number",
-      "outputShape": Blockly.OUTPUT_SHAPE_ROUND,
-      "checkboxInFlyout": true
+      "checkboxInFlyout": true,
+      "extensions": ["colours_sensing", "output_number"]
     });
   }
 };
@@ -419,11 +372,9 @@ Blockly.Blocks['sensing_videoon'] = {
       "inputsInline": true,
       "output": "Number",
       "category": Blockly.Categories.sensing,
-      "colour": Blockly.Colours.sensing.primary,
-      "colourSecondary": Blockly.Colours.sensing.secondary,
-      "colourTertiary": Blockly.Colours.sensing.tertiary,
       "outputShape": Blockly.OUTPUT_SHAPE_ROUND,
-      "checkboxInFlyout": true
+      "checkboxInFlyout": true,
+      "extensions": ["colours_sensing"]
     });
   }
 };
@@ -501,9 +452,7 @@ Blockly.Blocks['sensing_videotoggle'] = {
       "previousStatement": null,
       "nextStatement": null,
       "category": Blockly.Categories.sensing,
-      "colour": Blockly.Colours.sensing.primary,
-      "colourSecondary": Blockly.Colours.sensing.secondary,
-      "colourTertiary": Blockly.Colours.sensing.tertiary
+      "extensions": ["colours_sensing"]
     });
   }
 };
@@ -555,9 +504,7 @@ Blockly.Blocks['sensing_setvideotransparency'] = {
       "previousStatement": null,
       "nextStatement": null,
       "category": Blockly.Categories.sensing,
-      "colour": Blockly.Colours.sensing.primary,
-      "colourSecondary": Blockly.Colours.sensing.secondary,
-      "colourTertiary": Blockly.Colours.sensing.tertiary
+      "extensions": ["colours_sensing"]
     });
   }
 };
@@ -571,12 +518,10 @@ Blockly.Blocks['sensing_timer'] = {
     this.jsonInit({
       "message0": "timer",
       "category": Blockly.Categories.sensing,
-      "colour": Blockly.Colours.sensing.primary,
-      "colourSecondary": Blockly.Colours.sensing.secondary,
-      "colourTertiary": Blockly.Colours.sensing.tertiary,
       "output": "Number",
       "outputShape": Blockly.OUTPUT_SHAPE_ROUND,
-      "checkboxInFlyout": true
+      "checkboxInFlyout": true,
+      "extensions": ["colours_sensing"]
     });
   }
 };
@@ -592,9 +537,7 @@ Blockly.Blocks['sensing_resettimer'] = {
       "previousStatement": null,
       "nextStatement": null,
       "category": Blockly.Categories.sensing,
-      "colour": Blockly.Colours.sensing.primary,
-      "colourSecondary": Blockly.Colours.sensing.secondary,
-      "colourTertiary": Blockly.Colours.sensing.tertiary
+      "extensions": ["colours_sensing"]
     });
   }
 };
@@ -685,11 +628,9 @@ Blockly.Blocks['sensing_of'] = {
       ],
       "output": true,
       "category": Blockly.Categories.sensing,
-      "colour": Blockly.Colours.sensing.primary,
-      "colourSecondary": Blockly.Colours.sensing.secondary,
-      "colourTertiary": Blockly.Colours.sensing.tertiary,
       "outputShape": Blockly.OUTPUT_SHAPE_ROUND,
-      "checkboxInFlyout": true
+      "checkboxInFlyout": true,
+      "extensions": ["colours_sensing"]
     });
   }
 };
@@ -711,11 +652,9 @@ Blockly.Blocks['sensing_current'] = {
       "inputsInline": true,
       "output": "Number",
       "category": Blockly.Categories.sensing,
-      "colour": Blockly.Colours.sensing.primary,
-      "colourSecondary": Blockly.Colours.sensing.secondary,
-      "colourTertiary": Blockly.Colours.sensing.tertiary,
       "outputShape": Blockly.OUTPUT_SHAPE_ROUND,
-      "checkboxInFlyout": true
+      "checkboxInFlyout": true,
+      "extensions": ["colours_sensing"]
     });
   }
 };
@@ -763,11 +702,9 @@ Blockly.Blocks['sensing_dayssince2000'] = {
     this.jsonInit({
       "message0": "days since 2000",
       "category": Blockly.Categories.sensing,
-      "colour": Blockly.Colours.sensing.primary,
-      "colourSecondary": Blockly.Colours.sensing.secondary,
-      "colourTertiary": Blockly.Colours.sensing.tertiary,
       "output": "Number",
-      "outputShape": Blockly.OUTPUT_SHAPE_ROUND
+      "outputShape": Blockly.OUTPUT_SHAPE_ROUND,
+      "extensions": ["colours_sensing"]
     });
   }
 };
@@ -781,12 +718,10 @@ Blockly.Blocks['sensing_username'] = {
     this.jsonInit({
       "message0": "username",
       "category": Blockly.Categories.sensing,
-      "colour": Blockly.Colours.sensing.primary,
-      "colourSecondary": Blockly.Colours.sensing.secondary,
-      "colourTertiary": Blockly.Colours.sensing.tertiary,
       "output": "Number",
       "outputShape": Blockly.OUTPUT_SHAPE_ROUND,
-      "checkboxInFlyout": true
+      "checkboxInFlyout": true,
+      "extensions": ["colours_sensing"]
     });
   }
 };

--- a/blocks_vertical/sound.js
+++ b/blocks_vertical/sound.js
@@ -54,12 +54,10 @@ Blockly.Blocks['sound_sounds_menu'] = {
             ]
           }
         ],
-        "inputsInline": true,
-        "output": "String",
         "colour": Blockly.Colours.sounds.secondary,
         "colourSecondary": Blockly.Colours.sounds.secondary,
         "colourTertiary": Blockly.Colours.sounds.tertiary,
-        "outputShape": Blockly.OUTPUT_SHAPE_ROUND
+        "extensions": ["output_string"]
       });
   }
 };
@@ -152,12 +150,10 @@ Blockly.Blocks['sound_drums_menu'] = {
             ]
           }
         ],
-        "inputsInline": true,
-        "output": "String",
         "colour": Blockly.Colours.sounds.secondary,
         "colourSecondary": Blockly.Colours.sounds.secondary,
         "colourTertiary": Blockly.Colours.sounds.tertiary,
-        "outputShape": Blockly.OUTPUT_SHAPE_ROUND
+        "extensions": ["output_string"]
       });
   }
 };
@@ -339,12 +335,10 @@ Blockly.Blocks['sound_instruments_menu'] = {
             ]
           }
         ],
-        "inputsInline": true,
-        "output": "String",
         "colour": Blockly.Colours.sounds.secondary,
         "colourSecondary": Blockly.Colours.sounds.secondary,
         "colourTertiary": Blockly.Colours.sounds.tertiary,
-        "outputShape": Blockly.OUTPUT_SHAPE_ROUND
+        "extensions": ["output_string"]
       });
   }
 };
@@ -418,10 +412,8 @@ Blockly.Blocks['sound_volume'] = {
     this.jsonInit({
       "message0": "volume",
       "category": Blockly.Categories.sound,
-      "extensions": ["colours_sounds"],
-      "output": "Number",
-      "outputShape": Blockly.OUTPUT_SHAPE_ROUND,
-      "checkboxInFlyout": true
+      "checkboxInFlyout": true,
+      "extensions": ["colours_sounds", "output_number"]
     });
   }
 };
@@ -475,10 +467,8 @@ Blockly.Blocks['sound_tempo'] = {
     this.jsonInit({
       "message0": "tempo",
       "category": Blockly.Categories.sound,
-      "extensions": ["colours_sounds"],
-      "output": "Number",
-      "outputShape": Blockly.OUTPUT_SHAPE_ROUND,
-      "checkboxInFlyout": true
+      "checkboxInFlyout": true,
+      "extensions": ["colours_sounds", "output_number"]
     });
   }
 };

--- a/blocks_vertical/vertical_extensions.js
+++ b/blocks_vertical/vertical_extensions.js
@@ -31,7 +31,6 @@ goog.provide('Blockly.ScratchBlocks.VerticalExtensions');
 
 goog.require('Blockly.Colours');
 goog.require('Blockly.constants');
-goog.require('Blockly.Extensions');
 
 
 /**

--- a/blocks_vertical/vertical_extensions.js
+++ b/blocks_vertical/vertical_extensions.js
@@ -27,7 +27,17 @@ goog.require('Blockly.constants');
 goog.require('Blockly.Extensions');
 
 
+/**
+ * Helper function that generates an extension based on a category name.
+ * The generated function with set primary, secondary, and tertiary colours
+ * based on the category name.
+ * @param {String} category The name of the category to set colours for.
+ */
 Blockly.ScratchBlocks.VerticalExtensions.colourHelper = function(category) {
+  var colours = Blockly.Colours[category];
+  if (!(colours.primary && colours.secondary && colours.tertiary)) {
+    return function() { };
+  }
   return function() {
     var colours = Blockly.Colours[category];
     this.setColourFromRawValues_(colours.primary, colours.secondary,
@@ -46,15 +56,43 @@ Blockly.ScratchBlocks.VerticalExtensions.SHAPE_STATEMENT = function() {
   this.setNextStatement(true, null);
 };
 
+/**
+ * Extension to make a block be shaped as a hat block, regardless of its
+ * inputs.  That means the block should have a next connection and have inline
+ * inputs, but have no previous connection.
+ */
+Blockly.ScratchBlocks.VerticalExtensions.SHAPE_HAT = function() {
+  this.setInputsInline(true);
+  this.setNextStatement(true, null);
+};
 
-Blockly.Extensions.register('colours_control',
-    Blockly.ScratchBlocks.VerticalExtensions.colourHelper("control"));
+/**
+ * Extension to make a block be shaped as an end block, regardless of its
+ * inputs.  That means the block should have a previous connection and have
+ * inline inputs, but have no next connection.
+ */
+Blockly.ScratchBlocks.VerticalExtensions.SHAPE_END = function() {
+  this.setInputsInline(true);
+  this.setPreviousStatement(true, null);
+};
 
-Blockly.Extensions.register('colours_data',
-    Blockly.ScratchBlocks.VerticalExtensions.colourHelper("data"));
+Blockly.ScratchBlocks.VerticalExtensions.registerAll = function() {
+  var categoryNames =
+      ['control', 'data', 'sounds', 'motion', 'looks', 'event', 'sensing',
+      'pen', 'operators', 'more'];
+  // Register functions for all category colours.
+  for (var i = 0; i < categoryNames.length; i++) {
+    name = categoryNames[i];
+    Blockly.Extensions.register('colours_' + name,
+      Blockly.ScratchBlocks.VerticalExtensions.colourHelper(name));
+  }
+  // Register extensions for common block shapes.
+  Blockly.Extensions.register('shape_statement',
+      Blockly.ScratchBlocks.VerticalExtensions.SHAPE_STATEMENT);
+  Blockly.Extensions.register('shape_hat',
+      Blockly.ScratchBlocks.VerticalExtensions.SHAPE_HAT);
+  Blockly.Extensions.register('shape_end',
+      Blockly.ScratchBlocks.VerticalExtensions.SHAPE_END);
+};
 
-Blockly.Extensions.register('colours_sounds',
-    Blockly.ScratchBlocks.VerticalExtensions.colourHelper("sounds"));
-
-Blockly.Extensions.register('shape_statement',
-    Blockly.ScratchBlocks.VerticalExtensions.SHAPE_STATEMENT);
+Blockly.ScratchBlocks.VerticalExtensions.registerAll();

--- a/blocks_vertical/vertical_extensions.js
+++ b/blocks_vertical/vertical_extensions.js
@@ -18,6 +18,13 @@
  * limitations under the License.
  */
 
+/**
+ * @fileoverview Extensions for vertical blocks in scratch-blocks.
+ * The following extensions can be used to describe a block in Scratch terms.
+ * For instance, a block in the operators colour scheme with a number output
+ * would have the "colours_operators" and "output_number" extensions.
+ * @author fenichel@google.com (Rachel Fenichel)
+ */
 'use strict';
 
 goog.provide('Blockly.ScratchBlocks.VerticalExtensions');
@@ -32,14 +39,24 @@ goog.require('Blockly.Extensions');
  * The generated function with set primary, secondary, and tertiary colours
  * based on the category name.
  * @param {String} category The name of the category to set colours for.
+ * @return {function} An extension function that sets colours based on the given
+ *     category.
  */
 Blockly.ScratchBlocks.VerticalExtensions.colourHelper = function(category) {
   var colours = Blockly.Colours[category];
   if (!(colours.primary && colours.secondary && colours.tertiary)) {
+    /**
+     * Return an empty function, rather than throwing an error later.
+     * @this {Blockly.Block}
+     */
     return function() { };
   }
+  /**
+   * Set the primary, secondary, and tertiary colours on this block for the
+   * given category.
+   * @this {Blockly.Block}
+   */
   return function() {
-    var colours = Blockly.Colours[category];
     this.setColourFromRawValues_(colours.primary, colours.secondary,
         colours.tertiary);
   };
@@ -49,6 +66,8 @@ Blockly.ScratchBlocks.VerticalExtensions.colourHelper = function(category) {
  * Extension to make a block fit into a stack of statements, regardless of its
  * inputs.  That means the block should have a previous connection and a next
  * connection and have inline inputs.
+ * @this {Blockly.Block}
+ * @readonly
  */
 Blockly.ScratchBlocks.VerticalExtensions.SHAPE_STATEMENT = function() {
   this.setInputsInline(true);
@@ -60,6 +79,8 @@ Blockly.ScratchBlocks.VerticalExtensions.SHAPE_STATEMENT = function() {
  * Extension to make a block be shaped as a hat block, regardless of its
  * inputs.  That means the block should have a next connection and have inline
  * inputs, but have no previous connection.
+ * @this {Blockly.Block}
+ * @readonly
  */
 Blockly.ScratchBlocks.VerticalExtensions.SHAPE_HAT = function() {
   this.setInputsInline(true);
@@ -70,32 +91,57 @@ Blockly.ScratchBlocks.VerticalExtensions.SHAPE_HAT = function() {
  * Extension to make a block be shaped as an end block, regardless of its
  * inputs.  That means the block should have a previous connection and have
  * inline inputs, but have no next connection.
+ * @this {Blockly.Block}
+ * @readonly
  */
 Blockly.ScratchBlocks.VerticalExtensions.SHAPE_END = function() {
   this.setInputsInline(true);
   this.setPreviousStatement(true, null);
 };
 
-
+/**
+ * Extension to make represent a number reporter in Scratch-Blocks.
+ * That means the block has inline inputs, a round output shape, and a 'Number'
+ * output type.
+ * @this {Blockly.Block}
+ * @readonly
+ */
 Blockly.ScratchBlocks.VerticalExtensions.OUTPUT_NUMBER = function() {
   this.setInputsInline(true);
   this.setOutputShape(Blockly.OUTPUT_SHAPE_ROUND);
   this.setOutput(true, 'Number');
 };
 
+/**
+ * Extension to make represent a string reporter in Scratch-Blocks.
+ * That means the block has inline inputs, a round output shape, and a 'String'
+ * output type.
+ * @this {Blockly.Block}
+ * @readonly
+ */
 Blockly.ScratchBlocks.VerticalExtensions.OUTPUT_STRING = function() {
   this.setInputsInline(true);
   this.setOutputShape(Blockly.OUTPUT_SHAPE_ROUND);
   this.setOutput(true, 'String');
 };
 
+/**
+ * Extension to make represent a boolean reporter in Scratch-Blocks.
+ * That means the block has inline inputs, a round output shape, and a 'Boolean'
+ * output type.
+ * @this {Blockly.Block}
+ * @readonly
+ */
 Blockly.ScratchBlocks.VerticalExtensions.OUTPUT_BOOLEAN = function() {
   this.setInputsInline(true);
   this.setOutputShape(Blockly.OUTPUT_SHAPE_HEXAGONAL);
   this.setOutput(true, 'Boolean');
 };
 
-
+/**
+ * Register all extensions for scratch-blocks.
+ * @package
+ */
 Blockly.ScratchBlocks.VerticalExtensions.registerAll = function() {
   var categoryNames =
       ['control', 'data', 'sounds', 'motion', 'looks', 'event', 'sensing',
@@ -104,7 +150,7 @@ Blockly.ScratchBlocks.VerticalExtensions.registerAll = function() {
   for (var i = 0; i < categoryNames.length; i++) {
     name = categoryNames[i];
     Blockly.Extensions.register('colours_' + name,
-      Blockly.ScratchBlocks.VerticalExtensions.colourHelper(name));
+        Blockly.ScratchBlocks.VerticalExtensions.colourHelper(name));
   }
   // Register extensions for common block shapes.
   Blockly.Extensions.register('shape_statement',
@@ -113,6 +159,7 @@ Blockly.ScratchBlocks.VerticalExtensions.registerAll = function() {
       Blockly.ScratchBlocks.VerticalExtensions.SHAPE_HAT);
   Blockly.Extensions.register('shape_end',
       Blockly.ScratchBlocks.VerticalExtensions.SHAPE_END);
+
   // Output shapes and types are related.
   Blockly.Extensions.register('output_number',
       Blockly.ScratchBlocks.VerticalExtensions.OUTPUT_NUMBER);

--- a/blocks_vertical/vertical_extensions.js
+++ b/blocks_vertical/vertical_extensions.js
@@ -76,6 +76,26 @@ Blockly.ScratchBlocks.VerticalExtensions.SHAPE_END = function() {
   this.setPreviousStatement(true, null);
 };
 
+
+Blockly.ScratchBlocks.VerticalExtensions.OUTPUT_NUMBER = function() {
+  this.setInputsInline(true);
+  this.setOutputShape(Blockly.OUTPUT_SHAPE_ROUND);
+  this.setOutput(true, 'Number');
+};
+
+Blockly.ScratchBlocks.VerticalExtensions.OUTPUT_STRING = function() {
+  this.setInputsInline(true);
+  this.setOutputShape(Blockly.OUTPUT_SHAPE_ROUND);
+  this.setOutput(true, 'String');
+};
+
+Blockly.ScratchBlocks.VerticalExtensions.OUTPUT_BOOLEAN = function() {
+  this.setInputsInline(true);
+  this.setOutputShape(Blockly.OUTPUT_SHAPE_HEXAGONAL);
+  this.setOutput(true, 'Boolean');
+};
+
+
 Blockly.ScratchBlocks.VerticalExtensions.registerAll = function() {
   var categoryNames =
       ['control', 'data', 'sounds', 'motion', 'looks', 'event', 'sensing',
@@ -93,6 +113,13 @@ Blockly.ScratchBlocks.VerticalExtensions.registerAll = function() {
       Blockly.ScratchBlocks.VerticalExtensions.SHAPE_HAT);
   Blockly.Extensions.register('shape_end',
       Blockly.ScratchBlocks.VerticalExtensions.SHAPE_END);
+  // Output shapes and types are related.
+  Blockly.Extensions.register('output_number',
+      Blockly.ScratchBlocks.VerticalExtensions.OUTPUT_NUMBER);
+  Blockly.Extensions.register('output_string',
+      Blockly.ScratchBlocks.VerticalExtensions.OUTPUT_STRING);
+  Blockly.Extensions.register('output_boolean',
+      Blockly.ScratchBlocks.VerticalExtensions.OUTPUT_BOOLEAN);
 };
 
 Blockly.ScratchBlocks.VerticalExtensions.registerAll();

--- a/build.py
+++ b/build.py
@@ -244,8 +244,6 @@ class Gen_compressed(threading.Thread):
     # Add Blockly.Colours for use of centralized colour bank
     filenames.append(os.path.join("core", "colours.js"))
     filenames.append(os.path.join("core", "constants.js"))
-    # Add Blockly.Extensions for use of Blockly's extensions framework.
-    filenames.append(os.path.join("core", "extensions.js"))
     for filename in filenames:
       f = open(filename)
       params.append(("js_code", "".join(f.readlines())))

--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -477,7 +477,8 @@ Blockly.BlockSvg.prototype.updateColour = function() {
   this.svgPath_.setAttribute('stroke', strokeColour);
 
   // Render block fill
-  var fillColour = (this.isGlowingBlock_) ? this.getColourSecondary() : this.getColour();
+  var fillColour = (this.isGlowingBlock_ || this.isShadow()) ?
+      this.getColourSecondary() : this.getColour();
   this.svgPath_.setAttribute('fill', fillColour);
 
   // Render opacity

--- a/core/extensions.js
+++ b/core/extensions.js
@@ -33,6 +33,11 @@
  **/
 goog.provide('Blockly.Extensions');
 
+goog.require('Blockly.Mutator');
+goog.require('Blockly.utils');
+
+goog.require('goog.string');
+
 
 /**
  * The set of all registered extensions, keyed by extension name/id.


### PR DESCRIPTION
This is a continuation of #938 

I did not handle all blocks in the sensing category, because some seem to have the wrong output types.

Should be a no-op, but significantly shortens block definitions.