### PR TITLE
Fix Variable Getter Context Menu Bug.

### DIFF
--- a/blocks_vertical/data.js
+++ b/blocks_vertical/data.js
@@ -468,10 +468,10 @@ Blockly.Constants.Data.CUSTOM_CONTEXT_MENU_GET_VARIABLE_MIXIN = {
    */
   customContextMenu: function(options) {
     if (!this.isCollapsed()) {
-      var variablesList = this.workspace.variableList;
+      var variablesList = this.workspace.getVariablesOfType('');
       for (var i = 0; i < variablesList.length; i++) {
         var option = {enabled: true};
-        option.text = variablesList[i];
+        option.text = variablesList[i].name;
 
         option.callback =
             Blockly.Constants.Data.VARIABLE_OPTION_CALLBACK_FACTORY(this,


### PR DESCRIPTION
### Resolves

https://github.com/LLK/scratch-blocks/issues/964

### Proposed Changes

Replaces workspace.variableList with workspace.getAllVariables() because variableList no longer exists. Access the variableModel's 'name' field for setting the text of the options in the Context Menu.

### Reason for Changes

The context menu was not showing up when right clicking a variable getter. This is because it was tryingto access workspace.variableList.length when variableList no longer existed and threw an error.

### Test Coverage

_Please show how you have added tests to cover your changes_
