### PR TITLE
Use the secondary color for shadow block fills

### DIFF
--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -477,7 +477,8 @@ Blockly.BlockSvg.prototype.updateColour = function() {
   this.svgPath_.setAttribute('stroke', strokeColour);
 
   // Render block fill
-  var fillColour = (this.isGlowingBlock_) ? this.getColourSecondary() : this.getColour();
+  var fillColour = (this.isGlowingBlock_ || this.isShadow()) ?
+      this.getColourSecondary() : this.getColour();
   this.svgPath_.setAttribute('fill', fillColour);
 
   // Render opacity


### PR DESCRIPTION
Shadow blocks should always be filled with the secondary block color for that category.

This also means that blocks tat are always used as shadows don't need to have special color definitions.
