### PR TITLE
Don't fire events for insertion marker creation and deletion

### DIFF
--- a/core/gesture.js
+++ b/core/gesture.js
@@ -29,6 +29,7 @@ goog.provide('Blockly.Gesture');
 
 goog.require('Blockly.BlockDragger');
 goog.require('Blockly.constants');
+goog.require('Blockly.Events');
 goog.require('Blockly.FlyoutDragger');
 goog.require('Blockly.Tooltip');
 goog.require('Blockly.Touch');

--- a/core/insertion_marker_manager.js
+++ b/core/insertion_marker_manager.js
@@ -26,6 +26,7 @@
 
 goog.provide('Blockly.InsertionMarkerManager');
 
+goog.require('Blockly.Events');
 goog.require('Blockly.RenderedConnection');
 
 goog.require('goog.math.Coordinate');
@@ -157,14 +158,21 @@ Blockly.InsertionMarkerManager.prototype.dispose = function() {
   this.availableConnections_.length = 0;
   this.closestConnection_ = null;
   this.localConnection_ = null;
-  if (this.firstMarker_) {
-    this.firstMarker_.dispose();
-    this.firstMarker_ = null;
+
+  Blockly.Events.disable();
+  try {
+    if (this.firstMarker_) {
+      this.firstMarker_.dispose();
+      this.firstMarker_ = null;
+    }
+    if (this.lastMarker_) {
+      this.lastMarker_.dispose();
+      this.lastMarker_ = null;
+    }
+  } finally {
+    Blockly.Events.enable();
   }
-  if (this.lastMarker_) {
-    this.lastMarker_.dispose();
-    this.lastMarker_ = null;
-  }
+
   this.highlightedBlock_ = null;
 };
 
@@ -237,13 +245,20 @@ Blockly.InsertionMarkerManager.prototype.update = function(dxy, deleteArea) {
  */
 Blockly.InsertionMarkerManager.prototype.createMarkerBlock_ = function(sourceBlock) {
   var imType = sourceBlock.type;
-  var result = this.workspace_.newBlock(imType);
-  if (sourceBlock.mutationToDom) {
-    var oldMutationDom = sourceBlock.mutationToDom();
-    result.domToMutation(oldMutationDom);
+
+  Blockly.Events.disable();
+  try {
+    var result = this.workspace_.newBlock(imType);
+    if (sourceBlock.mutationToDom) {
+      var oldMutationDom = sourceBlock.mutationToDom();
+      result.domToMutation(oldMutationDom);
+    }
+    result.setInsertionMarker(true, sourceBlock.width);
+    result.initSvg();
+  } finally {
+    Blockly.Events.enable();
   }
-  result.setInsertionMarker(true, sourceBlock.width);
-  result.initSvg();
+
   return result;
 };
 


### PR DESCRIPTION
### Resolves

Fixes #934 
### Proposed Changes

Disable events before creating or deleting insertion markers; re-enable events after insertion marker creation or deletion.

### Reason for Changes

We were getting spurious events for the insertion markers, and also breaking undo/redo
