### PR TITLE
Use variable field directly instead of shadow

### DIFF
--- a/blocks_vertical/data.js
+++ b/blocks_vertical/data.js
@@ -27,32 +27,6 @@ goog.require('Blockly.Blocks');
 goog.require('Blockly.Colours');
 goog.require('Blockly.constants');
 
-
-Blockly.Blocks['data_variablemenu'] = {
-  /**
-   * Variable menu.
-   * @this Blockly.Block
-   */
-  init: function() {
-    this.jsonInit(
-      {
-        "message0": "%1",
-        "args0": [
-          {
-            "type": "field_variable",
-            "name": "VARIABLE"
-          }
-        ],
-        "inputsInline": true,
-        "output": "String",
-        "colour": Blockly.Colours.data.secondary,
-        "colourSecondary": Blockly.Colours.data.secondary,
-        "colourTertiary": Blockly.Colours.data.tertiary,
-        "outputShape": Blockly.OUTPUT_SHAPE_ROUND
-      });
-  }
-};
-
 Blockly.Blocks['data_variable'] = {
   /**
    * Block of Variables
@@ -90,7 +64,7 @@ Blockly.Blocks['data_setvariableto'] = {
       "message0": "set %1 to %2",
       "args0": [
         {
-          "type": "input_value",
+          "type": "field_variable",
           "name": "VARIABLE"
         },
         {
@@ -118,7 +92,7 @@ Blockly.Blocks['data_changevariableby'] = {
       "message0": "change %1 by %2",
       "args0": [
         {
-          "type": "input_value",
+          "type": "field_variable",
           "name": "VARIABLE"
         },
         {

--- a/core/variables.js
+++ b/core/variables.js
@@ -149,9 +149,9 @@ Blockly.Variables.flyoutCategory = function(workspace) {
 
     if (Blockly.Blocks['data_setvariableto']) {
       // <block type="data_setvariableto" gap="20">
-      //   <value name="VARIABLE">
-      //    <shadow type="data_variablemenu"></shadow>
-      //   </value>
+      //   <field name="VARIABLE">
+      //     variablename
+      //   </field>
       //   <value name="VALUE">
       //     <shadow type="text">
       //       <field name="TEXT">0</field>
@@ -167,9 +167,9 @@ Blockly.Variables.flyoutCategory = function(workspace) {
     }
     if (Blockly.Blocks['data_changevariableby']) {
       // <block type="data_changevariableby">
-      //   <value name="VARIABLE">
-      //    <shadow type="data_variablemenu"></shadow>
-      //   </value>
+      //   <field name="VARIABLE">
+      //     variablename
+      //   </field>
       //   <value name="VALUE">
       //     <shadow type="math_number">
       //       <field name="NUM">0</field>
@@ -185,9 +185,9 @@ Blockly.Variables.flyoutCategory = function(workspace) {
     }
     if (Blockly.Blocks['data_showvariable']) {
       // <block type="data_showvariable">
-      //   <value name="VARIABLE">
-      //     <shadow type="data_variablemenu"></shadow>
-      //   </value>
+      //   <field name="VARIABLE">
+      //     variablename
+      //   </field>
       // </block>
       var block = goog.dom.createDom('block');
       block.setAttribute('type', 'data_showvariable');
@@ -197,9 +197,9 @@ Blockly.Variables.flyoutCategory = function(workspace) {
     }
     if (Blockly.Blocks['data_hidevariable']) {
       // <block type="data_showvariable">
-      //   <value name="VARIABLE">
-      //     <shadow type="data_variablemenu"></shadow>
-      //   </value>
+      //   <field name="VARIABLE">
+      //     variablename
+      //   </field>
       // </block>
       var block = goog.dom.createDom('block');
       block.setAttribute('type', 'data_hidevariable');
@@ -234,26 +234,19 @@ Blockly.Variables.createShadowDom_ = function(type) {
 };
 
 /**
- * Create a dom element for value tag with a shadow variable inside.
+ * Create a dom element for variable.
  * @param {Blockly.VariableModel} variableModel The variable to use.
  * @return {!Element} An XML element.
  */
 Blockly.Variables.createVariableDom_ = function(variableModel) {
-  //   <value name="VARIABLE">
-  //     <shadow type="data_variablemenu">
-  //       <field name="VARIABLE">variablename
-  //       </field>
-  //     </shadow>
-  //   </value>
-  var value = Blockly.Variables.createValueDom_('VARIABLE');
-  var shadow = Blockly.Variables.createShadowDom_('data_variablemenu');
+  // <field name="VARIABLE">
+  //   variablename
+  // </field>
   var field = goog.dom.createDom('field', null, variableModel.name);
   field.setAttribute('name', 'VARIABLE');
   field.setAttribute('variableType', variableModel.type);
   field.setAttribute('id', variableModel.getId());
-  shadow.appendChild(field);
-  value.appendChild(shadow);
-  return value;
+  return field;
 };
 
 /**


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-blocks/issues/942
### Proposed Changes

_Describe what this Pull Request does_

### Reason for Changes

Uses a field instead of an input + shadow for the variable dropdown

_Explain why these changes should be made_
https://github.com/LLK/scratch-blocks/issues/942


Along with https://github.com/LLK/scratch-vm/pull/608, this works with importing projects as well. Here is what it looks like:

![image](https://user-images.githubusercontent.com/654102/27153429-65e3e16c-511f-11e7-89e5-72bb966529db.png)

vs what it used to be (circular inputs)

![image](https://user-images.githubusercontent.com/654102/27153435-702f2442-511f-11e7-9bd3-e71ecf2072ec.png)
