### PR TITLE
Fix traversal for tab ordering

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -624,16 +624,9 @@ Blockly.BlockSvg.prototype.tab = function(start, forward) {
     if (outputBlock) {
       outputBlock.tab(this, forward);
     } else { // Otherwise, go to next / previous block, depending on value of `forward`
-      if (forward) {
-        var nextBlock = this.nextConnection && this.nextConnection.targetBlock();
-        if (nextBlock) {
-          nextBlock.tab(this, forward);
-        }
-      } else {
-        var previousBlock = this.previousConnection && this.previousConnection.targetBlock();
-        if (previousBlock) {
-          previousBlock.tab(this, forward);
-        }
+      var block = forward ? this.getNextBlock() : this.getPreviousBlock();
+      if (block) {
+        block.tab(this, forward);
       }
     }
   } else if (target instanceof Blockly.Field) {

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -619,9 +619,22 @@ Blockly.BlockSvg.prototype.tab = function(start, forward) {
   var target = list[forward ? i + 1 : i - 1];
   if (!target) {
     // Ran off of list.
-    var parent = this.getParent();
-    if (parent) {
-      parent.tab(this, forward);
+    // If there is an output, tab up to that block.
+    var outputBlock = this.outputConnection && this.outputConnection.targetBlock();
+    if (outputBlock) {
+      outputBlock.tab(this, forward);
+    } else { // Otherwise, go to next / previous block, depending on value of `forward`
+      if (forward) {
+        var nextBlock = this.nextConnection && this.nextConnection.targetBlock();
+        if (nextBlock) {
+          nextBlock.tab(this, forward);
+        }
+      } else {
+        var previousBlock = this.previousConnection && this.previousConnection.targetBlock();
+        if (previousBlock) {
+          previousBlock.tab(this, forward);
+        }
+      }
     }
   } else if (target instanceof Blockly.Field) {
     target.showEditor_();

--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -286,11 +286,14 @@ Blockly.FieldTextInput.prototype.onHtmlInputKeyDown_ = function(e) {
   var tabKey = 9, enterKey = 13, escKey = 27;
   if (e.keyCode == enterKey) {
     Blockly.WidgetDiv.hide();
+    Blockly.DropDownDiv.hideWithoutAnimation();
   } else if (e.keyCode == escKey) {
     htmlInput.value = htmlInput.defaultValue;
     Blockly.WidgetDiv.hide();
+    Blockly.DropDownDiv.hideWithoutAnimation();
   } else if (e.keyCode == tabKey) {
     Blockly.WidgetDiv.hide();
+    Blockly.DropDownDiv.hideWithoutAnimation();
     this.sourceBlock_.tab(this, !e.shiftKey);
     e.preventDefault();
   }


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-blocks/issues/170

### Proposed Changes

_Describe what this Pull Request does_

Change the tab order traversal. Instead of always going to the parent (either output or previous connection), only go "up" to output if it exists. If there is no output, use next / previous connection as directed. 

This also fixes a bug that occurs when tabbing (and esc/entering) into fields that have a dropdown div open, namely the angle picker. 

### Reason for Changes

_Explain why these changes should be made_

Because it was wrong!

![tabbing](https://user-images.githubusercontent.com/654102/28687859-e8b9e0d4-72dd-11e7-8351-c37f171a333c.gif)

