### PR TITLE
Add glide (number) secs to [drop down] block

### DIFF
--- a/blocks_vertical/default_toolbox.js
+++ b/blocks_vertical/default_toolbox.js
@@ -99,6 +99,17 @@ Blockly.Blocks.defaultToolbox = '<xml id="toolbox-categories" style="display: no
         '</shadow>'+
       '</value>'+
     '</block>'+
+    '<block type="motion_glideto" id="motion_glideto">'+
+      '<value name="SECS">'+
+        '<shadow type="math_number">'+
+          '<field name="SECS">1</field>'+
+        '</shadow>'+
+      '</value>'+
+      '<value name="TO">'+
+        '<shadow type="motion_glideto_menu">'+
+        '</shadow>'+
+      '</value>'+
+    '</block>'+
     '<block type="motion_changexby" id="motion_changexby">'+
       '<value name="DX">'+
         '<shadow type="math_number">'+

--- a/blocks_vertical/default_toolbox.js
+++ b/blocks_vertical/default_toolbox.js
@@ -102,7 +102,7 @@ Blockly.Blocks.defaultToolbox = '<xml id="toolbox-categories" style="display: no
     '<block type="motion_glideto" id="motion_glideto">'+
       '<value name="SECS">'+
         '<shadow type="math_number">'+
-          '<field name="SECS">1</field>'+
+          '<field name="NUM">1</field>'+
         '</shadow>'+
       '</value>'+
       '<value name="TO">'+

--- a/blocks_vertical/motion.js
+++ b/blocks_vertical/motion.js
@@ -270,24 +270,24 @@ Blockly.Blocks['motion_glideto_menu'] = {
    * Glide to drop-down menu
    * @this Blockly.Block
    */
-  init: function () {
+  init: function() {
     this.jsonInit({
-        "message0": "%1",
-        "args0": [
-          {
-            "type": "field_dropdown",
-            "name": "TO",
-            "options": [
-              ['mouse-pointer', '_mouse_'],
-              ['random position', '_random_']
-            ]
-          }
-        ],
-        "colour": Blockly.Colours.motion.secondary,
-        "colourSecondary": Blockly.Colours.motion.secondary,
-        "colourTertiary": Blockly.Colours.motion.tertiary,
-        "extensions": ["output_string"]
-      });
+      "message0": "%1",
+      "args0": [
+        {
+          "type": "field_dropdown",
+          "name": "TO",
+          "options": [
+            ['mouse-pointer', '_mouse_'],
+            ['random position', '_random_']
+          ]
+        }
+      ],
+      "colour": Blockly.Colours.motion.secondary,
+      "colourSecondary": Blockly.Colours.motion.secondary,
+      "colourTertiary": Blockly.Colours.motion.tertiary,
+      "extensions": ["output_string"]
+    });
   }
 };
 
@@ -296,7 +296,7 @@ Blockly.Blocks['motion_glideto'] = {
    * Block to glide to a menu item
    * @this Blockly.Block
    */
-  init: function () {
+  init: function() {
     this.jsonInit({
       "message0": "glide %1 secs to %2",
       "args0": [

--- a/blocks_vertical/motion.js
+++ b/blocks_vertical/motion.js
@@ -265,6 +265,56 @@ Blockly.Blocks['motion_glidesecstoxy'] = {
   }
 };
 
+Blockly.Blocks['motion_glideto_menu'] = {
+  /**
+   * Glide to drop-down menu
+   * @this Blockly.Block
+   */
+  init: function () {
+    this.jsonInit({
+        "message0": "%1",
+        "args0": [
+          {
+            "type": "field_dropdown",
+            "name": "TO",
+            "options": [
+              ['mouse-pointer', '_mouse_'],
+              ['random position', '_random_']
+            ]
+          }
+        ],
+        "colour": Blockly.Colours.motion.secondary,
+        "colourSecondary": Blockly.Colours.motion.secondary,
+        "colourTertiary": Blockly.Colours.motion.tertiary,
+        "extensions": ["output_string"]
+      });
+  }
+};
+
+Blockly.Blocks['motion_glideto'] = {
+  /**
+   * Block to glide to a menu item
+   * @this Blockly.Block
+   */
+  init: function () {
+    this.jsonInit({
+      "message0": "glide %1 secs to %2",
+      "args0": [
+        {
+          "type": "input_value",
+          "name": "SECS"
+        },
+        {
+          "type": "input_value",
+          "name": "TO"
+        }
+      ],
+      "category": Blockly.Categories.motion,
+      "extensions": ["colours_motion", "shape_statement"]
+    });
+  }
+};
+
 Blockly.Blocks['motion_changexby'] = {
   /**
    * Block to change X.


### PR DESCRIPTION
### Resolves

LLK/scratch-gui#598

### Proposed Changes

Adds the “glide (number) secs to [drop down]” block to `motion.js` and `default_toolbox.js`

Comes with LLK/scratch-vm#662 and LLK/scratch-gui#634