### PR TITLE
Add back the block drag shadow

### DIFF
--- a/core/block_drag_surface.js
+++ b/core/block_drag_surface.js
@@ -129,9 +129,10 @@ Blockly.BlockDragSurfaceSvg.prototype.createDom = function() {
  * @return {string} ID for the filter element
  */
 Blockly.BlockDragSurfaceSvg.prototype.createDropShadowDom_ = function(defs) {
+  var rnd = String(Math.random()).substring(2);
   // Adjust these width/height, x/y properties to prevent the shadow from clipping
   var dragShadowFilter = Blockly.utils.createSvgElement('filter',
-    {'id': 'blocklyDragShadowFilter', 'height': '140%', 'width': '140%', y: '-20%', x: '-20%'}, defs);
+    {'id': 'blocklyDragShadowFilter' + rnd, 'height': '140%', 'width': '140%', y: '-20%', x: '-20%'}, defs);
   Blockly.utils.createSvgElement('feGaussianBlur',
     {'in': 'SourceAlpha', 'stdDeviation': Blockly.BlockDragSurfaceSvg.SHADOW_STD_DEVIATION}, dragShadowFilter);
   var componentTransfer = Blockly.utils.createSvgElement('feComponentTransfer',

--- a/core/block_drag_surface.js
+++ b/core/block_drag_surface.js
@@ -90,6 +90,20 @@ Blockly.BlockDragSurfaceSvg.prototype.scale_ = 1;
 Blockly.BlockDragSurfaceSvg.prototype.surfaceXY_ = null;
 
 /**
+ * ID for the drag shadow filter, set in createDom.
+ * @type {string}
+ * @private
+ */
+Blockly.BlockDragSurfaceSvg.prototype.dragShadowFilterId_ = '';
+
+/**
+ * Standard deviation for gaussian blur on drag shadow, in px.
+ * @type {number}
+ * @const
+ */
+Blockly.BlockDragSurfaceSvg.SHADOW_STD_DEVIATION = 6;
+
+/**
  * Create the drag surface and inject it into the container.
  */
 Blockly.BlockDragSurfaceSvg.prototype.createDom = function() {
@@ -103,7 +117,32 @@ Blockly.BlockDragSurfaceSvg.prototype.createDom = function() {
     'version': '1.1',
     'class': 'blocklyBlockDragSurface'
   }, this.container_);
+  var defs = Blockly.utils.createSvgElement('defs', {}, this.SVG_);
+  this.dragShadowFilterId_ = this.createDropShadowDom_(defs);
   this.dragGroup_ = Blockly.utils.createSvgElement('g', {}, this.SVG_);
+  this.dragGroup_.setAttribute('filter', 'url(#' + this.dragShadowFilterId_ + ')');
+};
+
+/**
+ * Scratch-specific: Create the SVG def for the drop shadow.
+ * @param {Element} defs Defs element to insert the shadow filter definition
+ * @return {string} ID for the filter element
+ */
+Blockly.BlockDragSurfaceSvg.prototype.createDropShadowDom_ = function(defs) {
+  // Adjust these width/height, x/y properties to prevent the shadow from clipping
+  var dragShadowFilter = Blockly.utils.createSvgElement('filter',
+    {'id': 'blocklyDragShadowFilter', 'height': '140%', 'width': '140%', y: '-20%', x: '-20%'}, defs);
+  Blockly.utils.createSvgElement('feGaussianBlur',
+    {'in': 'SourceAlpha', 'stdDeviation': Blockly.BlockDragSurfaceSvg.SHADOW_STD_DEVIATION}, dragShadowFilter);
+  var componentTransfer = Blockly.utils.createSvgElement('feComponentTransfer',
+    {'result': 'offsetBlur'}, dragShadowFilter);
+  // Shadow opacity is specified in the adjustable colour library,
+  // since the darkness of the shadow largely depends on the workspace colour.
+  Blockly.utils.createSvgElement('feFuncA',
+    {'type': 'linear', 'slope': Blockly.Colours.dragShadowOpacity}, componentTransfer);
+  Blockly.utils.createSvgElement('feComposite',
+    {'in': 'SourceGraphic', 'in2': 'offsetBlur', 'operator': 'over'}, dragShadowFilter);
+  return dragShadowFilter.id;
 };
 
 /**

--- a/core/css.js
+++ b/core/css.js
@@ -412,8 +412,8 @@ Blockly.Css.CONTENT = [
 
   '.blocklyDragging>.blocklyPath,',
   '.blocklyDragging>.blocklyPathLight {',
-    'fill-opacity: .8;',
-    'stroke-opacity: .8;',
+    'fill-opacity: 1.0;',
+    'stroke-opacity: 1.0;',
   '}',
 
   '.blocklyDragging>.blocklyPath {',


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_
Fixes https://github.com/LLK/scratch-blocks/issues/815

### Proposed Changes

_Describe what this Pull Request does_

Add back the code from @tmickel for the shadow below the block when it is being dragged. It had been accidentally removed (by me, woops 😢 ) when we merged in upstream changes to the block dragging code. 

This is basically verbatim from the old code (see this diff https://github.com/LLK/scratch-blocks/commit/be9d5fefed9f54568d94702b0ef3186625d93699#diff-40ab07a584c99b6f5e75d09bd2570ff4L106), apart from minor API updates for a few utilities. We never removed the drag colour stuff, so that is still all there. 

### Reason for Changes

_Explain why these changes should be made_

@carljbowman just to check, this is what we want right? 

![screen shot 2017-07-26 at 4 24 43 pm](https://user-images.githubusercontent.com/654102/28642062-1b1fd17e-721f-11e7-9319-5ef0366bcf53.png)

