### PR TITLE
Exclude image field from positioning fix

### DIFF
--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -623,8 +623,9 @@ Blockly.BlockSvg.prototype.renderFields_ =
     if (!root) {
       continue;
     }
-    // In blocks with a notch, non-label fields should be bumped to a min X,
-    // to avoid overlapping with the notch.
+    // In blocks with a notch, fields should be bumped to a min X,
+    // to avoid overlapping with the notch. Label and image fields are
+    // excluded.
     if (this.previousConnection && !(field instanceof Blockly.FieldLabel) &&
         !(field instanceof Blockly.FieldImage)) {
       cursorX = this.RTL ?

--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -625,7 +625,8 @@ Blockly.BlockSvg.prototype.renderFields_ =
     }
     // In blocks with a notch, non-label fields should be bumped to a min X,
     // to avoid overlapping with the notch.
-    if (this.previousConnection && !(field instanceof Blockly.FieldLabel) && !(field instanceof Blockly.FieldImage)) {
+    if (this.previousConnection && !(field instanceof Blockly.FieldLabel) &&
+        !(field instanceof Blockly.FieldImage)) {
       cursorX = this.RTL ?
         Math.min(cursorX, -Blockly.BlockSvg.INPUT_AND_FIELD_MIN_X) :
         Math.max(cursorX, Blockly.BlockSvg.INPUT_AND_FIELD_MIN_X);

--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -625,7 +625,7 @@ Blockly.BlockSvg.prototype.renderFields_ =
     }
     // In blocks with a notch, non-label fields should be bumped to a min X,
     // to avoid overlapping with the notch.
-    if (this.previousConnection && !(field instanceof Blockly.FieldLabel)) {
+    if (this.previousConnection && !(field instanceof Blockly.FieldLabel) && !(field instanceof Blockly.FieldImage)) {
       cursorX = this.RTL ?
         Math.min(cursorX, -Blockly.BlockSvg.INPUT_AND_FIELD_MIN_X) :
         Math.max(cursorX, Blockly.BlockSvg.INPUT_AND_FIELD_MIN_X);


### PR DESCRIPTION
### Resolves

For extensions, we'll be adding an icon to the start of each block. Currently those icons are positioned too far to the right, due to an existing positioning fix related to the notch in the block:

<img width="169" alt="screen shot 2017-08-22 at 11 51 49 am" src="https://user-images.githubusercontent.com/567844/29574953-039c18c4-8731-11e7-8bc0-eefc6c0e9260.png">

### Proposed Changes

Correct the positioning of leading icons by excluding image fields from the notch fix:

<img width="132" alt="screen shot 2017-08-22 at 11 48 08 am" src="https://user-images.githubusercontent.com/567844/29575026-41064db0-8731-11e7-9b28-2574d3e80c29.png">

