### PR TITLE
Add customcontextmenu in flyout for variable getter.

### DIFF
--- a/blocks_vertical/data.js
+++ b/blocks_vertical/data.js
@@ -456,7 +456,10 @@ Blockly.Constants.Data.CUSTOM_CONTEXT_MENU_GET_VARIABLE_MIXIN = {
    * @this Blockly.Block
    */
   customContextMenu: function(options) {
-    if (!this.isCollapsed()) {
+    if (this.isCollapsed()) {
+      return;
+    }
+    if (!this.isInFlyout) {
       var variablesList = this.workspace.getVariablesOfType('');
       for (var i = 0; i < variablesList.length; i++) {
         var option = {enabled: true};
@@ -467,6 +470,20 @@ Blockly.Constants.Data.CUSTOM_CONTEXT_MENU_GET_VARIABLE_MIXIN = {
             option.text);
         options.push(option);
       }
+    } else {
+      var renameOption = {
+        text: Blockly.Msg.RENAME_VARIABLE,
+        enabled: true,
+        callback: Blockly.Constants.Data.RENAME_OPTION_CALLBACK_FACTORY(this)
+      };
+      var name = this.getField('VARIABLE').text_;
+      var deleteOption = {
+        text: Blockly.Msg.DELETE_VARIABLE.replace('%1', name),
+        enabled: true,
+        callback: Blockly.Constants.Data.DELETE_OPTION_CALLBACK_FACTORY(this)
+      };
+      options.push(renameOption);
+      options.push(deleteOption);
     }
   }
 };
@@ -492,3 +509,32 @@ Blockly.Constants.Data.VARIABLE_OPTION_CALLBACK_FACTORY = function(block, name) 
     variableField.setText(name);
   };
 };
+
+/**
+ * Callback for rename variable dropdown menu option associated with a
+ * variable getter block.
+ * @param {!Blockly.Block} block The block with the variable to rename.
+ * @return {!function()} A function that renames the variable.
+ */
+Blockly.Constants.Data.RENAME_OPTION_CALLBACK_FACTORY = function(block) {
+  return function() {
+    var workspace = block.workspace;
+    var currentName = block.getField('VARIABLE').text_;
+    Blockly.FieldVariable.renameVariablePrompt(workspace, currentName);
+  };
+};
+
+/**
+ * Callback for delete variable dropdown menu option associated with a
+ * variable getter block.
+ * @param {!Blockly.Block} block The block with the variable to delete.
+ * @return {!function()} A function that deletes the variable.
+ */
+Blockly.Constants.Data.DELETE_OPTION_CALLBACK_FACTORY = function(block) {
+  return function() {
+    var workspace = block.workspace;
+    var name = block.getField('VARIABLE').text_;
+    workspace.deleteVariable(name);
+  };
+};
+

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -729,10 +729,9 @@ Blockly.BlockSvg.prototype.showContextMenu_ = function(e) {
   menuOptions.push(helpOption);
 
   // Allow the block to add or modify menuOptions.
-  if (this.customContextMenu && !block.isInFlyout) {
+  if (this.customContextMenu) {
     this.customContextMenu(menuOptions);
   }
-
   Blockly.ContextMenu.show(e, menuOptions, this.RTL);
   Blockly.ContextMenu.currentBlock = this;
 };

--- a/core/field_variable.js
+++ b/core/field_variable.js
@@ -195,15 +195,8 @@ Blockly.FieldVariable.prototype.onItemSelected = function(menu, menuItem) {
     }
     else if (id == Blockly.RENAME_VARIABLE_ID) {
       // Rename variable.
-      var oldName = this.getText();
-      Blockly.hideChaff();
-      Blockly.Variables.promptName(
-          Blockly.Msg.RENAME_VARIABLE_TITLE.replace('%1', oldName), oldName,
-          function(newName) {
-            if (newName) {
-              workspace.renameVariable(oldName, newName);
-            }
-          });
+      var currentName = this.getText();
+      Blockly.FieldVariable.renameVariablePrompt(workspace, currentName);
       return;
     } else if (id == Blockly.DELETE_VARIABLE_ID) {
       // Delete variable.
@@ -217,4 +210,21 @@ Blockly.FieldVariable.prototype.onItemSelected = function(menu, menuItem) {
   if (itemText !== null) {
     this.setValue(itemText);
   }
+};
+
+/**
+ * Prompt the user to rename a variable.
+ * @param {Blockly.Workspace} workspace Workspace the variable to rename is in.
+ * @param {string} currentName Current name of the variable to rename.
+ */
+Blockly.FieldVariable.renameVariablePrompt = function(workspace, currentName) {
+  // Rename variable.
+  Blockly.hideChaff();
+  Blockly.Variables.promptName(
+      Blockly.Msg.RENAME_VARIABLE_TITLE.replace('%1', currentName), currentName,
+      function(newName) {
+        if (newName) {
+          workspace.renameVariable(currentName, newName);
+        }
+      });
 };


### PR DESCRIPTION
### Resolves

Fixes https://github.com/LLK/scratch-blocks/issues/985

### Proposed Changes

Adds separate options for the variable getter custom context menu if it is in the flyout.

### Reason for Changes

We want the variable getter custom context menu to show "delete" and "rename" if the variable getter is in the flyout.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/llk/scratch-blocks/990)
<!-- Reviewable:end -->
