### PR TITLE
Make duplicated blocks stick to the cursor.

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -671,21 +671,22 @@ Blockly.BlockSvg.prototype.duplicateAndDragCallback_ = function() {
       var ws = oldBlock.workspace;
       var svgRootOld = oldBlock.getSvgRoot();
       if (!svgRootOld) {
-        throw 'oldBlock is not rendered.';
+        throw new Error('oldBlock is not rendered.');
       }
 
       // Create the new block by cloning the block in the flyout (via XML).
       var xml = Blockly.Xml.blockToDom(oldBlock);
       // The target workspace would normally resize during domToBlock, which
-      // will lead to weird jumps.  Save it for terminateDrag.
+      // will lead to weird jumps.
+      // Resizing will be enabled when the drag ends.
       ws.setResizesEnabled(false);
 
       // Using domToBlock instead of domToWorkspace means that the new block
       // will be placed at position (0, 0) in main workspace units.
-      var block = Blockly.Xml.domToBlock(xml, ws);
-      var svgRootNew = block.getSvgRoot();
+      var newBlock = Blockly.Xml.domToBlock(xml, ws);
+      var svgRootNew = newBlock.getSvgRoot();
       if (!svgRootNew) {
-        throw 'block is not rendered.';
+        throw new Error('newBlock is not rendered.');
       }
 
       // The position of the old block in workspace coordinates.
@@ -694,7 +695,7 @@ Blockly.BlockSvg.prototype.duplicateAndDragCallback_ = function() {
       // Place the new block as the same position as the old block.
       // TODO: Offset by the difference between the mouse position and the upper
       // left corner of the block.
-      block.moveBy(oldBlockPosWs.x, oldBlockPosWs.y);
+      newBlock.moveBy(oldBlockPosWs.x, oldBlockPosWs.y);
 
       // The position of the old block in pixels relative to the main
       // workspace's origin.
@@ -730,7 +731,7 @@ Blockly.BlockSvg.prototype.duplicateAndDragCallback_ = function() {
         },
         target: e.target
       };
-      ws.startDragWithFakeEvent(fakeEvent, block);
+      ws.startDragWithFakeEvent(fakeEvent, newBlock);
     }, 0);
   };
 };

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -672,8 +672,45 @@ Blockly.BlockSvg.prototype.showContextMenu_ = function(e) {
     var duplicateOption = {
       text: Blockly.Msg.DUPLICATE_BLOCK,
       enabled: true,
-      callback: function() {
-        Blockly.duplicate_(block);
+      callback: function(e) {
+        Blockly.duplicate_(block, e);
+
+        /*** HAX ***/
+        console.log("HERE GO THE HAX");
+        setTimeout(function() {
+          // e is from the click on the context menu, but is not a mouse event.
+          // it's something closure built.
+          var newBlock = Blockly.selected;
+          var fakeEvent = {
+            clientX: 1000,
+            clientY: 300,
+            type: 'mousedown',
+            preventDefault: function() {
+              e.preventDefault();
+            },
+            stopPropagation: function() {
+              e.stopPropagation();
+            },
+            target: e.target
+          };
+
+          Blockly.Touch.clearTouchIdentifier();
+          // e.preventDefault();
+          // e.stopPropagation();
+          // Also sets the touch identifier
+          if (!Blockly.Touch.checkTouchIdentifier(fakeEvent)) {
+            console.log('something went wrong while setting the touch identifier');
+          }
+          var gesture = block.workspace.getGesture(fakeEvent);
+          gesture.handleBlockStart(fakeEvent, newBlock);
+          gesture.handleWsStart(fakeEvent, block.workspace);
+          // Should be internal.
+          gesture.isDraggingBlock_ = true;
+          gesture.hasExceededDragRadius_ = true;
+          gesture.startDraggingBlock_();
+          console.log("HAX HAVE BEEN SET UP");
+        }, 0);
+        /*** NO MORE HAX ***/
       }
     };
     menuOptions.push(duplicateOption);

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -470,7 +470,7 @@ Blockly.BlockSvg.prototype.clearTransformAttributes_ = function() {
 /**
  * Snap this block to the nearest grid point.
  */
-Blockly.BlockSvg.prototype.snapToGrid  = function() {
+Blockly.BlockSvg.prototype.snapToGrid = function() {
   if (!this.workspace) {
     return;  // Deleted block.
   }
@@ -655,15 +655,15 @@ Blockly.BlockSvg.prototype.showHelp_ = function() {
 };
 
 /**
- * Callback function for a click on the "duplicate" context menu option in
- * Scratch Blocks.  The block is duplicated and attached to the mouse, which
- * acts as though it were pressed and mid-drag.  Clicking the mouse releases the
- * new dragging block.
+ * Creates a callback function for a click on the "duplicate" context menu
+ * option in Scratch Blocks.  The block is duplicated and attached to the mouse,
+ * which acts as though it were pressed and mid-drag.  Clicking the mouse
+ * releases the new dragging block.
  * @return {Function} A callback function that duplicates the block and starts a
  *     drag.
  * @private
  */
-Blockly.BlockSvg.prototype.duplicateAndDrag_ = function() {
+Blockly.BlockSvg.prototype.duplicateAndDragCallback_ = function() {
   var oldBlock = this;
   return function(e) {
     // Give the context menu a chance to close.
@@ -753,7 +753,7 @@ Blockly.BlockSvg.prototype.showContextMenu_ = function(e) {
     var duplicateOption = {
       text: Blockly.Msg.DUPLICATE_BLOCK,
       enabled: true,
-      callback: block.duplicateAndDrag_()
+      callback: block.duplicateAndDragCallback_()
     };
     menuOptions.push(duplicateOption);
 

--- a/core/gesture.js
+++ b/core/gesture.js
@@ -67,7 +67,7 @@ Blockly.Gesture = function(e, creatorWorkspace) {
    * @type {goog.math.Coordinate}
    * private
    */
-  this.currentDragDeltaXY_ = 0;
+  this.currentDragDeltaXY_ = new goog.math.Coordinate(0, 0);
 
   /**
    * The field that the gesture started on, or null if it did not start on a

--- a/core/gesture.js
+++ b/core/gesture.js
@@ -788,3 +788,21 @@ Blockly.Gesture.prototype.isDragging = function() {
 Blockly.Gesture.prototype.hasStarted = function() {
   return this.hasStarted_;
 };
+
+/**
+ * Don't even think about using this function before talking to rachel-fenichel.
+ *
+ * Force a drag to start without clicking and dragging the block itself.  Used
+ * to attach duplicated blocks to the mouse pointer.
+ * @param {!Object} fakeEvent An object with the properties needed to start a
+ *     drag, including clientX and clientY.
+ * @param {!Blockly.BlockSvg} block The block to start dragging.
+ * @package
+ */
+Blockly.Gesture.prototype.forceStartBlockDrag = function(fakeEvent, block) {
+  this.handleBlockStart(fakeEvent, block);
+  this.handleWsStart(fakeEvent, block.workspace);
+  this.isDraggingBlock_ = true;
+  this.hasExceededDragRadius_ = true;
+  this.startDraggingBlock_();
+};

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1951,10 +1951,7 @@ Blockly.WorkspaceSvg.prototype.cancelCurrentGesture = function() {
 Blockly.WorkspaceSvg.prototype.startDragWithFakeEvent = function(fakeEvent,
     block) {
   Blockly.Touch.clearTouchIdentifier();
-  // Also sets the touch identifier
-  if (!Blockly.Touch.checkTouchIdentifier(fakeEvent)) {
-    console.log('something went wrong while setting the touch identifier');
-  }
+  Blockly.Touch.checkTouchIdentifier(fakeEvent);
   var gesture = block.workspace.getGesture(fakeEvent);
   gesture.forceStartBlockDrag(fakeEvent, block);
 };

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -247,6 +247,14 @@ Blockly.WorkspaceSvg.prototype.isDragSurfaceActive_ = false;
 Blockly.WorkspaceSvg.prototype.lastRecordedPageScroll_ = null;
 
 /**
+ * The first parent div with 'injectionDiv' in the name, or null if not set.
+ * Access this with getInjectionDiv.
+ * @type {!Element}
+ * @private
+ */
+Blockly.WorkspaceSvg.prototype.injectionDiv_ = null;
+
+/**
  * Map from function names to callbacks, for deciding what to do when a button
  * is clicked.
  * @type {!Object<string, function(!Blockly.FlyoutButton)>}
@@ -329,6 +337,29 @@ Blockly.WorkspaceSvg.prototype.getSvgXY = function(element) {
  */
 Blockly.WorkspaceSvg.prototype.getOriginOffsetInPixels = function() {
   return Blockly.utils.getInjectionDivXY_(this.svgBlockCanvas_);
+};
+
+/**
+ * Return the injection div that is a parent of this workspace.
+ * Walks the DOM the first time it's called, then returns a cached value.
+ * @return {!Element} The first parent div with 'injectionDiv' in the name.
+ * @package
+ */
+Blockly.WorkspaceSvg.prototype.getInjectionDiv = function() {
+  // NB: it would be better to pass this in at createDom, but is more likely to
+  // break existing uses of Blockly.
+  if (!this.injectionDiv_) {
+    var element = this.svgGroup_;
+    while (element) {
+      var classes = element.getAttribute('class') || '';
+      if ((' ' + classes + ' ').indexOf(' injectionDiv ') != -1) {
+        this.injectionDiv_ = element;
+        break;
+      }
+      element = element.parentNode;
+    }
+  }
+  return this.injectionDiv_;
 };
 
 /**
@@ -1905,6 +1936,27 @@ Blockly.WorkspaceSvg.prototype.cancelCurrentGesture = function() {
   if (this.currentGesture_) {
     this.currentGesture_.cancel();
   }
+};
+
+/**
+ * Don't even think about using this function before talking to rachel-fenichel.
+ *
+ * Force a drag to start without clicking and dragging the block itself.  Used
+ * to attach duplicated blocks to the mouse pointer.
+ * @param {!Object} fakeEvent An object with the properties needed to start a
+ *     drag, including clientX and clientY.
+ * @param {!Blockly.BlockSvg} block The block to start dragging.
+ * @package
+ */
+Blockly.WorkspaceSvg.prototype.startDragWithFakeEvent = function(fakeEvent,
+    block) {
+  Blockly.Touch.clearTouchIdentifier();
+  // Also sets the touch identifier
+  if (!Blockly.Touch.checkTouchIdentifier(fakeEvent)) {
+    console.log('something went wrong while setting the touch identifier');
+  }
+  var gesture = block.workspace.getGesture(fakeEvent);
+  gesture.forceStartBlockDrag(fakeEvent, block);
 };
 
 /**


### PR DESCRIPTION
### Resolves

#828

### Proposed Changes

Duplicate blocks exactly on top of the existing block, then force a drag to start.

There's still a small jump, because the new block gets placed at the position of the old block instead of at the mouse position.  I'll look into that in a followup.

I think there's some cleanup I can do to decompose out code from this and #1000.  

### Reason for Changes

Matching Scratch 2.0 behaviour.

### Test Coverage

Tested in the vertical playground with categories and the simple multi_playground.