### PR TITLE
Fix #968

### DIFF
--- a/blocks_common/math.js
+++ b/blocks_common/math.js
@@ -49,7 +49,9 @@ Blockly.Blocks['math_number'] = {
       ],
       "output": "Number",
       "outputShape": Blockly.OUTPUT_SHAPE_ROUND,
-      "colour": Blockly.Colours.textField
+      "colour": Blockly.Colours.textField,
+      "colourSecondary": Blockly.Colours.textField,
+      "colourTertiary": Blockly.Colours.textField
     });
   }
 };
@@ -71,7 +73,9 @@ Blockly.Blocks['math_integer'] = {
       ],
       "output": "Number",
       "outputShape": Blockly.OUTPUT_SHAPE_ROUND,
-      "colour": Blockly.Colours.textField
+      "colour": Blockly.Colours.textField,
+      "colourSecondary": Blockly.Colours.textField,
+      "colourTertiary": Blockly.Colours.textField
     });
   }
 };
@@ -94,7 +98,9 @@ Blockly.Blocks['math_whole_number'] = {
       ],
       "output": "Number",
       "outputShape": Blockly.OUTPUT_SHAPE_ROUND,
-      "colour": Blockly.Colours.textField
+      "colour": Blockly.Colours.textField,
+      "colourSecondary": Blockly.Colours.textField,
+      "colourTertiary": Blockly.Colours.textField
     });
   }
 };
@@ -116,7 +122,9 @@ Blockly.Blocks['math_positive_number'] = {
       ],
       "output": "Number",
       "outputShape": Blockly.OUTPUT_SHAPE_ROUND,
-      "colour": Blockly.Colours.textField
+      "colour": Blockly.Colours.textField,
+      "colourSecondary": Blockly.Colours.textField,
+      "colourTertiary": Blockly.Colours.textField
     });
   }
 };
@@ -138,7 +146,9 @@ Blockly.Blocks['math_angle'] = {
       ],
       "output": "Number",
       "outputShape": Blockly.OUTPUT_SHAPE_ROUND,
-      "colour": Blockly.Colours.textField
+      "colour": Blockly.Colours.textField,
+      "colourSecondary": Blockly.Colours.textField,
+      "colourTertiary": Blockly.Colours.textField
     });
   }
 };

--- a/blocks_common/text.js
+++ b/blocks_common/text.js
@@ -48,7 +48,9 @@ Blockly.Blocks['text'] = {
       ],
       "output": "String",
       "outputShape": Blockly.OUTPUT_SHAPE_ROUND,
-      "colour": Blockly.Colours.textField
+      "colour": Blockly.Colours.textField,
+      "colourSecondary": Blockly.Colours.textField,
+      "colourTertiary": Blockly.Colours.textField
     });
   }
 };

--- a/blocks_vertical/data.js
+++ b/blocks_vertical/data.js
@@ -193,8 +193,7 @@ Blockly.Blocks['data_listindexall'] = {
         }
       ],
       "category": Blockly.Categories.data,
-      "colour": Blockly.Colours.textField,
-      "extensions": ["output_string"]
+      "extensions": ["colours_textfield", "output_string"]
     });
   }
 };
@@ -222,8 +221,7 @@ Blockly.Blocks['data_listindexrandom'] = {
         }
       ],
       "category": Blockly.Categories.data,
-      "colour": Blockly.Colours.textField,
-      "extensions": ["output_string"]
+      "extensions": ["colours_textfield", "output_string"]
     });
   }
 };

--- a/blocks_vertical/vertical_extensions.js
+++ b/blocks_vertical/vertical_extensions.js
@@ -35,7 +35,7 @@ goog.require('Blockly.constants');
 
 /**
  * Helper function that generates an extension based on a category name.
- * The generated function with set primary, secondary, and tertiary colours
+ * The generated function will set primary, secondary, and tertiary colours
  * based on the category name.
  * @param {String} category The name of the category to set colours for.
  * @return {function} An extension function that sets colours based on the given
@@ -43,12 +43,8 @@ goog.require('Blockly.constants');
  */
 Blockly.ScratchBlocks.VerticalExtensions.colourHelper = function(category) {
   var colours = Blockly.Colours[category];
-  if (!(colours.primary && colours.secondary && colours.tertiary)) {
-    /**
-     * Return an empty function, rather than throwing an error later.
-     * @this {Blockly.Block}
-     */
-    return function() { };
+  if (!(colours && colours.primary && colours.secondary && colours.tertiary)) {
+    throw new Error('Could not find colours for category "' + category + '"');
   }
   /**
    * Set the primary, secondary, and tertiary colours on this block for the
@@ -59,6 +55,14 @@ Blockly.ScratchBlocks.VerticalExtensions.colourHelper = function(category) {
     this.setColourFromRawValues_(colours.primary, colours.secondary,
         colours.tertiary);
   };
+};
+
+/**
+ * Extension to set the colours of a text field, which are all the same.
+ */
+Blockly.ScratchBlocks.VerticalExtensions.COLOUR_TEXTFIELD = function() {
+  this.setColourFromRawValues_(Blockly.Colours.textField,
+      Blockly.Colours.textField, Blockly.Colours.textField);
 };
 
 /**
@@ -151,6 +155,11 @@ Blockly.ScratchBlocks.VerticalExtensions.registerAll = function() {
     Blockly.Extensions.register('colours_' + name,
         Blockly.ScratchBlocks.VerticalExtensions.colourHelper(name));
   }
+
+  // Text fields transcend categories.
+  Blockly.Extensions.register('colours_textfield',
+      Blockly.ScratchBlocks.VerticalExtensions.COLOUR_TEXTFIELD);
+
   // Register extensions for common block shapes.
   Blockly.Extensions.register('shape_statement',
       Blockly.ScratchBlocks.VerticalExtensions.SHAPE_STATEMENT);


### PR DESCRIPTION
### Resolves

#968 

### Proposed Changes

For blocks under blocks_common I'm adding secondary and tertiary colours explicitly.
In blocks_vertical/vertical_extensions.js I added an extension for setting text field colours.
For blocks under blocks_vertical I'm using that new extension.

I added an explicit error if colours are undefined.

### Reason for Changes

If blocks only have one colour defined Scratch-Blocks will darken that colour to get the secondary and tertiary colours, which makes text fields look terrible.

### Test Coverage

I checked that an extension is thrown when a single colour in a category or an entire category of colours is missing.
I loaded up scratch-gui to make sure that the built files work.