### PR TITLE
Add variable disabled attribute and interactions with it.

### DIFF
--- a/core/block.js
+++ b/core/block.js
@@ -229,6 +229,8 @@ Blockly.Block.prototype.dispose = function(healStack) {
     // Already deleted.
     return;
   }
+  var variableField = this.getField('VARIABLE');
+  var workspace = this.workspace;
   // Terminate onchange event calls.
   if (this.onchangeWrapper_) {
     this.workspace.removeChangeListener(this.onchangeWrapper_);
@@ -278,6 +280,12 @@ Blockly.Block.prototype.dispose = function(healStack) {
     }
   } finally {
     Blockly.Events.enable();
+    if (variableField) {
+      var variable = workspace.getVariable(variableField.text_);
+      if (variable && !variable.isEnabled()) {
+        workspace.deleteDisabledVariableIfUnused(variable);
+      }
+    }
   }
 };
 

--- a/core/events.js
+++ b/core/events.js
@@ -121,6 +121,18 @@ Blockly.Events.VAR_DELETE = 'var_delete';
 Blockly.Events.VAR_RENAME = 'var_rename';
 
 /**
+ * Name of event that disables a variable.
+ * @const
+ */
+Blockly.Events.VAR_DISABLE = 'var_disable';
+
+/**
+ * Name of event that enables a variable.
+ * @const
+ */
+Blockly.Events.VAR_ENABLE = 'var_enable';
+
+/**
  * Name of event that records a UI change.
  * @const
  */
@@ -326,6 +338,12 @@ Blockly.Events.fromJson = function(json, workspace) {
       break;
     case Blockly.Events.VAR_RENAME:
       event = new Blockly.Events.VarRename(null);
+      break;
+    case Blockly.Events.VAR_DISABLE:
+      event = new Blockly.Events.VarDisable(null);
+      break;
+    case Blockly.Events.VAR_ENABLE:
+      event = new Blockly.Events.VarEnable(null);
       break;
     case Blockly.Events.UI:
       event = new Blockly.Events.Ui(null);
@@ -966,7 +984,11 @@ Blockly.Events.VarCreate.prototype.run = function(forward) {
   if (forward) {
     workspace.createVariable(this.varName, this.varType, this.varId);
   } else {
+    // In case there is a var_enable event in the same group, prevent the
+    // flyoutCategory from re-enabling the variable.
+    Blockly.Variables.allowEnable = false;
     workspace.deleteVariableById(this.varId);
+    Blockly.Variables.allowEnable = false;
   }
 };
 
@@ -1083,6 +1105,84 @@ Blockly.Events.VarRename.prototype.run = function(forward) {
   } else {
     workspace.renameVariableById(this.varId, this.oldName);
   }
+};
+
+/**
+ * Class for a variable disable event. This is a scratch specific event, it is
+ *     not included in mainline Blockly.
+ * @param {Blockly.VariableModel} variable The disabled variable.
+ *     Null for a blank event.
+ * @extends {Blockly.Events.Abstract}
+ * @constructor
+ */
+Blockly.Events.VarDisable = function(variable) {
+  if (!variable) {
+    return;  // Blank event to be populated by fromJson.
+  }
+  Blockly.Events.VarDisable.superClass_.constructor.call(this, variable);
+};
+goog.inherits(Blockly.Events.VarDisable, Blockly.Events.Abstract);
+
+/**
+ * Type of this event.
+ * @type {string}
+ */
+Blockly.Events.VarDisable.prototype.type = Blockly.Events.VAR_DISABLE;
+
+/**
+ * Run a variable disable event.
+ * @param {boolean} forward True if run forward, false if run backward (undo).
+ */
+Blockly.Events.VarDisable.prototype.run = function(forward) {
+  var workspace = this.getEventWorkspace_();
+  if (!workspace) {
+    return;
+  }
+  var variable = workspace.getVariableById(this.varId);
+  if (forward) {
+    variable.disable();
+  } else {
+    variable.enable();
+  }
+  workspace.refreshToolboxSelection_();
+};
+
+/**
+ * Class for a variable enable event. This is a scratch specific event, it is
+ *     not included in mainline Blockly.
+ * @param {Blockly.VariableModel} variable The enabled variable.
+ *     Null for a blank event.
+ * @extends {Blockly.Events.Abstract}
+ * @constructor
+ */
+Blockly.Events.VarEnable = function(variable) {
+  if (!variable) {
+    return;  // Blank event to be populated by fromJson.
+  }
+  Blockly.Events.VarEnable.superClass_.constructor.call(this, variable);
+};
+goog.inherits(Blockly.Events.VarEnable, Blockly.Events.Abstract);
+
+/**
+ * Type of this event.
+ * @type {string}
+ */
+Blockly.Events.VarEnable.prototype.type = Blockly.Events.VAR_ENABLE;
+
+/**
+ * Run a variable enable event.
+ * @param {boolean} forward True if run forward, false if run backward (undo).
+ */
+Blockly.Events.VarEnable.prototype.run = function(forward) {
+  var workspace = this.getEventWorkspace_();
+  if (!workspace) return;
+  var variable = workspace.getVariableById(this.varId);
+  if (forward) {
+    variable.enable();
+  } else {
+    variable.disable();
+  }
+  workspace.refreshToolboxSelection_();
 };
 
 /**

--- a/core/field_variable.js
+++ b/core/field_variable.js
@@ -163,9 +163,11 @@ Blockly.FieldVariable.dropdownCreate = function() {
   }
   variableModelList.sort(Blockly.VariableModel.compareByName);
   var options = [];
-  for (var i = 0; i < variableModelList.length; i++) {
+  for (var i = 0, variable; variable = variableModelList[i]; i++) {
+    if (variable.isEnabled() || this.getValue() == variable.name) {
     // Set the uuid as the internal representation of the variable.
-    options[i] = [variableModelList[i].name, variableModelList[i].getId()];
+      options.push([variableModelList[i].name, variableModelList[i].getId()]);
+    }
   }
   options.push([Blockly.Msg.RENAME_VARIABLE, Blockly.RENAME_VARIABLE_ID]);
   options.push([Blockly.Msg.DELETE_VARIABLE.replace('%1', name),
@@ -181,6 +183,7 @@ Blockly.FieldVariable.dropdownCreate = function() {
  * @param {!goog.ui.MenuItem} menuItem The MenuItem selected within menu.
  */
 Blockly.FieldVariable.prototype.onItemSelected = function(menu, menuItem) {
+  var priorSelectedVariable;
   var id = menuItem.getValue();
   // TODO(marisaleung): change setValue() to take in an id as the parameter.
   // Then remove itemText.
@@ -188,9 +191,15 @@ Blockly.FieldVariable.prototype.onItemSelected = function(menu, menuItem) {
   if (this.sourceBlock_ && this.sourceBlock_.workspace) {
     var workspace = this.sourceBlock_.workspace;
     var variable = workspace.getVariableById(id);
+    priorSelectedVariable = workspace.getVariableById(this.value_);
     // If the item selected is a variable, set itemText to the variable name.
     if (variable) {
       itemText = variable.name;
+      // If the field is disabled, enable it.
+      if (!variable.isEnabled()) {
+        variable.enable();
+        this.sourceBlock_.workspace.refreshToolboxSelection_();
+      }
     }
     else if (id == Blockly.RENAME_VARIABLE_ID) {
       // Rename variable.
@@ -214,6 +223,11 @@ Blockly.FieldVariable.prototype.onItemSelected = function(menu, menuItem) {
     itemText = this.callValidator(itemText);
   }
   if (itemText !== null) {
+    Blockly.Events.setGroup(true);
     this.setValue(itemText);
+    if (priorSelectedVariable && !priorSelectedVariable.isEnabled()) {
+      workspace.deleteDisabledVariableIfUnused(priorSelectedVariable);
+    }
+    Blockly.Events.setGroup(false);
   }
 };

--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -298,6 +298,9 @@ Blockly.Flyout.prototype.init = function(targetWorkspace) {
 
   this.workspace_.renameVariableById =
       this.targetWorkspace_.renameVariableById.bind(this.targetWorkspace_);
+
+  this.workspace_.getVariableUses =
+      this.targetWorkspace_.getVariableUses.bind(this.targetWorkspace_);
 };
 
 /**

--- a/core/variable_model.js
+++ b/core/variable_model.js
@@ -76,6 +76,14 @@ Blockly.VariableModel = function(workspace, name, opt_type, opt_id) {
    */
   this.id_ = opt_id || Blockly.utils.genUid();
 
+  /**
+   * The enabled status of the variable. If enabled is false, the variable
+   * will not appear in dropdowns or the toolbox. Otherwise it will appear.
+   * @type {boolean}
+   * @private
+   */
+  this.enabled_ = true;
+
   Blockly.Events.fire(new Blockly.Events.VarCreate(this));
 };
 
@@ -84,6 +92,30 @@ Blockly.VariableModel = function(workspace, name, opt_type, opt_id) {
  */
 Blockly.VariableModel.prototype.getId = function() {
   return this.id_;
+};
+
+/**
+ * Disable the variable.
+ */
+Blockly.VariableModel.prototype.disable = function() {
+  this.enabled_ = false;
+  Blockly.Variables.allowEnable = false;
+  Blockly.Events.fire(new Blockly.Events.VarDisable(this));
+};
+
+/**
+ * Enable the variable.
+ */
+Blockly.VariableModel.prototype.enable = function() {
+  this.enabled_ = true;
+  Blockly.Events.fire(new Blockly.Events.VarEnable(this));
+};
+
+/**
+ * @return {boolean} True if the variable is enabled, false otherwise.
+ */
+Blockly.VariableModel.prototype.isEnabled = function() {
+  return this.enabled_;
 };
 
 /**

--- a/core/variables.js
+++ b/core/variables.js
@@ -45,6 +45,13 @@ goog.require('goog.string');
 Blockly.Variables.NAME_TYPE = Blockly.VARIABLE_CATEGORY_NAME;
 
 /**
+ * Allow disabled variables to be enabled.
+ * @type {boolean}
+ * @private
+ */
+Blockly.Variables.allowEnable = true;
+
+/**
  * Find all user-created variables that are in use in the workspace.
  * For use by generators.
  * @param {!Blockly.Block|!Blockly.Workspace} root Root block or workspace.
@@ -123,8 +130,19 @@ Blockly.Variables.flyoutCategory = function(workspace) {
   });
 
   xmlList.push(button);
-
+  var firstVariable;
   for (var i = 0; i < variableModelList.length; i++) {
+    if (!variableModelList[i].isEnabled()) {
+      if (Blockly.Variables.allowEnable) {
+        variableModelList[i].enable();
+      } else {
+        continue;
+      }
+    }
+    if (!firstVariable) {
+      firstVariable = variableModelList[i];
+    }
+
     if (Blockly.Blocks['data_variable']) {
       // <block type="data_variable">
       //    <field name="VARIABLE" variableType="" id="">variablename</field>
@@ -161,7 +179,7 @@ Blockly.Variables.flyoutCategory = function(workspace) {
       var block = goog.dom.createDom('block');
       block.setAttribute('type', 'data_setvariableto');
       block.setAttribute('gap', 8);
-      block.appendChild(Blockly.Variables.createVariableDom_(variableModelList[0]));
+      block.appendChild(Blockly.Variables.createVariableDom_(firstVariable));
       block.appendChild(Blockly.Variables.createTextDom_());
       xmlList.push(block);
     }
@@ -179,7 +197,7 @@ Blockly.Variables.flyoutCategory = function(workspace) {
       var block = goog.dom.createDom('block');
       block.setAttribute('type', 'data_changevariableby');
       block.setAttribute('gap', 8);
-      block.appendChild(Blockly.Variables.createVariableDom_(variableModelList[0]));
+      block.appendChild(Blockly.Variables.createVariableDom_(firstVariable));
       block.appendChild(Blockly.Variables.createMathNumberDom_());
       xmlList.push(block);
     }
@@ -192,7 +210,7 @@ Blockly.Variables.flyoutCategory = function(workspace) {
       var block = goog.dom.createDom('block');
       block.setAttribute('type', 'data_showvariable');
       block.setAttribute('gap', 8);
-      block.appendChild(Blockly.Variables.createVariableDom_(variableModelList[0]));
+      block.appendChild(Blockly.Variables.createVariableDom_(firstVariable));
       xmlList.push(block);
     }
     if (Blockly.Blocks['data_hidevariable']) {
@@ -203,10 +221,11 @@ Blockly.Variables.flyoutCategory = function(workspace) {
       // </block>
       var block = goog.dom.createDom('block');
       block.setAttribute('type', 'data_hidevariable');
-      block.appendChild(Blockly.Variables.createVariableDom_(variableModelList[0]));
+      block.appendChild(Blockly.Variables.createVariableDom_(firstVariable));
       xmlList.push(block);
     }
   }
+  Blockly.Variables.allowEnable = true;
   return xmlList;
 };
 

--- a/core/widgetdiv.js
+++ b/core/widgetdiv.js
@@ -156,7 +156,6 @@ Blockly.WidgetDiv.hide = function(opt_noAnimate) {
       Blockly.WidgetDiv.owner_ = null;
       Blockly.WidgetDiv.hideAndClearDom_();
     }
-    Blockly.Events.setGroup(false);
   }
 };
 

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1046,9 +1046,11 @@ Blockly.WorkspaceSvg.prototype.deleteVariableById = function(id) {
  * @package
  */
 Blockly.WorkspaceSvg.prototype.createVariable = function(name, opt_type, opt_id) {
+  Blockly.Events.setGroup(true);
   var newVar = Blockly.WorkspaceSvg.superClass_.createVariable.call(this, name,
     opt_type, opt_id);
   this.refreshToolboxSelection_();
+  Blockly.Events.setGroup(false);
   return newVar;
 };
 


### PR DESCRIPTION
### Resolves

Implements the spec discussed here: https://github.com/LLK/scratch-blocks/issues/975
Deleted variables reappear on toolbox refresh if they are deleted and still exist in the workspace.

### Proposed Changes

- Add a disabled attribute to VariableModel.
- When a variable is disabled, it does not show up in dropdowns or the toolbox. If a dropdown in the workspace already has that variable selected, that instance will remain.
- A variable is disabled when the user tries to delete a variable at the same time that there is a workspace instance of it.
- When the variable is enabled, it will reappear in the dropdowns and toolbox.
- A variable is enabled when the toolbox refreshes and when it is selected in a dropdown on the workspace.
- A variable is deleted if it is disabled and the last instance of it in the workspace is removed. For example:
    1. If the last instance is a block and it is deleted.
    2. If the last instance is a dropdown with that variable selected, and the a different variable is selected. 
- Undo and redo features are supported.

### Reason for Changes

Made to match the spec in the issue above. This is so variable can come back in the toolbox if a user accidentally deleted it when that variable is still used in the workspace.
