### PR TITLE
Fix problem with insertion markers

### DIFF
--- a/core/connection.js
+++ b/core/connection.js
@@ -381,7 +381,9 @@ Blockly.Connection.prototype.canConnectToPrevious_ = function(candidate) {
 
   if (isFirstStatementConnection && sourceHasPreviousConn) {
     return true;
-  } else if (isNextConnection ||
+  }
+
+  if (isNextConnection ||
       (isFirstStatementConnection && !sourceHasPreviousConn)) {
     // If the candidate is the first connection in a stack, we can connect.
     if (!candidate.targetConnection) {

--- a/core/connection.js
+++ b/core/connection.js
@@ -375,9 +375,14 @@ Blockly.Connection.prototype.canConnectToPrevious_ = function(candidate) {
     return false;
   }
 
-  if (isFirstStatementConnection) {
+  // Complex blocks with no previous connection will not be allowed to connect
+  // mid-stack.
+  var sourceHasPreviousConn = this.sourceBlock_.previousConnection != null;
+
+  if (isFirstStatementConnection && sourceHasPreviousConn) {
     return true;
-  } else if (isNextConnection) {
+  } else if (isNextConnection ||
+      (isFirstStatementConnection && !sourceHasPreviousConn)) {
     // If the candidate is the first connection in a stack, we can connect.
     if (!candidate.targetConnection) {
       return true;


### PR DESCRIPTION
### Resolves

Fix #946

### Proposed Changes

If a block has a statement input and no previous connection, it is not allowed to connect in the middle of a stack of blocks.

### Reason for Changes

The old behaviour made blocks disconnect and fail to reconnect during a drag.

### Test Coverage
Tested in the vertical playground by forcing the repeat block to not have a previous connection.

The fix works, but in testing #854 was very obviously problematic.

![64182cd7-5339-4202-801c-079d00d64467](https://user-images.githubusercontent.com/13686399/28041851-c32ada6e-657f-11e7-84ed-6e1ce5ff403b.gif)

