### PR TITLE
Center variable reporter; fix field centering to work for it

### DIFF
--- a/blocks_vertical/data.js
+++ b/blocks_vertical/data.js
@@ -37,6 +37,7 @@ Blockly.Blocks['data_variable'] = {
   init: function() {
     this.jsonInit({
       "message0": "%1",
+      "lastDummyAlign0": "CENTRE",
       "args0": [
         {
           "type": "field_variable_getter",

--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -1123,14 +1123,14 @@ Blockly.BlockSvg.prototype.renderDrawRight_ = function(steps,
         fieldY += row.height / 2;
 
         // Align inline field rows (left/right/centre).
-        if (input.align != Blockly.ALIGN_LEFT) {
-          var fieldRightX = inputRows.rightEdge - input.fieldWidth -
-              (2 * Blockly.BlockSvg.SEP_SPACE_X);
-          if (input.align == Blockly.ALIGN_RIGHT) {
-            fieldX += fieldRightX;
-          } else if (input.align == Blockly.ALIGN_CENTRE) {
-            fieldX += fieldRightX / 2;
-          }
+        if (input.align === Blockly.ALIGN_RIGHT) {
+          fieldX += inputRows.rightEdge - input.fieldWidth -
+            (2 * Blockly.BlockSvg.SEP_SPACE_X);
+        } else if (input.align === Blockly.ALIGN_CENTRE) {
+          fieldX = Math.max(
+            inputRows.rightEdge / 2 - input.fieldWidth / 2,
+            fieldX
+          );
         }
 
         cursorX = this.renderFields_(input.fieldRow, fieldX, fieldY);


### PR DESCRIPTION
### Resolves
--
### Proposed Changes

Before:
<img width="76" alt="before_center" src="https://user-images.githubusercontent.com/120403/28809099-fe2dc40c-764e-11e7-9966-cc1a8906ac13.png">

After:
<img width="74" alt="after_center" src="https://user-images.githubusercontent.com/120403/28809101-02d5af38-764f-11e7-9c73-040bab161f19.png">
<img width="59" alt="screen shot 2017-08-01 at 12 19 08 am" src="https://user-images.githubusercontent.com/120403/28809105-108ea8fa-764f-11e7-8c0f-2b6a01dccf62.png">
<img width="212" alt="screen shot 2017-08-01 at 12 19 30 am" src="https://user-images.githubusercontent.com/120403/28809108-1bc59710-764f-11e7-8bce-b3accaacdc35.png">


### Reason for Changes

Variables named with "text with a small width" (e.g., a single character) were not aligned in the center of the reporter. By adding the CENTRE alignment (and fixing its implementation), they are.

### Test Coverage
--