### PR TITLE
Remove unecessary setGroup(false).

### DIFF
--- a/core/widgetdiv.js
+++ b/core/widgetdiv.js
@@ -156,7 +156,6 @@ Blockly.WidgetDiv.hide = function(opt_noAnimate) {
       Blockly.WidgetDiv.owner_ = null;
       Blockly.WidgetDiv.hideAndClearDom_();
     }
-    Blockly.Events.setGroup(false);
   }
 };
 


### PR DESCRIPTION
### Resolves

The setGroup(true) in Blockly.WidgetDiv.show() was removed already, and it looks like this is a leftover setGroup(false). Tested and removed.
