### PR TITLE
Add shadow dom ID uniquifier to 'Duplicate' code path

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -686,20 +686,7 @@ Blockly.BlockSvg.prototype.duplicateAndDragCallback_ = function() {
       var newBlock = Blockly.Xml.domToBlock(xml, ws);
 
       // Scratch-specific: Give shadow dom new IDs to prevent duplicating on paste
-      var blocks = newBlock.getDescendants();
-      for (var i = blocks.length - 1; i >= 0; i--) {
-        var descendant = blocks[i];
-        for (var j = 0; j < descendant.inputList.length; j++) {
-          var connection = descendant.inputList[j].connection;
-          if (connection) {
-            var shadowDom = connection.getShadowDom();
-            if (shadowDom) {
-              shadowDom.setAttribute('id', Blockly.utils.genUid());
-              connection.setShadowDom(shadowDom);
-            }
-          }
-        }
-      }
+      Blockly.utils.changeObscuredShadowIds(newBlock);
 
       var svgRootNew = newBlock.getSvgRoot();
       if (!svgRootNew) {

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -684,6 +684,23 @@ Blockly.BlockSvg.prototype.duplicateAndDragCallback_ = function() {
       // Using domToBlock instead of domToWorkspace means that the new block
       // will be placed at position (0, 0) in main workspace units.
       var newBlock = Blockly.Xml.domToBlock(xml, ws);
+
+      // Scratch-specific: Give shadow dom new IDs to prevent duplicating on paste
+      var blocks = newBlock.getDescendants();
+      for (var i = blocks.length - 1; i >= 0; i--) {
+        var descendant = blocks[i];
+        for (var j = 0; j < descendant.inputList.length; j++) {
+          var connection = descendant.inputList[j].connection;
+          if (connection) {
+            var shadowDom = connection.getShadowDom();
+            if (shadowDom) {
+              shadowDom.setAttribute('id', Blockly.utils.genUid());
+              connection.setShadowDom(shadowDom);
+            }
+          }
+        }
+      }
+
       var svgRootNew = newBlock.getSvgRoot();
       if (!svgRootNew) {
         throw new Error('newBlock is not rendered.');

--- a/core/utils.js
+++ b/core/utils.js
@@ -931,3 +931,26 @@ Blockly.utils.setCssTransform = function(node, transform) {
   node.style['transform'] = transform;
   node.style['-webkit-transform'] = transform;
 };
+
+
+/**
+ * Re-assign obscured shadow blocks new IDs to prevent collisions
+ * Scratch specific to help the VM handle deleting obscured shadows.
+ * @param {Blockly.Block} block the root block to be processed.
+ */
+Blockly.utils.changeObscuredShadowIds = function(block) {
+  var blocks = block.getDescendants();
+  for (var i = blocks.length - 1; i >= 0; i--) {
+    var descendant = blocks[i];
+    for (var j = 0; j < descendant.inputList.length; j++) {
+      var connection = descendant.inputList[j].connection;
+      if (connection) {
+        var shadowDom = connection.getShadowDom();
+        if (shadowDom) {
+          shadowDom.setAttribute('id', Blockly.utils.genUid());
+          connection.setShadowDom(shadowDom);
+        }
+      }
+    }
+  }
+};

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -945,22 +945,12 @@ Blockly.WorkspaceSvg.prototype.paste = function(xmlBlock) {
   try {
     var block = Blockly.Xml.domToBlock(xmlBlock, this);
 
+    // Scratch-specific: Give shadow dom new IDs to prevent duplicating on paste
+    Blockly.utils.changeObscuredShadowIds(block);
+
     var blocks = block.getDescendants();
     for (var i = blocks.length - 1; i >= 0; i--) {
       var descendant = blocks[i];
-
-      // Scratch-specific: Give shadow dom new IDs to prevent duplicating on paste
-      for (var j = 0; j < descendant.inputList.length; j++) {
-        var connection = descendant.inputList[j].connection;
-        if (connection) {
-          var shadowDom = connection.getShadowDom();
-          if (shadowDom) {
-            shadowDom.setAttribute('id', Blockly.utils.genUid());
-            connection.setShadowDom(shadowDom);
-          }
-        }
-      }
-
       // Rerender to get around problem with IE and Edge not measuring text
       // correctly when it is hidden.
       if (goog.userAgent.IE || goog.userAgent.EDGE) {


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-blocks/issues/1024, a recurring and high priority problem that occurs when you use the "Duplicate" menu option. 

### Proposed Changes

_Describe what this Pull Request does_
Like the previous version of this bug, fix it by giving unique IDs to all shadows. 

### Reason for Changes

_Explain why these changes should be made_
See linked issue for more background. TL;DR duplicate IDs, even for obscured shadows, breaks scratch-vm's expectations of having unique IDs. 