### PR TITLE
Fix horizontal flyout errors

### DIFF
--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -556,17 +556,10 @@ Blockly.Flyout.prototype.clearOldBlocks_ = function() {
  * @private
  */
 Blockly.Flyout.prototype.addBlockListeners_ = function(root, block, rect) {
-  if (this.autoClose) {
-    this.listeners_.push(Blockly.bindEventWithChecks_(root, 'mousedown', null,
-        this.createBlockFunc_(block)));
-    this.listeners_.push(Blockly.bindEventWithChecks_(rect, 'mousedown', null,
-        this.createBlockFunc_(block)));
-  } else {
-    this.listeners_.push(Blockly.bindEventWithChecks_(root, 'mousedown', null,
-        this.blockMouseDown_(block)));
-    this.listeners_.push(Blockly.bindEventWithChecks_(rect, 'mousedown', null,
-        this.blockMouseDown_(block)));
-  }
+  this.listeners_.push(Blockly.bindEventWithChecks_(root, 'mousedown', null,
+      this.blockMouseDown_(block)));
+  this.listeners_.push(Blockly.bindEventWithChecks_(rect, 'mousedown', null,
+      this.blockMouseDown_(block)));
   this.listeners_.push(Blockly.bindEvent_(root, 'mouseover', block,
       block.addSelect));
   this.listeners_.push(Blockly.bindEvent_(root, 'mouseout', block,


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Resolves https://github.com/LLK/scratch-blocks/issues/1038

Removes code that handles auto-closing flyouts, which do not exist in Scratch Blocks.

Fixes the error preventing the blocks from being positioned when you used a horizontal (top|bottom) toolbox. This doesn't fix the way the categories are positioned, but that is changing so I just wanted to first fix the actual error. 

### Proposed Changes

_Describe what this Pull Request does_

There was a bit of old code that was removed a long time ago upstream (https://github.com/google/blockly/commit/4e3faf0158b5e756d72601e1bf9e090fb1b7a495). Removed that to match upstream.

![image](https://user-images.githubusercontent.com/654102/29714682-30a7bb64-8972-11e7-8bc1-c1d09d17f632.png)

![image](https://user-images.githubusercontent.com/654102/29714685-3267e744-8972-11e7-8307-c7acb4a24758.png)

h/t to https://github.com/LLK/scratch-blocks/pull/1044 for pointing in the right direction to this fix. 