### PR TITLE
Use extensions for the sensing category

### DIFF
--- a/blocks_vertical/sensing.js
+++ b/blocks_vertical/sensing.js
@@ -67,10 +67,7 @@ Blockly.Blocks['sensing_touchingobjectmenu'] = {
             ]
           }
         ],
-        "colour": Blockly.Colours.sensing.secondary,
-        "colourSecondary": Blockly.Colours.sensing.secondary,
-        "colourTertiary": Blockly.Colours.sensing.tertiary,
-        "extensions": ["output_string"]
+        "extensions": ["colours_sensing", "output_string"]
       });
   }
 };
@@ -157,12 +154,7 @@ Blockly.Blocks['sensing_distancetomenu'] = {
             ]
           }
         ],
-        "inputsInline": true,
-        "output": "String",
-        "colour": Blockly.Colours.sensing.secondary,
-        "colourSecondary": Blockly.Colours.sensing.secondary,
-        "colourTertiary": Blockly.Colours.sensing.tertiary,
-        "outputShape": Blockly.OUTPUT_SHAPE_ROUND
+        "extensions": ["colours_sensing", "output_string"]
       });
   }
 };
@@ -181,10 +173,8 @@ Blockly.Blocks['sensing_askandwait'] = {
           "name": "QUESTION"
         }
       ],
-      "previousStatement": null,
-      "nextStatement": null,
       "category": Blockly.Categories.sensing,
-      "extensions": ["colours_sensing"]
+      "extensions": ["colours_sensing", "shape_statement"]
     });
   }
 };
@@ -198,10 +188,8 @@ Blockly.Blocks['sensing_answer'] = {
     this.jsonInit({
       "message0": "answer",
       "category": Blockly.Categories.sensing,
-      "output": "Number",
-      "outputShape": Blockly.OUTPUT_SHAPE_ROUND,
       "checkboxInFlyout": true,
-      "extensions": ["colours_sensing"]
+      "extensions": ["colours_sensing", "output_number"]
     });
   }
 };
@@ -285,12 +273,7 @@ Blockly.Blocks['sensing_keyoptions'] = {
           ]
         }
       ],
-      "inputsInline": true,
-      "output": "String",
-      "colour": Blockly.Colours.sensing.secondary,
-      "colourSecondary": Blockly.Colours.sensing.secondary,
-      "colourTertiary": Blockly.Colours.sensing.tertiary,
-      "outputShape": Blockly.OUTPUT_SHAPE_ROUND
+      "extensions": ["colours_sensing", "output_string"]
     });
   }
 };
@@ -370,12 +353,9 @@ Blockly.Blocks['sensing_videoon'] = {
           "name": "VIDEOONMENU2"
         }
       ],
-      "inputsInline": true,
-      "output": "Number",
       "category": Blockly.Categories.sensing,
-      "outputShape": Blockly.OUTPUT_SHAPE_ROUND,
       "checkboxInFlyout": true,
-      "extensions": ["colours_sensing"]
+      "extensions": ["colours_sensing", "output_number"]
     });
   }
 };
@@ -399,12 +379,7 @@ Blockly.Blocks['sensing_videoonmenuone'] = {
             ]
           }
         ],
-        "inputsInline": true,
-        "output": "String",
-        "colour": Blockly.Colours.sensing.secondary,
-        "colourSecondary": Blockly.Colours.sensing.secondary,
-        "colourTertiary": Blockly.Colours.sensing.tertiary,
-        "outputShape": Blockly.OUTPUT_SHAPE_ROUND
+        "extensions": ["colours_sensing", "output_string"]
       });
   }
 };
@@ -426,12 +401,7 @@ Blockly.Blocks['sensing_videoonmenutwo'] = {
             ]
           }
         ],
-        "inputsInline": true,
-        "output": "String",
-        "colour": Blockly.Colours.sensing.secondary,
-        "colourSecondary": Blockly.Colours.sensing.secondary,
-        "colourTertiary": Blockly.Colours.sensing.tertiary,
-        "outputShape": Blockly.OUTPUT_SHAPE_ROUND
+        "extensions": ["colours_sensing", "output_string"]
       });
   }
 };
@@ -450,10 +420,8 @@ Blockly.Blocks['sensing_videotoggle'] = {
           "name": "VIDEOTOGGLEMENU"
         }
       ],
-      "previousStatement": null,
-      "nextStatement": null,
       "category": Blockly.Categories.sensing,
-      "extensions": ["colours_sensing"]
+      "extensions": ["colours_sensing", "shape_statement"]
     });
   }
 };
@@ -478,12 +446,7 @@ Blockly.Blocks['sensing_videotogglemenu'] = {
             ]
           }
         ],
-        "inputsInline": true,
-        "output": "String",
-        "colour": Blockly.Colours.sensing.secondary,
-        "colourSecondary": Blockly.Colours.sensing.secondary,
-        "colourTertiary": Blockly.Colours.sensing.tertiary,
-        "outputShape": Blockly.OUTPUT_SHAPE_ROUND
+        "extensions": ["colours_sensing", "output_string"]
       });
   }
 };
@@ -502,10 +465,8 @@ Blockly.Blocks['sensing_setvideotransparency'] = {
           "name": "TRANSPARENCY"
         }
       ],
-      "previousStatement": null,
-      "nextStatement": null,
       "category": Blockly.Categories.sensing,
-      "extensions": ["colours_sensing"]
+      "extensions": ["colours_sensing", "shape_statement"]
     });
   }
 };
@@ -519,10 +480,8 @@ Blockly.Blocks['sensing_timer'] = {
     this.jsonInit({
       "message0": "timer",
       "category": Blockly.Categories.sensing,
-      "output": "Number",
-      "outputShape": Blockly.OUTPUT_SHAPE_ROUND,
       "checkboxInFlyout": true,
-      "extensions": ["colours_sensing"]
+      "extensions": ["colours_sensing", "output_number"]
     });
   }
 };
@@ -535,10 +494,8 @@ Blockly.Blocks['sensing_resettimer'] = {
   init: function() {
     this.jsonInit({
       "message0": "reset timer",
-      "previousStatement": null,
-      "nextStatement": null,
       "category": Blockly.Categories.sensing,
-      "extensions": ["colours_sensing"]
+      "extensions": ["colours_sensing", "shape_statement"]
     });
   }
 };
@@ -569,12 +526,7 @@ Blockly.Blocks['sensing_of_property_menu'] = {
             ]
           }
         ],
-        "inputsInline": true,
-        "output": "String",
-        "colour": Blockly.Colours.sensing.secondary,
-        "colourSecondary": Blockly.Colours.sensing.secondary,
-        "colourTertiary": Blockly.Colours.sensing.tertiary,
-        "outputShape": Blockly.OUTPUT_SHAPE_ROUND
+        "extensions": ["colours_sensing", "output_string"]
       });
   }
 };
@@ -598,12 +550,7 @@ Blockly.Blocks['sensing_of_object_menu'] = {
             ]
           }
         ],
-        "inputsInline": true,
-        "output": "String",
-        "colour": Blockly.Colours.sensing.secondary,
-        "colourSecondary": Blockly.Colours.sensing.secondary,
-        "colourTertiary": Blockly.Colours.sensing.tertiary,
-        "outputShape": Blockly.OUTPUT_SHAPE_ROUND
+        "extensions": ["colours_sensing", "output_string"]
       });
   }
 };
@@ -650,12 +597,9 @@ Blockly.Blocks['sensing_current'] = {
           "name": "CURRENTMENU"
         }
       ],
-      "inputsInline": true,
-      "output": "Number",
       "category": Blockly.Categories.sensing,
-      "outputShape": Blockly.OUTPUT_SHAPE_ROUND,
       "checkboxInFlyout": true,
-      "extensions": ["colours_sensing"]
+      "extensions": ["colours_sensing", "output_number"]
     });
   }
 };
@@ -684,12 +628,7 @@ Blockly.Blocks['sensing_currentmenu'] = {
             ]
           }
         ],
-        "inputsInline": true,
-        "output": "String",
-        "colour": Blockly.Colours.sensing.secondary,
-        "colourSecondary": Blockly.Colours.sensing.secondary,
-        "colourTertiary": Blockly.Colours.sensing.tertiary,
-        "outputShape": Blockly.OUTPUT_SHAPE_ROUND
+        "extensions": ["colours_sensing", "output_string"]
       });
   }
 };
@@ -703,9 +642,7 @@ Blockly.Blocks['sensing_dayssince2000'] = {
     this.jsonInit({
       "message0": "days since 2000",
       "category": Blockly.Categories.sensing,
-      "output": "Number",
-      "outputShape": Blockly.OUTPUT_SHAPE_ROUND,
-      "extensions": ["colours_sensing"]
+      "extensions": ["colours_sensing", "output_number"]
     });
   }
 };
@@ -719,10 +656,8 @@ Blockly.Blocks['sensing_username'] = {
     this.jsonInit({
       "message0": "username",
       "category": Blockly.Categories.sensing,
-      "output": "Number",
-      "outputShape": Blockly.OUTPUT_SHAPE_ROUND,
       "checkboxInFlyout": true,
-      "extensions": ["colours_sensing"]
+      "extensions": ["colours_sensing", "output_number"]
     });
   }
 };


### PR DESCRIPTION
I skipped this file on a previous pass because I think some of the output types are wrong.  On this change I've preserved the existing output types, even if they are wrong, and switched to using blockly extensions for shape and colour.
