### PR TITLE
Don't flip the green flag in RTL

### DIFF
--- a/blocks_vertical/event.js
+++ b/blocks_vertical/event.js
@@ -43,8 +43,7 @@ Blockly.Blocks['event_whenflagclicked'] = {
           "src": Blockly.mainWorkspace.options.pathToMedia + "green-flag.svg",
           "width": 24,
           "height": 24,
-          "alt": "flag",
-          "flip_rtl": true
+          "alt": "flag"
         }
       ],
       "category": Blockly.Categories.event,


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes issue mentioned at the end of https://github.com/LLK/scratch-blocks/pull/1034

### Proposed Changes

_Describe what this Pull Request does_

Removes `flip_rtl` property from green flag field image description.

### Reason for Changes

_Explain why these changes should be made_

@carljbowman says the green flag should not fly the other direction in RTL

### Test Coverage

_Please show how you have added tests to cover your changes_

n/a