### PR TITLE
Remove all audio effects except for pitch and pan

### DIFF
--- a/blocks_vertical/sound.js
+++ b/blocks_vertical/sound.js
@@ -257,11 +257,7 @@ Blockly.Blocks['sound_playnoteforbeats'] = {
 
 Blockly.Blocks['sound_effects_menu_options'] = [
   ['pitch', 'PITCH'],
-  ['pan left/right', 'PAN'],
-  ['echo', 'ECHO'],
-  ['reverb', 'REVERB'],
-  ['fuzz', 'FUZZ'],
-  ['robot', 'ROBOT']
+  ['pan left/right', 'PAN']
 ];
 
 Blockly.Blocks['sound_seteffectto'] = {


### PR DESCRIPTION
### Resolves

To address performance issues that cause the audio to drop out (as discussed [here](https://github.com/LLK/scratch-audio/issues/22) and [here](https://github.com/LLK/scratch-audio/issues/27)), we are removing the echo, reverb, fuzz and robot effects. 

### Proposed Changes

Remove the echo, reverb, fuzz, and robot effects.

### Reason for Changes

These effects create large numbers of webaudio nodes, which contributes to audio glitches.