### PR TITLE
Fix block count in deletion confirmation dialog

### DIFF
--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1414,7 +1414,7 @@ Blockly.WorkspaceSvg.prototype.showContextMenu_ = function(e) {
         deleteNext();
       } else {
         Blockly.confirm(Blockly.Msg.DELETE_ALL_BLOCKS.
-            replace('%1', String(deleteCount),
+            replace('%1', String(deleteCount)),
             function(ok) {
               if (ok) {
                 deleteNext();

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1414,7 +1414,7 @@ Blockly.WorkspaceSvg.prototype.showContextMenu_ = function(e) {
         deleteNext();
       } else {
         Blockly.confirm(Blockly.Msg.DELETE_ALL_BLOCKS.
-            replace('%1', deleteList.length),
+            replace('%1', String(deleteCount),
             function(ok) {
               if (ok) {
                 deleteNext();


### PR DESCRIPTION
### Resolves

#978, using changes proposed by @rachel-fenichel 

### Proposed Changes

Replaced `deleteList.length` with `String(deleteCount)`

### Reason for Changes

The right click menu should be consistent with the confirmation dialog.