### PR TITLE
Single auto-scrolling flyout containing all of the blocks

### DIFF
--- a/blocks_vertical/default_toolbox.js
+++ b/blocks_vertical/default_toolbox.js
@@ -30,6 +30,7 @@ goog.require('Blockly.Blocks');
 
 Blockly.Blocks.defaultToolbox = '<xml id="toolbox-categories" style="display: none">'+
   '<category name="Motion" colour="#4C97FF" secondaryColour="#3373CC">'+
+    '<label text="Motion" web-class="categoryLabel"></label>' +
     '<block type="motion_movesteps" id="motion_movesteps">'+
       '<value name="STEPS">'+
         '<shadow type="math_number">'+
@@ -145,6 +146,7 @@ Blockly.Blocks.defaultToolbox = '<xml id="toolbox-categories" style="display: no
     '<block type="motion_direction" id="motion_direction"></block>'+
   '</category>'+
   '<category name="Looks" colour="#9966FF" secondaryColour="#774DCB">'+
+    '<label text="Looks" web-class="categoryLabel"></label>' +
     '<block type="looks_show" id="looks_show"></block>'+
     '<block type="looks_hide" id="looks_hide"></block>'+
     '<block type="looks_switchcostumeto" id="looks_switchcostumeto">'+
@@ -207,6 +209,7 @@ Blockly.Blocks.defaultToolbox = '<xml id="toolbox-categories" style="display: no
     '<block type="looks_size" id="looks_size"></block>'+
   '</category>'+
   '<category name="Sound" colour="#D65CD6" secondaryColour="#BD42BD">'+
+    '<label text="Sound" web-class="categoryLabel"></label>' +
     '<block type="sound_play" id="sound_play">'+
       '<value name="SOUND_MENU">'+
         '<shadow type="sound_sounds_menu"></shadow>'+
@@ -299,6 +302,7 @@ Blockly.Blocks.defaultToolbox = '<xml id="toolbox-categories" style="display: no
     '<block type="sound_tempo" id="sound_tempo"></block>'+
   '</category>'+
   '<category name="Pen" colour="#00B295" secondaryColour="#0B8E69">'+
+    '<label text="Pen" web-class="categoryLabel"></label>' +
     '<block type="pen_clear" id="pen_clear"></block>'+
     '<block type="pen_stamp" id="pen_stamp"></block>'+
     '<block type="pen_pendown" id="pen_pendown"></block>'+
@@ -353,8 +357,10 @@ Blockly.Blocks.defaultToolbox = '<xml id="toolbox-categories" style="display: no
     '</block>'+
   '</category>'+
   '<category name="Data" colour="#FF8C1A" secondaryColour="#DB6E00" custom="VARIABLE">' +
+    '<label text="Data" web-class="categoryLabel"></label>' +
   '</category>' +
   '<category name="Events" colour="#FFD500" secondaryColour="#CC9900">'+
+    '<label text="Events" web-class="categoryLabel"></label>' +
     '<block type="event_whenflagclicked" id="event_whenflagclicked"></block>'+
     '<block type="event_whenkeypressed" id="event_whenkeypressed">'+
     '</block>'+
@@ -382,6 +388,7 @@ Blockly.Blocks.defaultToolbox = '<xml id="toolbox-categories" style="display: no
     '</block>'+
   '</category>'+
   '<category name="Control" colour="#FFAB19" secondaryColour="#CF8B17">'+
+    '<label text="Control" web-class="categoryLabel"></label>' +
     '<block type="control_wait" id="control_wait">'+
       '<value name="DURATION">'+
         '<shadow type="math_positive_number">'+
@@ -411,6 +418,7 @@ Blockly.Blocks.defaultToolbox = '<xml id="toolbox-categories" style="display: no
     '<block type="control_delete_this_clone" id="control_delete_this_clone"></block>'+
   '</category>'+
   '<category name="Sensing" colour="#4CBFE6" secondaryColour="#2E8EB8">'+
+    '<label text="Sensing" web-class="categoryLabel"></label>' +
     '<block type="sensing_touchingobject" id="sensing_touchingobject">'+
       '<value name="TOUCHINGOBJECTMENU">'+
         '<shadow type="sensing_touchingobjectmenu"></shadow>'+
@@ -461,6 +469,7 @@ Blockly.Blocks.defaultToolbox = '<xml id="toolbox-categories" style="display: no
   '<block type="sensing_dayssince2000" id="sensing_dayssince2000"></block>'+
   '</category>'+
   '<category name="Operators" colour="#40BF4A" secondaryColour="#389438">'+
+    '<label text="Operators" web-class="categoryLabel"></label>' +
     '<block type="operator_add" id="operator_add">'+
       '<value name="NUM1">'+
         '<shadow type="math_number">'+

--- a/blocks_vertical/default_toolbox.js
+++ b/blocks_vertical/default_toolbox.js
@@ -30,7 +30,6 @@ goog.require('Blockly.Blocks');
 
 Blockly.Blocks.defaultToolbox = '<xml id="toolbox-categories" style="display: none">'+
   '<category name="Motion" colour="#4C97FF" secondaryColour="#3373CC">'+
-    '<label text="Motion" web-class="categoryLabel"></label>' +
     '<block type="motion_movesteps" id="motion_movesteps">'+
       '<value name="STEPS">'+
         '<shadow type="math_number">'+
@@ -146,7 +145,6 @@ Blockly.Blocks.defaultToolbox = '<xml id="toolbox-categories" style="display: no
     '<block type="motion_direction" id="motion_direction"></block>'+
   '</category>'+
   '<category name="Looks" colour="#9966FF" secondaryColour="#774DCB">'+
-    '<label text="Looks" web-class="categoryLabel"></label>' +
     '<block type="looks_show" id="looks_show"></block>'+
     '<block type="looks_hide" id="looks_hide"></block>'+
     '<block type="looks_switchcostumeto" id="looks_switchcostumeto">'+
@@ -209,7 +207,6 @@ Blockly.Blocks.defaultToolbox = '<xml id="toolbox-categories" style="display: no
     '<block type="looks_size" id="looks_size"></block>'+
   '</category>'+
   '<category name="Sound" colour="#D65CD6" secondaryColour="#BD42BD">'+
-    '<label text="Sound" web-class="categoryLabel"></label>' +
     '<block type="sound_play" id="sound_play">'+
       '<value name="SOUND_MENU">'+
         '<shadow type="sound_sounds_menu"></shadow>'+
@@ -302,7 +299,6 @@ Blockly.Blocks.defaultToolbox = '<xml id="toolbox-categories" style="display: no
     '<block type="sound_tempo" id="sound_tempo"></block>'+
   '</category>'+
   '<category name="Pen" colour="#00B295" secondaryColour="#0B8E69">'+
-    '<label text="Pen" web-class="categoryLabel"></label>' +
     '<block type="pen_clear" id="pen_clear"></block>'+
     '<block type="pen_stamp" id="pen_stamp"></block>'+
     '<block type="pen_pendown" id="pen_pendown"></block>'+
@@ -357,10 +353,8 @@ Blockly.Blocks.defaultToolbox = '<xml id="toolbox-categories" style="display: no
     '</block>'+
   '</category>'+
   '<category name="Data" colour="#FF8C1A" secondaryColour="#DB6E00" custom="VARIABLE">' +
-    '<label text="Data" web-class="categoryLabel"></label>' +
   '</category>' +
   '<category name="Events" colour="#FFD500" secondaryColour="#CC9900">'+
-    '<label text="Events" web-class="categoryLabel"></label>' +
     '<block type="event_whenflagclicked" id="event_whenflagclicked"></block>'+
     '<block type="event_whenkeypressed" id="event_whenkeypressed">'+
     '</block>'+
@@ -388,7 +382,6 @@ Blockly.Blocks.defaultToolbox = '<xml id="toolbox-categories" style="display: no
     '</block>'+
   '</category>'+
   '<category name="Control" colour="#FFAB19" secondaryColour="#CF8B17">'+
-    '<label text="Control" web-class="categoryLabel"></label>' +
     '<block type="control_wait" id="control_wait">'+
       '<value name="DURATION">'+
         '<shadow type="math_positive_number">'+
@@ -418,7 +411,6 @@ Blockly.Blocks.defaultToolbox = '<xml id="toolbox-categories" style="display: no
     '<block type="control_delete_this_clone" id="control_delete_this_clone"></block>'+
   '</category>'+
   '<category name="Sensing" colour="#4CBFE6" secondaryColour="#2E8EB8">'+
-    '<label text="Sensing" web-class="categoryLabel"></label>' +
     '<block type="sensing_touchingobject" id="sensing_touchingobject">'+
       '<value name="TOUCHINGOBJECTMENU">'+
         '<shadow type="sensing_touchingobjectmenu"></shadow>'+
@@ -469,7 +461,6 @@ Blockly.Blocks.defaultToolbox = '<xml id="toolbox-categories" style="display: no
   '<block type="sensing_dayssince2000" id="sensing_dayssince2000"></block>'+
   '</category>'+
   '<category name="Operators" colour="#40BF4A" secondaryColour="#389438">'+
-    '<label text="Operators" web-class="categoryLabel"></label>' +
     '<block type="operator_add" id="operator_add">'+
       '<value name="NUM1">'+
         '<shadow type="math_number">'+

--- a/core/css.js
+++ b/core/css.js
@@ -494,7 +494,11 @@ Blockly.Css.CONTENT = [
   '}',
 
   '.blocklyFlyoutLabelText {',
-    'fill: #000;',
+    'font-family: "Helvetica Neue", Helvetica, sans-serif;',
+    'font-size: 14pt;',
+    'fill: #575E75;',
+    'transform: translate(-40px, 0px);',
+    'font-weight: bold;',
   '}',
 
   /*

--- a/core/css.js
+++ b/core/css.js
@@ -497,7 +497,6 @@ Blockly.Css.CONTENT = [
     'font-family: "Helvetica Neue", Helvetica, sans-serif;',
     'font-size: 14pt;',
     'fill: #575E75;',
-    'transform: translate(-40px, 0px);',
     'font-weight: bold;',
   '}',
 

--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -534,19 +534,19 @@ Blockly.Flyout.prototype.show = function(xmlList) {
 };
 
 /**
- * Store an array of with category names and scrollbar positions.
+ * Store an array of category names and scrollbar positions.
  * This is used when scrolling the flyout to cause a category to be selected.
  * @private
  */
 Blockly.Flyout.prototype.recordCategoryScrollPositions_ = function() {
   this.categoryScrollPositions = [];
   for (var i = 0; i < this.buttons_.length; i++) {
-    if (this.buttons_[i].isCategoryLabel_) {
+    if (this.buttons_[i].getIsCategoryLabel()) {
       var categoryLabel = this.buttons_[i];
       this.categoryScrollPositions.push({
-        categoryName: categoryLabel.text_,
+        categoryName: categoryLabel.getText(),
         position: this.horizontalLayout_ ?
-          categoryLabel.position_.x : categoryLabel.position_.y
+          categoryLabel.getPosition().x : categoryLabel.getPosition().y
       });
     }
   }

--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -547,6 +547,7 @@ Blockly.Flyout.prototype.recordCategoryScrollPositions_ = function() {
 /**
  * Step the scrolling animation by scrolling a fraction of the way to
  * a scroll target, and request the next frame if necessary.
+ * @package
  */
 Blockly.Flyout.prototype.stepScrollAnimation = function() {
   if (!this.scrollTarget) {

--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -124,7 +124,7 @@ Blockly.Flyout = function(workspaceOptions) {
  * Does the flyout automatically close when a block is created?
  * @type {boolean}
  */
-Blockly.Flyout.prototype.autoClose = true;
+Blockly.Flyout.prototype.autoClose = false;
 
 /**
  * Whether the flyout is visible.

--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -520,6 +520,19 @@ Blockly.Flyout.prototype.show = function(xmlList) {
 
   this.reflowWrapper_ = this.reflow.bind(this);
   this.workspace_.addChangeListener(this.reflowWrapper_);
+
+  // make a map of scrollbar positions to category names
+  // so that scrolling the flyout can cause a category to be selected
+  this.categoryScrollPositions = [];
+  for (var i=0; i<this.buttons_.length; i++) {
+    var category = this.buttons_[i];
+    if (category.isLabel_) {
+      this.categoryScrollPositions.push({
+        categoryName:category.text_,
+        position:category.position_.y
+      });
+    }
+  }
 };
 
 /**

--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -456,8 +456,8 @@ Blockly.Flyout.prototype.show = function(xmlList) {
       var newList = fnToApply(this.workspace_.targetWorkspace);
       // Insert the new list of blocks in the middle of the list.
       // We use splice to insert at index i, and remove a single element
-      // (the placeholder string). Because the spread operator (...) is not available,
-      // use apply and concat the array.
+      // (the placeholder string). Because the spread operator (...) is not
+      // available, use apply and concat the array.
       xmlList.splice.apply(xmlList, [i, 1].concat(newList));
       xml = xmlList[i];
     }

--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -532,7 +532,7 @@ Blockly.Flyout.prototype.show = function(xmlList) {
  */
 Blockly.Flyout.prototype.recordCategoryScrollPositions_ = function() {
   this.categoryScrollPositions = [];
-  for (var i=0; i<this.buttons_.length; i++) {
+  for (var i = 0; i < this.buttons_.length; i++) {
     if (this.buttons_[i].isCategoryLabel_) {
       var categoryLabel = this.buttons_[i];
       this.categoryScrollPositions.push({

--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -553,6 +553,23 @@ Blockly.Flyout.prototype.recordCategoryScrollPositions_ = function() {
 };
 
 /**
+ * Select a category using the scroll position.
+ * @param  {number} pos The scroll position.
+ * @package
+ */
+Blockly.Flyout.prototype.selectCategoryByScrollPosition = function(pos) {
+  var scaledPos = pos / this.workspace_.scale;
+  // Traverse the array of scroll positions in reverse, so we can select the furthest
+  // category that the scroll position is beyond
+  for (var i = this.categoryScrollPositions.length - 1; i >= 0; i--) {
+    if (scaledPos > this.categoryScrollPositions[i].position) {
+      this.parentToolbox_.selectCategoryByName(this.categoryScrollPositions[i].categoryName);
+      return;
+    }
+  }
+};
+
+/**
  * Step the scrolling animation by scrolling a fraction of the way to
  * a scroll target, and request the next frame if necessary.
  * @package

--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -447,16 +447,17 @@ Blockly.Flyout.prototype.show = function(xmlList) {
   var gaps = [];
   this.permanentlyDisabled_.length = 0;
   for (var i = 0, xml; xml = xmlList[i]; i++) {
-    // Handle the dynamic category for variables, represented by a name instead of a list of XML.
+    // Handle dynamic categories, represented by a name instead of a list of XML.
     // Look up the correct category generation function and call that to get a
     // valid XML list.
     if (typeof xmlList[i] === 'string') {
       var fnToApply = this.workspace_.targetWorkspace.getToolboxCategoryCallback(
           xmlList[i]);
       var newList = fnToApply(this.workspace_.targetWorkspace);
-      // insert the new list of variable blocks in the middle of the list
-      // we use splice to insert at index i, and remove a single element (the placeholder string)
-      // because the spread operator (...) is not available, use apply and concat the array
+      // Insert the new list of blocks in the middle of the list.
+      // We use splice to insert at index i, and remove a single element
+      // (the placeholder string). Because the spread operator (...) is not available,
+      // use apply and concat the array.
       xmlList.splice.apply(xmlList, [i, 1].concat(newList));
       xml = xmlList[i];
     }

--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -441,25 +441,25 @@ Blockly.Flyout.prototype.show = function(xmlList) {
   this.hide();
   this.clearOldBlocks_();
 
-  // Handle dynamic categories, represented by a name instead of a list of XML.
-  // Look up the correct category generation function and call that to get a
-  // valid XML list.
-  if (typeof xmlList == 'string') {
-    var fnToApply = this.workspace_.targetWorkspace.getToolboxCategoryCallback(
-        xmlList);
-    goog.asserts.assert(goog.isFunction(fnToApply),
-        'Couldn\'t find a callback function when opening a toolbox category.');
-    xmlList = fnToApply(this.workspace_.targetWorkspace);
-    goog.asserts.assert(goog.isArray(xmlList),
-        'The result of a toolbox category callback must be an array.');
-  }
-
   this.setVisible(true);
   // Create the blocks to be shown in this flyout.
   var contents = [];
   var gaps = [];
   this.permanentlyDisabled_.length = 0;
   for (var i = 0, xml; xml = xmlList[i]; i++) {
+    // Handle the dynamic category for variables, represented by a name instead of a list of XML.
+    // Look up the correct category generation function and call that to get a
+    // valid XML list.
+    if (typeof xmlList[i] === 'string') {
+      var fnToApply = this.workspace_.targetWorkspace.getToolboxCategoryCallback(
+          xmlList[i]);
+      var newList = fnToApply(this.workspace_.targetWorkspace);
+      // insert the new list of variable blocks in the middle of the list
+      // we use splice to insert at index i, and remove a single element (the placeholder string)
+      // because the spread operator (...) is not available, use apply and concat the array
+      xmlList.splice.apply(xmlList, [i, 1].concat(newList));
+      xml = xmlList[i];
+    }
     if (xml.tagName) {
       var tagName = xml.tagName.toUpperCase();
       var default_gap = this.horizontalLayout_ ? this.GAP_X : this.GAP_Y;

--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -522,15 +522,23 @@ Blockly.Flyout.prototype.show = function(xmlList) {
   this.reflowWrapper_ = this.reflow.bind(this);
   this.workspace_.addChangeListener(this.reflowWrapper_);
 
-  // make a map of scrollbar positions to category names
-  // so that scrolling the flyout can cause a category to be selected
+  this.recordCategoryScrollPositions_();
+};
+
+/**
+ * Store an array of with category names and scrollbar positions.
+ * This is used when scrolling the flyout to cause a category to be selected.
+ * @private
+ */
+Blockly.Flyout.prototype.recordCategoryScrollPositions_ = function() {
   this.categoryScrollPositions = [];
   for (var i=0; i<this.buttons_.length; i++) {
-    var category = this.buttons_[i];
-    if (category.isLabel_) {
+    if (this.buttons_[i].isCategoryLabel_) {
+      var categoryLabel = this.buttons_[i];
       this.categoryScrollPositions.push({
-        categoryName:category.text_,
-        position:this.horizontalLayout_ ? category.position_.x : category.position_.y
+        categoryName: categoryLabel.text_,
+        position: this.horizontalLayout_ ?
+          categoryLabel.position_.x : categoryLabel.position_.y
       });
     }
   }

--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -529,7 +529,7 @@ Blockly.Flyout.prototype.show = function(xmlList) {
     if (category.isLabel_) {
       this.categoryScrollPositions.push({
         categoryName:category.text_,
-        position:category.position_.y
+        position:this.horizontalLayout_ ? category.position_.x : category.position_.y
       });
     }
   }

--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -229,6 +229,14 @@ Blockly.Flyout.prototype.verticalOffset_ = 0;
 Blockly.Flyout.prototype.dragAngleRange_ = 70;
 
 /**
+ * The fraction of the distance to the scroll target to move the flyout on
+ * each animation frame, when auto-scrolling. Values closer to 1.0 will make
+ * the scroll animation complete faster. Use 1.0 for no animation.
+ * @type {number}
+ */
+Blockly.Flyout.prototype.scrollAnimationFraction = 0.3;
+
+/**
  * Creates the flyout's DOM.  Only needs to be called once. The flyout can
  * either exist as its own svg element or be a g element nested inside a
  * separate svg element.
@@ -560,7 +568,7 @@ Blockly.Flyout.prototype.stepScrollAnimation = function() {
     this.scrollbar_.set(this.scrollTarget);
     return;
   }
-  this.scrollbar_.set(scrollPos + diff * 0.3);
+  this.scrollbar_.set(scrollPos + diff * this.scrollAnimationFraction);
 
   // Polyfilled by goog.dom.animationFrame.polyfill
   requestAnimationFrame(this.stepScrollAnimation.bind(this));

--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -118,6 +118,14 @@ Blockly.Flyout = function(workspaceOptions) {
    * @private
    */
   this.parentToolbox_ = null;
+
+  /**
+   * The target position for the flyout scroll animation in pixels.
+   * Is a number while animating, null otherwise.
+   * @type {?number}
+   * @package
+   */
+  this.scrollTarget = null;
 };
 
 /**
@@ -458,7 +466,7 @@ Blockly.Flyout.prototype.show = function(xmlList) {
     // Handle dynamic categories, represented by a name instead of a list of XML.
     // Look up the correct category generation function and call that to get a
     // valid XML list.
-    if (typeof xmlList[i] === 'string') {
+    if (typeof xml === 'string') {
       var fnToApply = this.workspace_.targetWorkspace.getToolboxCategoryCallback(
           xmlList[i]);
       var newList = fnToApply(this.workspace_.targetWorkspace);
@@ -554,15 +562,15 @@ Blockly.Flyout.prototype.recordCategoryScrollPositions_ = function() {
 
 /**
  * Select a category using the scroll position.
- * @param  {number} pos The scroll position.
+ * @param {number} pos The scroll position in pixels.
  * @package
  */
 Blockly.Flyout.prototype.selectCategoryByScrollPosition = function(pos) {
-  var scaledPos = pos / this.workspace_.scale;
+  var workspacePos = pos / this.workspace_.scale;
   // Traverse the array of scroll positions in reverse, so we can select the furthest
-  // category that the scroll position is beyond
+  // category that the scroll position is beyond.
   for (var i = this.categoryScrollPositions.length - 1; i >= 0; i--) {
-    if (scaledPos > this.categoryScrollPositions[i].position) {
+    if (workspacePos > this.categoryScrollPositions[i].position) {
       this.parentToolbox_.selectCategoryByName(this.categoryScrollPositions[i].categoryName);
       return;
     }

--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -545,6 +545,27 @@ Blockly.Flyout.prototype.recordCategoryScrollPositions_ = function() {
 };
 
 /**
+ * Step the scrolling animation by scrolling a fraction of the way to
+ * a scroll target, and request the next frame if necessary.
+ */
+Blockly.Flyout.prototype.stepScrollAnimation = function() {
+  if (!this.scrollTarget) {
+    return;
+  }
+  var scrollPos = this.horizontalLayout_ ?
+    -this.workspace_.scrollX : -this.workspace_.scrollY;
+  var diff = this.scrollTarget - scrollPos;
+  if (Math.abs(diff) < 1) {
+    this.scrollbar_.set(this.scrollTarget);
+    return;
+  }
+  this.scrollbar_.set(scrollPos + diff * 0.3);
+
+  // Polyfilled by goog.dom.animationFrame.polyfill
+  requestAnimationFrame(this.stepScrollAnimation.bind(this));
+};
+
+/**
  * Delete blocks and background buttons from a previous showing of the flyout.
  * @private
  */

--- a/core/flyout_button.js
+++ b/core/flyout_button.js
@@ -166,15 +166,6 @@ Blockly.FlyoutButton.prototype.createDom = function() {
   rect.setAttribute('width', this.width);
   rect.setAttribute('height', this.height);
 
-  // Add underline to flyout labels
-  if (this.isLabel_) {
-    // var lineWidth = this.workspace_.getMetrics().contentWidth;
-    var lineWidth = 300;
-    var underline = Blockly.utils.createSvgElement('line',
-        {'x1':0, 'y1':this.height, 'x2':lineWidth, 'y2':this.height, 'stroke-width':1, 'stroke':'#ddd'},
-        this.svgGroup_);
-  }
-
   svgText.setAttribute('text-anchor', 'middle');
   svgText.setAttribute('alignment-baseline', 'central');
   svgText.setAttribute('x', this.width / 2);

--- a/core/flyout_button.js
+++ b/core/flyout_button.js
@@ -155,10 +155,10 @@ Blockly.FlyoutButton.prototype.createDom = function() {
       this.svgGroup_);
   svgText.textContent = this.text_;
 
-  this.width = svgText.getComputedTextLength() +
-      2 * Blockly.FlyoutButton.MARGIN;
+  this.width = svgText.getComputedTextLength();
 
   if (!this.isLabel_) {
+    this.width += 2 * Blockly.FlyoutButton.MARGIN;
     shadow.setAttribute('width', this.width);
     shadow.setAttribute('height', this.height);
   }

--- a/core/flyout_button.js
+++ b/core/flyout_button.js
@@ -74,6 +74,13 @@ Blockly.FlyoutButton = function(workspace, targetWorkspace, xml, isLabel) {
   this.isLabel_ = isLabel;
 
   /**
+   * Whether this button is a label at the top of a category.
+   * @type {boolean}
+   * @private
+   */
+  this.isCategoryLabel_ = xml.getAttribute('category-label') === 'true';
+
+  /**
    * Function to call when this button is clicked.
    * @type {function(!Blockly.FlyoutButton)}
    * @private

--- a/core/flyout_button.js
+++ b/core/flyout_button.js
@@ -225,6 +225,7 @@ Blockly.FlyoutButton.prototype.getTargetWorkspace = function() {
 /**
  * Get whether this button is a label at the top of a category.
  * @return {boolean} True if it is a category label.
+ * @package
  */
 Blockly.FlyoutButton.prototype.getIsCategoryLabel = function() {
   return this.isCategoryLabel_;
@@ -233,15 +234,16 @@ Blockly.FlyoutButton.prototype.getIsCategoryLabel = function() {
 /**
  * Get the text of this button.
  * @return {string} The text on the button.
+ * @package
  */
 Blockly.FlyoutButton.prototype.getText = function() {
   return this.text_;
 };
 
-
 /**
  * Get the position of this button.
  * @return {!goog.math.Coordinate} The button position.
+ * @package
  */
 Blockly.FlyoutButton.prototype.getPosition = function() {
   return this.position_;

--- a/core/flyout_button.js
+++ b/core/flyout_button.js
@@ -162,8 +162,18 @@ Blockly.FlyoutButton.prototype.createDom = function() {
     shadow.setAttribute('width', this.width);
     shadow.setAttribute('height', this.height);
   }
+
   rect.setAttribute('width', this.width);
   rect.setAttribute('height', this.height);
+
+  // Add underline to flyout labels
+  if (this.isLabel_) {
+    // var lineWidth = this.workspace_.getMetrics().contentWidth;
+    var lineWidth = 300;
+    var underline = Blockly.utils.createSvgElement('line',
+        {'x1':0, 'y1':this.height, 'x2':lineWidth, 'y2':this.height, 'stroke-width':1, 'stroke':'#ddd'},
+        this.svgGroup_);
+  }
 
   svgText.setAttribute('text-anchor', 'middle');
   svgText.setAttribute('alignment-baseline', 'central');

--- a/core/flyout_button.js
+++ b/core/flyout_button.js
@@ -223,6 +223,31 @@ Blockly.FlyoutButton.prototype.getTargetWorkspace = function() {
 };
 
 /**
+ * Get whether this button is a label at the top of a category.
+ * @return {boolean} True if it is a category label.
+ */
+Blockly.FlyoutButton.prototype.getIsCategoryLabel = function() {
+  return this.isCategoryLabel_;
+};
+
+/**
+ * Get the text of this button.
+ * @return {string} The text on the button.
+ */
+Blockly.FlyoutButton.prototype.getText = function() {
+  return this.text_;
+};
+
+
+/**
+ * Get the position of this button.
+ * @return {!goog.math.Coordinate} The button position.
+ */
+Blockly.FlyoutButton.prototype.getPosition = function() {
+  return this.position_;
+};
+
+/**
  * Dispose of this button.
  */
 Blockly.FlyoutButton.prototype.dispose = function() {

--- a/core/flyout_horizontal.js
+++ b/core/flyout_horizontal.js
@@ -246,7 +246,7 @@ Blockly.HorizontalFlyout.prototype.scrollToStart = function() {
 
 /**
  * Scroll the flyout to a position.
- * @param {Number} pos The targeted scroll position.
+ * @param {number} pos The targeted scroll position.
  */
 Blockly.HorizontalFlyout.prototype.scrollTo = function(pos) {
   this.scrollTarget = pos * this.workspace_.scale;

--- a/core/flyout_horizontal.js
+++ b/core/flyout_horizontal.js
@@ -307,22 +307,6 @@ Blockly.HorizontalFlyout.prototype.wheel_ = function(e) {
 };
 
 /**
- * Select a category using the scroll position
- * @param  {number} pos The scroll position.
- */
-Blockly.HorizontalFlyout.prototype.selectCategoryByScrollPosition = function(pos) {
-  var scaledPos = pos / this.workspace_.scale;
-  // Traverse the array of scroll positions in reverse, so we can select the lowest
-  // category that the scroll position is below
-  for (var i = this.categoryScrollPositions.length - 1; i >= 0; i--) {
-    if (scaledPos > this.categoryScrollPositions[i].position) {
-      this.parentToolbox_.selectCategoryByName(this.categoryScrollPositions[i].categoryName);
-      return;
-    }
-  }
-};
-
-/**
  * Lay out the blocks in the flyout.
  * @param {!Array.<!Object>} contents The blocks and buttons to lay out.
  * @param {!Array.<number>} gaps The visible gaps between blocks.

--- a/core/flyout_horizontal.js
+++ b/core/flyout_horizontal.js
@@ -251,8 +251,8 @@ Blockly.HorizontalFlyout.prototype.scrollToStart = function() {
 Blockly.HorizontalFlyout.prototype.scrollTo = function(pos) {
   this.scrollTarget = pos * this.workspace_.scale;
 
-  // Make sure not to set the scroll target below the lowest point we can
-  // scroll to, i.e. the content height minus the view height
+  // Make sure not to set the scroll target past the farthest point we can
+  // scroll to, i.e. the content width minus the view width
   var contentWidth = this.workspace_.getMetrics().contentWidth;
   var viewWidth = this.workspace_.getMetrics().viewWidth;
   this.scrollTarget = Math.min(this.scrollTarget, contentWidth - viewWidth);

--- a/core/flyout_horizontal.js
+++ b/core/flyout_horizontal.js
@@ -258,25 +258,7 @@ Blockly.HorizontalFlyout.prototype.scrollTo = function(pos) {
   var viewWidth = metrics.viewWidth;
   this.scrollTarget = Math.min(this.scrollTarget, contentWidth - viewWidth);
 
-  this.step();
-};
-
-/**
- * Step the scrolling animation by scrolling a fraction of the way to
- * a scroll target, and request the next frame if necessary.
- */
-Blockly.HorizontalFlyout.prototype.step = function() {
-  if (!this.scrollTarget) return;
-  var scrollXPos = -this.workspace_.scrollX;
-  var diff = this.scrollTarget - scrollXPos;
-  if (Math.abs(diff) < 1) {
-    this.scrollbar_.set(this.scrollTarget);
-    return;
-  }
-  this.scrollbar_.set(scrollXPos + diff * 0.3);
-
-  // Polyfilled by goog.dom.animationFrame.polyfill
-  requestAnimationFrame(this.step.bind(this));
+  this.stepScrollAnimation();
 };
 
 /**

--- a/core/flyout_horizontal.js
+++ b/core/flyout_horizontal.js
@@ -253,8 +253,9 @@ Blockly.HorizontalFlyout.prototype.scrollTo = function(pos) {
 
   // Make sure not to set the scroll target past the farthest point we can
   // scroll to, i.e. the content width minus the view width
-  var contentWidth = this.workspace_.getMetrics().contentWidth;
-  var viewWidth = this.workspace_.getMetrics().viewWidth;
+  var metrics = this.workspace_.getMetrics();
+  var contentWidth = metrics.contentWidth;
+  var viewWidth = metrics.viewWidth;
   this.scrollTarget = Math.min(this.scrollTarget, contentWidth - viewWidth);
 
   this.step();

--- a/core/flyout_horizontal.js
+++ b/core/flyout_horizontal.js
@@ -245,11 +245,48 @@ Blockly.HorizontalFlyout.prototype.scrollToStart = function() {
 };
 
 /**
+ * Scroll the flyout to a position.
+ * @param {Number} pos The targeted scroll position.
+ */
+Blockly.HorizontalFlyout.prototype.scrollTo = function(pos) {
+  this.scrollTarget = pos * this.workspace_.scale;
+
+  // Make sure not to set the scroll target below the lowest point we can
+  // scroll to, i.e. the content height minus the view height
+  var contentWidth = this.workspace_.getMetrics().contentWidth;
+  var viewWidth = this.workspace_.getMetrics().viewWidth;
+  this.scrollTarget = Math.min(this.scrollTarget, contentWidth - viewWidth);
+
+  this.step();
+};
+
+/**
+ * Step the scrolling animation by scrolling a fraction of the way to
+ * a scroll target, and request the next frame if necessary.
+ */
+Blockly.HorizontalFlyout.prototype.step = function() {
+  if (!this.scrollTarget) return;
+  var scrollXPos = -this.workspace_.scrollX;
+  var diff = this.scrollTarget - scrollXPos;
+  if (Math.abs(diff) < 1) {
+    this.scrollbar_.set(this.scrollTarget);
+    return;
+  }
+  this.scrollbar_.set(scrollXPos + diff * 0.3);
+
+  // Polyfilled by goog.dom.animationFrame.polyfill
+  requestAnimationFrame(this.step.bind(this));
+};
+
+/**
  * Scroll the flyout.
  * @param {!Event} e Mouse wheel scroll event.
  * @private
  */
 Blockly.HorizontalFlyout.prototype.wheel_ = function(e) {
+    // remove scrollTarget to stop auto scrolling in step()
+  this.scrollTarget = null;
+
   var delta = e.deltaX;
 
   if (delta) {

--- a/core/flyout_horizontal.js
+++ b/core/flyout_horizontal.js
@@ -33,6 +33,7 @@ goog.require('Blockly.FlyoutButton');
 goog.require('Blockly.Flyout');
 goog.require('Blockly.WorkspaceSvg');
 goog.require('goog.dom');
+goog.require('goog.dom.animationFrame.polyfill');
 goog.require('goog.events');
 goog.require('goog.math.Rect');
 goog.require('goog.userAgent');
@@ -247,6 +248,7 @@ Blockly.HorizontalFlyout.prototype.scrollToStart = function() {
 /**
  * Scroll the flyout to a position.
  * @param {number} pos The targeted scroll position.
+ * @package
  */
 Blockly.HorizontalFlyout.prototype.scrollTo = function(pos) {
   this.scrollTarget = pos * this.workspace_.scale;

--- a/core/flyout_horizontal.js
+++ b/core/flyout_horizontal.js
@@ -289,6 +289,12 @@ Blockly.HorizontalFlyout.prototype.wheel_ = function(e) {
 
   var delta = e.deltaX;
 
+  // If we're scrolling more vertically than horizontally,
+  // use the vertical scroll delta instead
+  if (Math.abs(e.deltaY) > Math.abs(delta)) {
+    delta = e.deltaY;
+  }
+
   if (delta) {
     // Firefox's mouse wheel deltas are a tenth that of Chrome/Safari.
     // DeltaMode is 1 for a mouse wheel, but not for a trackpad scroll event

--- a/core/flyout_horizontal.js
+++ b/core/flyout_horizontal.js
@@ -267,7 +267,7 @@ Blockly.HorizontalFlyout.prototype.scrollTo = function(pos) {
  * @private
  */
 Blockly.HorizontalFlyout.prototype.wheel_ = function(e) {
-  // remove scrollTarget to stop auto scrolling in step()
+  // remove scrollTarget to stop auto scrolling in stepScrollAnimation
   this.scrollTarget = null;
 
   var delta = e.deltaX;

--- a/core/flyout_horizontal.js
+++ b/core/flyout_horizontal.js
@@ -328,7 +328,7 @@ Blockly.HorizontalFlyout.prototype.selectCategoryByScrollPosition = function(pos
   var scaledPos = pos / this.workspace_.scale;
   // Traverse the array of scroll positions in reverse, so we can select the lowest
   // category that the scroll position is below
-  for (var i=this.categoryScrollPositions.length-1; i>=0; i--) {
+  for (var i = this.categoryScrollPositions.length - 1; i >= 0; i--) {
     if (scaledPos > this.categoryScrollPositions[i].position) {
       this.parentToolbox_.selectCategoryByName(this.categoryScrollPositions[i].categoryName);
       return;

--- a/core/flyout_horizontal.js
+++ b/core/flyout_horizontal.js
@@ -303,12 +303,30 @@ Blockly.HorizontalFlyout.prototype.wheel_ = function(e) {
     // When the flyout moves from a wheel event, hide WidgetDiv and DropDownDiv.
     Blockly.WidgetDiv.hide(true);
     Blockly.DropDownDiv.hideWithoutAnimation();
+
+    this.selectCategoryByScrollPosition(pos);
   }
 
   // Don't scroll the page.
   e.preventDefault();
   // Don't propagate mousewheel event (zooming).
   e.stopPropagation();
+};
+
+/**
+ * Select a category using the scroll position
+ * @param  {number} pos The scroll position.
+ */
+Blockly.HorizontalFlyout.prototype.selectCategoryByScrollPosition = function(pos) {
+  var scaledPos = pos / this.workspace_.scale;
+  // Traverse the array of scroll positions in reverse, so we can select the lowest
+  // category that the scroll position is below
+  for (var i=this.categoryScrollPositions.length-1; i>=0; i--) {
+    if (scaledPos > this.categoryScrollPositions[i].position) {
+      this.parentToolbox_.selectCategoryByName(this.categoryScrollPositions[i].categoryName);
+      return;
+    }
+  }
 };
 
 /**

--- a/core/flyout_horizontal.js
+++ b/core/flyout_horizontal.js
@@ -290,8 +290,9 @@ Blockly.HorizontalFlyout.prototype.wheel_ = function(e) {
   var delta = e.deltaX;
 
   if (delta) {
-    if (goog.userAgent.GECKO) {
-      // Firefox's deltas are a tenth that of Chrome/Safari.
+    // Firefox's mouse wheel deltas are a tenth that of Chrome/Safari.
+    // DeltaMode is 1 for a mouse wheel, but not for a trackpad scroll event
+    if (goog.userAgent.GECKO && (e.deltaMode === 1)) {
       delta *= 10;
     }
     var metrics = this.getMetrics_();

--- a/core/flyout_horizontal.js
+++ b/core/flyout_horizontal.js
@@ -272,8 +272,11 @@ Blockly.HorizontalFlyout.prototype.wheel_ = function(e) {
 
   var delta = e.deltaX;
 
-  // If we're scrolling more vertically than horizontally,
-  // use the vertical scroll delta instead
+  // If we're scrolling more vertically than horizontally, use the vertical
+  // scroll delta instead. This allows people using a mouse wheel (which can
+  // only scroll vertically) to scroll the horizontal flyout. It also allows
+  // trackpad users to scroll it by scrolling either horizontally or
+  // vertically.
   if (Math.abs(e.deltaY) > Math.abs(delta)) {
     delta = e.deltaY;
   }

--- a/core/flyout_horizontal.js
+++ b/core/flyout_horizontal.js
@@ -284,7 +284,7 @@ Blockly.HorizontalFlyout.prototype.step = function() {
  * @private
  */
 Blockly.HorizontalFlyout.prototype.wheel_ = function(e) {
-    // remove scrollTarget to stop auto scrolling in step()
+  // remove scrollTarget to stop auto scrolling in step()
   this.scrollTarget = null;
 
   var delta = e.deltaX;

--- a/core/flyout_vertical.js
+++ b/core/flyout_vertical.js
@@ -410,7 +410,7 @@ Blockly.VerticalFlyout.prototype.selectCategoryByScrollPosition = function(pos) 
   var scaledPos = pos / this.workspace_.scale;
   // Traverse the array of scroll positions in reverse, so we can select the lowest
   // category that the scroll position is below
-  for (var i=this.categoryScrollPositions.length-1; i>=0; i--) {
+  for (var i = this.categoryScrollPositions.length - 1; i >= 0; i--) {
     if (scaledPos > this.categoryScrollPositions[i].position) {
       this.parentToolbox_.selectCategoryByName(this.categoryScrollPositions[i].categoryName);
       return;

--- a/core/flyout_vertical.js
+++ b/core/flyout_vertical.js
@@ -355,7 +355,7 @@ Blockly.VerticalFlyout.prototype.scrollTo = function(pos) {
  * @private
  */
 Blockly.VerticalFlyout.prototype.wheel_ = function(e) {
-  // remove scrollTarget to stop auto scrolling in step()
+  // remove scrollTarget to stop auto scrolling in stepScrollAnimation
   this.scrollTarget = null;
 
   var delta = e.deltaY;

--- a/core/flyout_vertical.js
+++ b/core/flyout_vertical.js
@@ -37,6 +37,7 @@ goog.require('goog.dom');
 goog.require('goog.events');
 goog.require('goog.math.Rect');
 goog.require('goog.userAgent');
+goog.require('goog.dom.animationFrame.polyfill');
 
 
 /**
@@ -332,11 +333,41 @@ Blockly.VerticalFlyout.prototype.scrollToStart = function() {
 };
 
 /**
+ * Scroll the flyout to a position.
+ * @param {Number} pos The targeted scroll position.
+ */
+Blockly.VerticalFlyout.prototype.scrollTo = function(pos) {
+  this.scrollTarget = pos * this.workspace_.scale;
+  this.step();
+};
+
+/**
+ * Step the scrolling animation by scrolling a fraction of the way to
+ * a scroll target, and request the next frame if necessary.
+ */
+Blockly.VerticalFlyout.prototype.step = function() {
+  if (!this.scrollTarget) return;
+  var scrollYPos = -this.workspace_.scrollY;
+  var diff = this.scrollTarget - scrollYPos;
+  if (Math.abs(diff) < 1) {
+    this.scrollbar_.set(this.scrollTarget);
+    return;
+  }
+  this.scrollbar_.set(scrollYPos + diff * 0.3);
+
+  // Polyfilled by goog.dom.animationFrame.polyfill
+  requestAnimationFrame(this.step.bind(this));
+};
+
+/**
  * Scroll the flyout.
  * @param {!Event} e Mouse wheel scroll event.
  * @private
  */
 Blockly.VerticalFlyout.prototype.wheel_ = function(e) {
+  // remove scrollTarget to stop auto scrolling in step()
+  this.scrollTarget = null;
+
   var delta = e.deltaY;
 
   if (delta) {

--- a/core/flyout_vertical.js
+++ b/core/flyout_vertical.js
@@ -338,6 +338,13 @@ Blockly.VerticalFlyout.prototype.scrollToStart = function() {
  */
 Blockly.VerticalFlyout.prototype.scrollTo = function(pos) {
   this.scrollTarget = pos * this.workspace_.scale;
+
+  // Make sure not to set the scroll target below the lowest point we can
+  // scroll to, i.e. the content height minus the view height
+  var contentHeight = this.workspace_.getMetrics().contentHeight;
+  var viewHeight = this.workspace_.getMetrics().viewHeight;
+  this.scrollTarget = Math.min(this.scrollTarget, contentHeight - viewHeight);
+
   this.step();
 };
 

--- a/core/flyout_vertical.js
+++ b/core/flyout_vertical.js
@@ -378,8 +378,9 @@ Blockly.VerticalFlyout.prototype.wheel_ = function(e) {
   var delta = e.deltaY;
 
   if (delta) {
-    if (goog.userAgent.GECKO) {
-      // Firefox's deltas are a tenth that of Chrome/Safari.
+    // Firefox's mouse wheel deltas are a tenth that of Chrome/Safari.
+    // DeltaMode is 1 for a mouse wheel, but not for a trackpad scroll event
+    if (goog.userAgent.GECKO && (e.deltaMode === 1)) {
       delta *= 10;
     }
     var metrics = this.getMetrics_();

--- a/core/flyout_vertical.js
+++ b/core/flyout_vertical.js
@@ -341,8 +341,9 @@ Blockly.VerticalFlyout.prototype.scrollTo = function(pos) {
 
   // Make sure not to set the scroll target below the lowest point we can
   // scroll to, i.e. the content height minus the view height
-  var contentHeight = this.workspace_.getMetrics().contentHeight;
-  var viewHeight = this.workspace_.getMetrics().viewHeight;
+  var metrics = this.workspace_.getMetrics();
+  var contentHeight = metrics.contentHeight;
+  var viewHeight = metrics.viewHeight;
   this.scrollTarget = Math.min(this.scrollTarget, contentHeight - viewHeight);
 
   this.step();

--- a/core/flyout_vertical.js
+++ b/core/flyout_vertical.js
@@ -346,25 +346,7 @@ Blockly.VerticalFlyout.prototype.scrollTo = function(pos) {
   var viewHeight = metrics.viewHeight;
   this.scrollTarget = Math.min(this.scrollTarget, contentHeight - viewHeight);
 
-  this.step();
-};
-
-/**
- * Step the scrolling animation by scrolling a fraction of the way to
- * a scroll target, and request the next frame if necessary.
- */
-Blockly.VerticalFlyout.prototype.step = function() {
-  if (!this.scrollTarget) return;
-  var scrollYPos = -this.workspace_.scrollY;
-  var diff = this.scrollTarget - scrollYPos;
-  if (Math.abs(diff) < 1) {
-    this.scrollbar_.set(this.scrollTarget);
-    return;
-  }
-  this.scrollbar_.set(scrollYPos + diff * 0.3);
-
-  // Polyfilled by goog.dom.animationFrame.polyfill
-  requestAnimationFrame(this.step.bind(this));
+  this.stepScrollAnimation();
 };
 
 /**

--- a/core/flyout_vertical.js
+++ b/core/flyout_vertical.js
@@ -386,22 +386,6 @@ Blockly.VerticalFlyout.prototype.wheel_ = function(e) {
 };
 
 /**
- * Select a category using the scroll position
- * @param  {number} pos The scroll position.
- */
-Blockly.VerticalFlyout.prototype.selectCategoryByScrollPosition = function(pos) {
-  var scaledPos = pos / this.workspace_.scale;
-  // Traverse the array of scroll positions in reverse, so we can select the lowest
-  // category that the scroll position is below
-  for (var i = this.categoryScrollPositions.length - 1; i >= 0; i--) {
-    if (scaledPos > this.categoryScrollPositions[i].position) {
-      this.parentToolbox_.selectCategoryByName(this.categoryScrollPositions[i].categoryName);
-      return;
-    }
-  }
-};
-
-/**
  * Delete blocks and background buttons from a previous showing of the flyout.
  * @private
  */

--- a/core/flyout_vertical.js
+++ b/core/flyout_vertical.js
@@ -334,7 +334,7 @@ Blockly.VerticalFlyout.prototype.scrollToStart = function() {
 
 /**
  * Scroll the flyout to a position.
- * @param {Number} pos The targeted scroll position.
+ * @param {number} pos The targeted scroll position.
  */
 Blockly.VerticalFlyout.prototype.scrollTo = function(pos) {
   this.scrollTarget = pos * this.workspace_.scale;

--- a/core/flyout_vertical.js
+++ b/core/flyout_vertical.js
@@ -384,12 +384,30 @@ Blockly.VerticalFlyout.prototype.wheel_ = function(e) {
     // When the flyout moves from a wheel event, hide WidgetDiv and DropDownDiv.
     Blockly.WidgetDiv.hide(true);
     Blockly.DropDownDiv.hideWithoutAnimation();
+
+    this.selectCategoryByScrollPosition(pos);
   }
 
   // Don't scroll the page.
   e.preventDefault();
   // Don't propagate mousewheel event (zooming).
   e.stopPropagation();
+};
+
+/**
+ * Select a category using the scroll position
+ * @param  {number} pos The scroll position.
+ */
+Blockly.VerticalFlyout.prototype.selectCategoryByScrollPosition = function(pos) {
+  var scaledPos = pos / this.workspace_.scale;
+  // Traverse the array of scroll positions in reverse, so we can select the lowest
+  // category that the scroll position is below
+  for (var i=this.categoryScrollPositions.length-1; i>=0; i--) {
+    if (scaledPos > this.categoryScrollPositions[i].position) {
+      this.parentToolbox_.selectCategoryByName(this.categoryScrollPositions[i].categoryName);
+      return;
+    }
+  }
 };
 
 /**

--- a/core/flyout_vertical.js
+++ b/core/flyout_vertical.js
@@ -34,11 +34,10 @@ goog.require('Blockly.FlyoutButton');
 goog.require('Blockly.utils');
 goog.require('Blockly.WorkspaceSvg');
 goog.require('goog.dom');
+goog.require('goog.dom.animationFrame.polyfill');
 goog.require('goog.events');
 goog.require('goog.math.Rect');
 goog.require('goog.userAgent');
-goog.require('goog.dom.animationFrame.polyfill');
-
 
 /**
  * Class for a flyout.
@@ -334,7 +333,8 @@ Blockly.VerticalFlyout.prototype.scrollToStart = function() {
 
 /**
  * Scroll the flyout to a position.
- * @param {number} pos The targeted scroll position.
+ * @param {number} pos The targeted scroll position in workspace coordinates.
+ * @package
  */
 Blockly.VerticalFlyout.prototype.scrollTo = function(pos) {
   this.scrollTarget = pos * this.workspace_.scale;

--- a/core/toolbox.js
+++ b/core/toolbox.js
@@ -193,7 +193,8 @@ Blockly.Toolbox.prototype.showAll = function() {
 
     // create a label node to go at the top of the category
     var parser = new DOMParser();
-    var labelString = `<label text="${category.name_}" web-class="categoryLabel"></label>`;
+    var labelString = '<label text="' + category.name_ +
+      '" web-class="categoryLabel"></label>';
     var labelXML = parser.parseFromString(labelString, 'text/xml');
     allContents.push(labelXML.children[0]);
 

--- a/core/toolbox.js
+++ b/core/toolbox.js
@@ -179,7 +179,7 @@ Blockly.Toolbox.prototype.createFlyout_ = function() {
  */
 Blockly.Toolbox.prototype.populate_ = function(newTree) {
   this.categoryMenu_.populate(newTree);
-  this.showAll();
+  this.showAll_();
   this.setSelectedItem(this.categoryMenu_.categories_[0]);
 };
 
@@ -187,7 +187,7 @@ Blockly.Toolbox.prototype.populate_ = function(newTree) {
  * Show all blocks for all categories in the flyout
  * @private
  */
-Blockly.Toolbox.prototype.showAll = function() {
+Blockly.Toolbox.prototype.showAll_ = function() {
   var allContents = [];
   for (var i = 0; i < this.categoryMenu_.categories_.length; i++) {
     var category = this.categoryMenu_.categories_[i];
@@ -322,7 +322,7 @@ Blockly.Toolbox.prototype.getClientRect = function() {
  * procedures.
  */
 Blockly.Toolbox.prototype.refreshSelection = function() {
-  this.showAll();
+  this.showAll_();
 };
 
 /**

--- a/core/toolbox.js
+++ b/core/toolbox.js
@@ -188,7 +188,7 @@ Blockly.Toolbox.prototype.populate_ = function(newTree) {
  */
 Blockly.Toolbox.prototype.showAll = function() {
   var allContents = [];
-  for (var i=0; i<this.categoryMenu_.categories_.length; i++) {
+  for (var i = 0; i < this.categoryMenu_.categories_.length; i++) {
     var category = this.categoryMenu_.categories_[i];
 
     // create a label node to go at the top of the category
@@ -343,7 +343,7 @@ Blockly.Toolbox.prototype.setSelectedItem = function(item) {
     // Scroll flyout to the top of the selected category
     var categoryName = item.name_;
     var scrollPositions = this.flyout_.categoryScrollPositions;
-    for (var i=0; i<scrollPositions.length; i++) {
+    for (var i = 0; i < scrollPositions.length; i++) {
       if (categoryName === scrollPositions[i].categoryName) {
         this.flyout_.scrollTo(scrollPositions[i].position);
         return;
@@ -357,7 +357,7 @@ Blockly.Toolbox.prototype.setSelectedItem = function(item) {
  * @param {string} name The name of the category to select.
  */
 Blockly.Toolbox.prototype.selectCategoryByName = function(name) {
-  for (var i=0; i<this.categoryMenu_.categories_.length; i++) {
+  for (var i = 0; i < this.categoryMenu_.categories_.length; i++) {
     var category = this.categoryMenu_.categories_[i];
     if (name === category.name_) {
       this.selectedItem_.setSelected(false);

--- a/core/toolbox.js
+++ b/core/toolbox.js
@@ -179,7 +179,20 @@ Blockly.Toolbox.prototype.createFlyout_ = function() {
  */
 Blockly.Toolbox.prototype.populate_ = function(newTree) {
   this.categoryMenu_.populate(newTree);
+  this.showAll();
   this.setSelectedItem(this.categoryMenu_.categories_[0]);
+};
+
+/**
+ * Show all blocks for all categories in the flyout
+ */
+Blockly.Toolbox.prototype.showAll = function() {
+  var allContents = [];
+  for (var i=0; i<this.categoryMenu_.categories_.length; i++) {
+    var category = this.categoryMenu_.categories_[i];
+    allContents = allContents.concat(category.getContents());
+  }
+  this.flyout_.show(allContents);
 };
 
 /**
@@ -296,10 +309,7 @@ Blockly.Toolbox.prototype.getClientRect = function() {
  * procedures.
  */
 Blockly.Toolbox.prototype.refreshSelection = function() {
-  var selectedItem = this.getSelectedItem();
-  if (selectedItem && selectedItem.getContents()) {
-    this.flyout_.show(selectedItem.getContents());
-  }
+  this.showAll();
 };
 
 /**

--- a/core/toolbox.js
+++ b/core/toolbox.js
@@ -359,6 +359,7 @@ Blockly.Toolbox.prototype.setSelectedItem = function(item) {
 /**
  * Select a category by name.
  * @param {string} name The name of the category to select.
+ * @package
  */
 Blockly.Toolbox.prototype.selectCategoryByName = function(name) {
   for (var i = 0; i < this.categoryMenu_.categories_.length; i++) {

--- a/core/toolbox.js
+++ b/core/toolbox.js
@@ -293,7 +293,7 @@ Blockly.Toolbox.prototype.getClientRect = function() {
   var x = toolboxRect.left;
   var y = toolboxRect.top;
   var width = this.getWidth();
-  var height = toolboxRect.height;
+  var height = toolboxRect.height + this.flyout_.height_;
 
   // Assumes that the toolbox is on the SVG edge.  If this changes
   // (e.g. toolboxes in mutators) then this code will need to be more complex.
@@ -306,7 +306,7 @@ Blockly.Toolbox.prototype.getClientRect = function() {
     return new goog.math.Rect(-BIG_NUM, -BIG_NUM, 2 * BIG_NUM,
         BIG_NUM + y + height);
   } else {  // Bottom
-    return new goog.math.Rect(0, y, 2 * BIG_NUM, BIG_NUM + width);
+    return new goog.math.Rect(0, y - height, 2 * BIG_NUM, BIG_NUM);
   }
 };
 

--- a/core/toolbox.js
+++ b/core/toolbox.js
@@ -342,13 +342,10 @@ Blockly.Toolbox.prototype.setSelectedItem = function(item) {
     this.selectedItem_.setSelected(true);
     // Scroll flyout to the top of the selected category
     var categoryName = item.name_;
-    for (var i=0; i<this.flyout_.buttons_.length; i++) {
-      if (this.flyout_.buttons_[i].text_ === categoryName) {
-        if (this.horizontalLayout_) {
-          this.flyout_.scrollTo(this.flyout_.buttons_[i].position_.x);
-        } else {
-          this.flyout_.scrollTo(this.flyout_.buttons_[i].position_.y);
-        }
+    var scrollPositions = this.flyout_.categoryScrollPositions;
+    for (var i=0; i<scrollPositions.length; i++) {
+      if (categoryName === scrollPositions[i].categoryName) {
+        this.flyout_.scrollTo(scrollPositions[i].position);
         return;
       }
     }

--- a/core/toolbox.js
+++ b/core/toolbox.js
@@ -192,8 +192,10 @@ Blockly.Toolbox.prototype.showAll = function() {
     var category = this.categoryMenu_.categories_[i];
 
     // create a label node to go at the top of the category
-    var labelString = '<xml><label text="' + category.name_ +
-      '" web-class="categoryLabel"></label></xml>';
+    var labelString = '<xml><label text="' + category.name_ + '"' +
+      ' category-label="true"' +
+      ' web-class="categoryLabel">' +
+      '</label></xml>';
     var labelXML = Blockly.Xml.textToDom(labelString);
     allContents.push(labelXML.firstChild);
 

--- a/core/toolbox.js
+++ b/core/toolbox.js
@@ -185,6 +185,7 @@ Blockly.Toolbox.prototype.populate_ = function(newTree) {
 
 /**
  * Show all blocks for all categories in the flyout
+ * @private
  */
 Blockly.Toolbox.prototype.showAll = function() {
   var allContents = [];

--- a/core/toolbox.js
+++ b/core/toolbox.js
@@ -351,6 +351,7 @@ Blockly.Toolbox.prototype.setSelectedItem = function(item) {
     var scrollPositions = this.flyout_.categoryScrollPositions;
     for (var i = 0; i < scrollPositions.length; i++) {
       if (categoryName === scrollPositions[i].categoryName) {
+        this.flyout_.setVisible(true);
         this.flyout_.scrollTo(scrollPositions[i].position);
         return;
       }

--- a/core/toolbox.js
+++ b/core/toolbox.js
@@ -325,18 +325,22 @@ Blockly.Toolbox.prototype.getSelectedItem = function() {
  */
 Blockly.Toolbox.prototype.setSelectedItem = function(item) {
   if (this.selectedItem_) {
-    // Don't do anything if they selected the already-open category.
-    if (this.selectedItem_ == item) {
-      return;
-    }
     // They selected a different category but one was already open.  Close it.
     this.selectedItem_.setSelected(false);
   }
   this.selectedItem_ = item;
   if (this.selectedItem_ != null) {
     this.selectedItem_.setSelected(true);
-    this.flyout_.show(item.getContents());
-    this.flyout_.scrollToStart();
+    // Scroll flyout to the top of the selected category
+    var categoryName = item.name_;
+    for (var i=0; i<this.flyout_.buttons_.length; i++) {
+      if (this.flyout_.buttons_[i].text_ === categoryName) {
+        this.flyout_.scrollTo(this.flyout_.buttons_[i].position_.y);
+        return;
+      }
+    }
+  }
+};
   }
 };
 

--- a/core/toolbox.js
+++ b/core/toolbox.js
@@ -296,6 +296,9 @@ Blockly.Toolbox.prototype.getClientRect = function() {
   var x = toolboxRect.left;
   var y = toolboxRect.top;
   var width = this.getWidth();
+  // The height here is the combined height of the category menu and flyout.
+  // It is used get a correct delete area when the toolbox is in horizontal
+  // mode (on the top or bottom).
   var height = toolboxRect.height + this.flyout_.height_;
 
   // Assumes that the toolbox is on the SVG edge.  If this changes

--- a/core/toolbox.js
+++ b/core/toolbox.js
@@ -312,7 +312,7 @@ Blockly.Toolbox.prototype.getClientRect = function() {
     return new goog.math.Rect(-BIG_NUM, -BIG_NUM, 2 * BIG_NUM,
         BIG_NUM + y + height);
   } else {  // Bottom
-    return new goog.math.Rect(0, y - height, 2 * BIG_NUM, BIG_NUM);
+    return new goog.math.Rect(0, y, 2 * BIG_NUM, BIG_NUM);
   }
 };
 

--- a/core/toolbox.js
+++ b/core/toolbox.js
@@ -287,6 +287,11 @@ Blockly.Toolbox.prototype.getClientRect = function() {
     return null;
   }
 
+  // If not an auto closing flyout, always use the (larger) flyout client rect
+  if (!this.flyout_.autoClose) {
+    return this.flyout_.getClientRect();
+  }
+
   // BIG_NUM is offscreen padding so that blocks dragged beyond the toolbox
   // area are still deleted.  Must be smaller than Infinity, but larger than
   // the largest screen size.
@@ -295,11 +300,8 @@ Blockly.Toolbox.prototype.getClientRect = function() {
 
   var x = toolboxRect.left;
   var y = toolboxRect.top;
-  var width = this.getWidth();
-  // The height here is the combined height of the category menu and flyout.
-  // It is used get a correct delete area when the toolbox is in horizontal
-  // mode (on the top or bottom).
-  var height = toolboxRect.height + this.flyout_.height_;
+  var width = toolboxRect.width;
+  var height = toolboxRect.height;
 
   // Assumes that the toolbox is on the SVG edge.  If this changes
   // (e.g. toolboxes in mutators) then this code will need to be more complex.

--- a/core/toolbox.js
+++ b/core/toolbox.js
@@ -341,6 +341,19 @@ Blockly.Toolbox.prototype.setSelectedItem = function(item) {
     }
   }
 };
+
+/**
+ * Select a category by name.
+ * @param {string} name The name of the category to select.
+ */
+Blockly.Toolbox.prototype.selectCategoryByName = function(name) {
+  for (var i=0; i<this.categoryMenu_.categories_.length; i++) {
+    var category = this.categoryMenu_.categories_[i];
+    if (name === category.name_) {
+      this.selectedItem_.setSelected(false);
+      this.selectedItem_ = category;
+      this.selectedItem_.setSelected(true);
+    }
   }
 };
 

--- a/core/toolbox.js
+++ b/core/toolbox.js
@@ -192,11 +192,10 @@ Blockly.Toolbox.prototype.showAll = function() {
     var category = this.categoryMenu_.categories_[i];
 
     // create a label node to go at the top of the category
-    var parser = new DOMParser();
-    var labelString = '<label text="' + category.name_ +
-      '" web-class="categoryLabel"></label>';
-    var labelXML = parser.parseFromString(labelString, 'text/xml');
-    allContents.push(labelXML.children[0]);
+    var labelString = '<xml><label text="' + category.name_ +
+      '" web-class="categoryLabel"></label></xml>';
+    var labelXML = Blockly.Xml.textToDom(labelString);
+    allContents.push(labelXML.firstChild);
 
     allContents = allContents.concat(category.getContents());
   }

--- a/core/toolbox.js
+++ b/core/toolbox.js
@@ -190,6 +190,13 @@ Blockly.Toolbox.prototype.showAll = function() {
   var allContents = [];
   for (var i=0; i<this.categoryMenu_.categories_.length; i++) {
     var category = this.categoryMenu_.categories_[i];
+
+    // create a label node to go at the top of the category
+    var parser = new DOMParser();
+    var labelString = `<label text="${category.name_}" web-class="categoryLabel"></label>`;
+    var labelXML = parser.parseFromString(labelString, 'text/xml');
+    allContents.push(labelXML.children[0]);
+
     allContents = allContents.concat(category.getContents());
   }
   this.flyout_.show(allContents);

--- a/core/toolbox.js
+++ b/core/toolbox.js
@@ -342,7 +342,11 @@ Blockly.Toolbox.prototype.setSelectedItem = function(item) {
     var categoryName = item.name_;
     for (var i=0; i<this.flyout_.buttons_.length; i++) {
       if (this.flyout_.buttons_[i].text_ === categoryName) {
-        this.flyout_.scrollTo(this.flyout_.buttons_[i].position_.y);
+        if (this.horizontalLayout_) {
+          this.flyout_.scrollTo(this.flyout_.buttons_[i].position_.x);
+        } else {
+          this.flyout_.scrollTo(this.flyout_.buttons_[i].position_.y);
+        }
         return;
       }
     }


### PR DESCRIPTION
### Resolves

Resolves part of https://github.com/LLK/scratch-blocks/issues/1040

### Proposed Changes

Concatenate all the blocks into a single flyout, with category labels, so that you can scroll continuously through them. When you select a category in the category menu, auto-scroll to that category.