### PR TITLE
Bring the most recently edited stack to the front

### DIFF
--- a/core/insertion_marker_manager.js
+++ b/core/insertion_marker_manager.js
@@ -205,6 +205,9 @@ Blockly.InsertionMarkerManager.prototype.applyConnections = function() {
       var inferiorConnection = this.localConnection_.isSuperior() ?
           this.closestConnection_ : this.localConnection_;
       inferiorConnection.getSourceBlock().connectionUiEffect();
+      // Bring the just-edited stack to the front.
+      var rootBlock = this.topBlock_.getRootBlock();
+      rootBlock.bringToFront();
     }
   }
 };


### PR DESCRIPTION
### Resolves

Fixes #937 

### Proposed Changes

At the end of a drag that connected to a block, find the root block of the new stack and bring it to the front.

### Reason for Changes

From #937:
"

The root cause is: * <g> tags do not respect z-index so svg renders them in the  * order that they are in the dom.  By placing this block first within the  * block group's <g>, it will render on top of any other blocks. (from Blockly.BlockSvg.prototype.bringToFront)We're never explicitly calling bringToFront during a drag, but adding at the top level of the workspace effectively brings it to the front, while adding a block connected to another one doesn't bring it to the front.The solution is to find the top block in the stack and bring it to the front.Calling bringToFront on the dragging block would also work but would get expensive if the dragging block is being connected to the end of a long stack--we would be calling appendChild() for every single block above it i nthe stack.The fix belongs in Blockly.draggedConnectionManager.prototype.applyConnections in main blockly. In scratch-blocks it belongs in Blockly.InsertionMarkerManager.prototype.applyConnections.
"

### Test Coverage

Tested in the vertical playground.