### PR TITLE
Move non-label fields to min X (fix #983)

### DIFF
--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -626,7 +626,9 @@ Blockly.BlockSvg.prototype.renderFields_ =
     // In blocks with a notch, non-label fields should be bumped to a min X,
     // to avoid overlapping with the notch.
     if (this.previousConnection && !(field instanceof Blockly.FieldLabel)) {
-      cursorX = Math.max(cursorX, Blockly.BlockSvg.INPUT_AND_FIELD_MIN_X);
+      cursorX = this.RTL ?
+        Math.min(cursorX, -Blockly.BlockSvg.INPUT_AND_FIELD_MIN_X) :
+        Math.max(cursorX, Blockly.BlockSvg.INPUT_AND_FIELD_MIN_X);
     }
     // Offset the field upward by half its height.
     // This vertically centers the fields around cursorY.

--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -393,11 +393,11 @@ Blockly.BlockSvg.FIELD_DEFAULT_CORNER_RADIUS = 4 * Blockly.BlockSvg.GRID_UNIT;
 Blockly.BlockSvg.MAX_DISPLAY_LENGTH = Infinity;
 
 /**
- * Minimum X of inputs on the first row of blocks with no previous connection.
+ * Minimum X of inputs and fields for blocks with a previous connection.
  * Ensures that inputs will not overlap with the top notch of blocks.
  * @const
  */
-Blockly.BlockSvg.NO_PREVIOUS_INPUT_X_MIN = 12 * Blockly.BlockSvg.GRID_UNIT;
+Blockly.BlockSvg.INPUT_AND_FIELD_MIN_X = 12 * Blockly.BlockSvg.GRID_UNIT;
 
 /**
  * Vertical padding around inline elements.
@@ -622,6 +622,11 @@ Blockly.BlockSvg.prototype.renderFields_ =
     var root = field.getSvgRoot();
     if (!root) {
       continue;
+    }
+    // In blocks with a notch, non-label fields should be bumped to a min X,
+    // to avoid overlapping with the notch.
+    if (this.previousConnection && !(field instanceof Blockly.FieldLabel)) {
+      cursorX = Math.max(cursorX, Blockly.BlockSvg.INPUT_AND_FIELD_MIN_X);
     }
     // Offset the field upward by half its height.
     // This vertically centers the fields around cursorY.
@@ -1129,9 +1134,10 @@ Blockly.BlockSvg.prototype.renderDrawRight_ = function(steps,
         cursorX = this.renderFields_(input.fieldRow, fieldX, fieldY);
         if (input.type == Blockly.INPUT_VALUE) {
           // Create inline input connection.
-          if (y === 0 && this.previousConnection) {
-            // Force inputs to be past the notch
-            cursorX = Math.max(cursorX, Blockly.BlockSvg.NO_PREVIOUS_INPUT_X_MIN);
+          // In blocks with a notch, inputs should be bumped to a min X,
+          // to avoid overlapping with the notch.
+          if (this.previousConnection) {
+            cursorX = Math.max(cursorX, Blockly.BlockSvg.INPUT_AND_FIELD_MIN_X);
           }
           if (this.RTL) {
             connectionX = connectionsXY.x - cursorX;


### PR DESCRIPTION
### Resolves

#983 

### Proposed Changes

Before:
<img width="190" alt="before" src="https://user-images.githubusercontent.com/120403/28448550-c72d8830-6da6-11e7-9fd8-934b0e72bbee.png">

After:
<img width="196" alt="after" src="https://user-images.githubusercontent.com/120403/28448554-cd39a880-6da6-11e7-8492-1307274645fd.png">

<img width="199" alt="screen shot 2017-07-21 at 12 15 36 am" src="https://user-images.githubusercontent.com/120403/28448927-d2f0ff46-6da9-11e7-8493-be4703950a3e.png">

### Reason for Changes

paying penance and finishing my unfinished business with @carljbowman 

### Test Coverage

none, but block_render_svg is pretty light in this regard