### PR TITLE
No keyboard events for non-rendered workspaces

### DIFF
--- a/core/blockly.js
+++ b/core/blockly.js
@@ -174,8 +174,10 @@ Blockly.svgResize = function(workspace) {
  * @private
  */
 Blockly.onKeyDown_ = function(e) {
-  if (Blockly.mainWorkspace.options.readOnly || Blockly.utils.isTargetInput(e)) {
-    // No key actions on readonly workspaces.
+  if (Blockly.mainWorkspace.options.readOnly ||
+      Blockly.utils.isTargetInput(e) ||
+      !Blockly.mainWorkspace.rendered) {
+    // No key actions on readonly and non-rendered workspaces.
     // When focused on an HTML text input widget, don't trap any keys.
     return;
   }

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -818,6 +818,7 @@ Blockly.WorkspaceSvg.prototype.setVisible = function(isVisible) {
     Blockly.hideChaff(true);
     Blockly.DropDownDiv.hideWithoutAnimation();
   }
+  this.rendered = isVisible;
 };
 
 /**


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-blocks/issues/1019

### Proposed Changes

_Describe what this Pull Request does_

1. Set the `rendered` property of the workspace to `isVisible` when calling `setVisible`. 
2. Do not allow keyboard events when `mainWorkspace.rendered` is false.

### Reason for Changes

_Explain why these changes should be made_

Hidden workspace should not respond to global keyboard events, since it isn't visible! This interferes with other keyboard events in scratch when using other parts of the app (e.g. the sound/costume editors). 

### Test Coverage

_Please show how you have added tests to cover your changes_

None added. Let me know if there is a good place for testing this. I didn't see any existing tests around `setVisible`