### PR TITLE
Develop fix fieldToDom

### DIFF
--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -278,6 +278,13 @@ Blockly.Flyout.prototype.init = function(targetWorkspace) {
   // A flyout connected to a workspace doesn't have its own current gesture.
   this.workspace_.getGesture =
       this.targetWorkspace_.getGesture.bind(this.targetWorkspace_);
+
+  // Get variables from the main workspace rather than the target workspace.
+  this.workspace_.getVariable =
+      this.targetWorkspace_.getVariable.bind(this.targetWorkspace_);
+
+  this.workspace_.getVariableById =
+      this.targetWorkspace_.getVariableById.bind(this.targetWorkspace_);
 };
 
 /**

--- a/core/xml.js
+++ b/core/xml.js
@@ -110,7 +110,8 @@ Blockly.Xml.blockToDom = function(block, opt_noId) {
     if (field.name && field.EDITABLE) {
       var container = goog.dom.createDom('field', null, field.getValue());
       container.setAttribute('name', field.name);
-      if (field instanceof Blockly.FieldVariable) {
+      if (field instanceof Blockly.FieldVariable || field instanceof
+        Blockly.FieldVariableGetter) {
         var variable = block.workspace.getVariable(field.getValue());
         if (variable) {
           container.setAttribute('id', variable.getId());


### PR DESCRIPTION
### Resolves

https://github.com/LLK/scratch-blocks/issues/959
https://github.com/LLK/scratch-blocks/issues/958
### Proposed Changes

Checks main workspace instead of flyout workspace for a variable when getVariable is called.
Includes type and id for FieldVariableGetter field when converting from field to DOM.
### Reason for Changes

With this change, an extra variable is added to the flyout's workspace when the variable already exists in the main workspace.
This is problematic for the vm because when a new variable is created, the variable will be created in the vm with the correct id. And then the block that contains the variable in the toolbox will not be able to find it and then will fire a block create event that does not include all of the variable information.
### Test Coverage

_Please show how you have added tests to cover your changes_
