### PR TITLE
Correctly apply flipRTL for images in vertical RTL

### DIFF
--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -633,21 +633,32 @@ Blockly.BlockSvg.prototype.renderFields_ =
     // Offset the field upward by half its height.
     // This vertically centers the fields around cursorY.
     var yOffset = -field.getSize().height / 2;
+    var translateX, translateY;
+    var scale = '';
     if (this.RTL) {
       cursorX -= field.renderSep + field.renderWidth;
-      root.setAttribute('transform',
-          'translate(' + cursorX + ',' + (cursorY + yOffset) + ')');
+      translateX = cursorX;
+      translateY = cursorY + yOffset;
       if (field.renderWidth) {
         cursorX -= Blockly.BlockSvg.SEP_SPACE_X;
       }
     } else {
-      root.setAttribute('transform',
-          'translate(' + (cursorX + field.renderSep) + ',' + (cursorY + yOffset) + ')');
+      translateX = cursorX + field.renderSep;
+      translateY = cursorY + yOffset;
       if (field.renderWidth) {
         cursorX += field.renderSep + field.renderWidth +
             Blockly.BlockSvg.SEP_SPACE_X;
       }
     }
+    if (this.RTL &&
+        field instanceof Blockly.FieldImage &&
+        field.getFlipRTL()) {
+      scale = 'scale(-1 1)';
+      translateX += field.renderWidth;
+    }
+    root.setAttribute('transform',
+      'translate(' + translateX + ', ' + translateY + ') ' + scale
+    );
     // Fields are invisible on insertion marker.
     if (this.isInsertionMarker()) {
       root.setAttribute('display', 'none');


### PR DESCRIPTION
### Resolves
--
### Proposed Changes

Before (see arrows, GF):
<img width="174" alt="before" src="https://user-images.githubusercontent.com/120403/28808411-d04c2be6-7649-11e7-8a2f-a8fb2f109944.png">
After:
<img width="175" alt="after" src="https://user-images.githubusercontent.com/120403/28808416-d4673662-7649-11e7-9864-32b01b14f97c.png">


### Reason for Changes

Image fields that have the "flipRTL" property on them are intended to be flipped in RTL mode. This works for the horizontal blocks rendering, but was never implemented for vertical rendering. With this change, it is.