### PR TITLE
Correctly place blocks when the flyout and main workspace are at diferent zoom levels.

### DIFF
--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -320,6 +320,18 @@ Blockly.WorkspaceSvg.prototype.getSvgXY = function(element) {
 };
 
 /**
+ * Return the position of the workspace origin relative to the injection div
+ * origin in pixels.
+ * The workspace origin is where a block would render at position (0, 0).
+ * It is not the upper left corner of the workspace SVG.
+ * @return {!goog.math.Coordinate} Offset in pixels.
+ * @package
+ */
+Blockly.WorkspaceSvg.prototype.getOriginOffsetInPixels = function() {
+  return Blockly.utils.getInjectionDivXY_(this.svgBlockCanvas_);
+};
+
+/**
  * Save resize handler data so we can delete it later in dispose.
  * @param {!Array.<!Array>} handler Data that can be passed to unbindEvent_.
  */


### PR DESCRIPTION

### Resolves

#880 

### Proposed Changes

Gets rid of `scroll / scale - scroll` math!  Instead, everything is expressed in terms of either pixels of workspace units/coordinates.  All of the positions are now translated to pixels, and math is done in the pixel realm.  The deltas are changed back to workspace units only when they are applied.

### Reason for Changes

The old math was bad and no one understood it, so we couldn't fix it.

### Test Coverage

Tested in RTL and LTR mode on the vertical playground.  In both cases I zoomed in and dragged in blocks, zoomed out and dragged in blocks, and scrolled both the main workspace and the flyout workspace before dragging blocks.