### PR TITLE
Fix "sprinkles" in playgrounds

### DIFF
--- a/tests/horizontal_playground.html
+++ b/tests/horizontal_playground.html
@@ -195,7 +195,11 @@
 
       function sprinkles(n) {
         var prototypes = [];
-        var toolbox = getToolboxElement();
+        var toolbox = workspace.options.languageTree;
+        if (!toolbox) {
+          console.error('Toolbox not found; add a toolbox element to the DOM.');
+          return;
+        }
         var blocks = toolbox.getElementsByTagName('block');
         for (var i = 0; i < n; i++) {
           var blockXML = blocks[Math.floor(Math.random() * blocks.length)];

--- a/tests/vertical_playground.html
+++ b/tests/vertical_playground.html
@@ -209,7 +209,11 @@
 
       function sprinkles(n) {
         var prototypes = [];
-        var toolbox = getToolboxElement();
+        var toolbox = workspace.options.languageTree;
+        if (!toolbox) {
+          console.error('Toolbox not found; add a toolbox element to the DOM.');
+          return;
+        }
         var blocks = toolbox.getElementsByTagName('block');
         for (var i = 0; i < n; i++) {
           var blockXML = blocks[Math.floor(Math.random() * blocks.length)];

--- a/tests/vertical_playground_compressed.html
+++ b/tests/vertical_playground_compressed.html
@@ -193,7 +193,11 @@
 
       function sprinkles(n) {
         var prototypes = [];
-        var toolbox = getToolboxElement();
+        var toolbox = workspace.options.languageTree;
+        if (!toolbox) {
+          console.error('Toolbox not found; add a toolbox element to the DOM.');
+          return;
+        }
         var blocks = toolbox.getElementsByTagName('block');
         for (var i = 0; i < n; i++) {
           var blockXML = blocks[Math.floor(Math.random() * blocks.length)];


### PR DESCRIPTION
### Resolves

#739 

### Proposed Changes

Fixes the "sprinkles" buttons in the playgrounds. This is a more limited version of @TheBrokenRail's change in https://github.com/LLK/scratch-blocks/pull/803. In that case, `getToolboxElement` is actually used to initialize Blockly's toolbox from the DOM. In this version, that remains intact while sprinkles reads the blocks from the live toolbox.

### Reason for Changes

It makes a neat demo and a useful performance test :)

### Test Coverage

n/a