### PR TITLE
Set primary, secondary and tertiary colors on setValue

### DIFF
--- a/core/field_colour.js
+++ b/core/field_colour.js
@@ -106,11 +106,8 @@ Blockly.FieldColour.prototype.setValue = function(colour) {
   }
   this.colour_ = colour;
   if (this.sourceBlock_) {
-    this.sourceBlock_.setColour(
-      colour,
-      this.sourceBlock_.getColourSecondary(),
-      this.sourceBlock_.getColourTertiary()
-    );
+    // Set the primary, secondary and tertiary colour to this value.
+    this.sourceBlock_.setColour(colour, colour, colour);
   }
 };
 

--- a/core/field_colour.js
+++ b/core/field_colour.js
@@ -107,6 +107,7 @@ Blockly.FieldColour.prototype.setValue = function(colour) {
   this.colour_ = colour;
   if (this.sourceBlock_) {
     // Set the primary, secondary and tertiary colour to this value.
+    // The renderer expects to be able to use the secondary color as the fill for a shadow.
     this.sourceBlock_.setColour(colour, colour, colour);
   }
 };


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-blocks/issues/986

### Proposed Changes

_Describe what this Pull Request does_

Changes the `setValue` function of the `FieldColour` to set all 3 colors (primary, secondary and tertiary) instead of just the primary color.

### Reason for Changes

_Explain why these changes should be made_

The secondary and tertiary colors are not used by the `FieldColour`, but the renderer expects to be able to use the secondary color as the fill for a shadow. See linked issue for more.
