### PR TITLE
Slider color picker

### DIFF
--- a/blocks_common/colour.js
+++ b/blocks_common/colour.js
@@ -49,7 +49,7 @@ Blockly.Blocks['colour_picker'] = {
       "message0": "%1",
       "args0": [
         {
-          "type": "field_colour",
+          "type": "field_colour_slider",
           "name": "COLOUR",
           "colour": randomColour()
         }

--- a/core/block.js
+++ b/core/block.js
@@ -1360,6 +1360,9 @@ Blockly.Block.prototype.interpolate_ = function(message, args, lastDummyAlign) {
             case 'field_colour':
               field = new Blockly.FieldColour(element['colour']);
               break;
+            case 'field_colour_slider':
+              field = new Blockly.FieldColourSlider(element['colour']);
+              break;
             case 'field_variable':
               field = Blockly.Block.newFieldVariableFromJson_(element);
               break;

--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -468,7 +468,8 @@ Blockly.BlockSvg.prototype.updateColour = function() {
     // Special case: if we contain a colour field, set to a special stroke colour.
     if (this.inputList[0] &&
         this.inputList[0].fieldRow[0] &&
-        this.inputList[0].fieldRow[0] instanceof Blockly.FieldColour) {
+        (this.inputList[0].fieldRow[0] instanceof Blockly.FieldColour ||
+        this.inputList[0].fieldRow[0] instanceof Blockly.FieldColourSlider)) {
       strokeColour = Blockly.Colours.colourPickerStroke;
     }
   }

--- a/core/blockly.js
+++ b/core/blockly.js
@@ -36,6 +36,7 @@ goog.require('Blockly.Events');
 goog.require('Blockly.FieldAngle');
 goog.require('Blockly.FieldCheckbox');
 goog.require('Blockly.FieldColour');
+goog.require('Blockly.FieldColourSlider');
 // Date picker commented out since it increases footprint by 60%.
 // Add it only if you need it.
 //goog.require('Blockly.FieldDate');

--- a/core/css.js
+++ b/core/css.js
@@ -823,18 +823,18 @@ Blockly.Css.CONTENT = [
     'cursor: pointer;',
   '}',
 
-  '.scratchColorPickerLabel {',
+  '.scratchColourPickerLabel {',
     'font-family: "Helvetica Neue", Helvetica, sans-serif;',
     'font-size: 0.65rem;',
     'color: $colour_toolboxText;',
     'margin: 8px;',
   '}',
 
-  '.scratchColorPickerLabelText {',
+  '.scratchColourPickerLabelText {',
     'font-weight: bold;',
   '}',
 
-  '.scratchColorPickerReadout {',
+  '.scratchColourPickerReadout {',
     'margin-left: 10px;',
   '}',
 

--- a/core/css.js
+++ b/core/css.js
@@ -790,54 +790,52 @@ Blockly.Css.CONTENT = [
     'color: #fff;',
   '}',
 
-  /* Copied from: goog/css/colorpicker-simplegrid.css */
-  /*
-   * Copyright 2007 The Closure Library Authors. All Rights Reserved.
-   *
-   * Use of this source code is governed by the Apache License, Version 2.0.
-   * See the COPYING file for details.
-   */
-
-  /* Author: pupius@google.com (Daniel Pupius) */
-
-  /*
-    Styles to make the colorpicker look like the old gmail color picker
-    NOTE: without CSS scoping this will override styles defined in palette.css
-  */
-  '.blocklyWidgetDiv .goog-palette {',
-    'outline: none;',
-    'cursor: default;',
-  '}',
-
-  '.blocklyWidgetDiv .goog-palette-table {',
-    'border-collapse: collapse;',
-  '}',
-
-  '.blocklyWidgetDiv .goog-palette-cell {',
-    'height: 13px;',
-    'width: 15px;',
-    'margin: 0;',
-    'border: 0;',
-    'text-align: center;',
-    'vertical-align: middle;',
-    'font-size: 1px;',
-  '}',
-
-  '.blocklyWidgetDiv .goog-palette-colorswatch {',
+  '.blocklyDropDownDiv .goog-slider-horizontal {',
+    'margin: 8px;',
+    'height: 22px;',
+    'width: 150px;',
     'position: relative;',
-    'height: 13px;',
-    'width: 15px;',
+    'outline: none;',
+    'border-radius: 11px;',
+    'margin-bottom: 20px;',
   '}',
 
-  '.blocklyWidgetDiv .goog-palette-cell-hover .goog-palette-colorswatch {',
-    'border: 1px solid #FFF;',
-    'box-sizing: border-box;',
+  '.blocklyDropDownDiv .goog-slider-horizontal .goog-slider-thumb {',
+    'width: 26px;',
+    'height: 26px;',
+    'margin-top: -1px;',
+    'position: absolute;',
+    'background-color: white;',
+    'border-radius: 100%;',
+    '-webkit-box-shadow: 0 0 0 4px rgba(0, 0, 0, 0.15);',
+    '-moz-box-shadow: 0 0 0 4px rgba(0, 0, 0, 0.15);',
+    'box-shadow: 0 0 0 4px rgba(0, 0, 0, 0.15);',
   '}',
 
-  '.blocklyWidgetDiv .goog-palette-cell-selected .goog-palette-colorswatch {',
-    'border: 1px solid #000;',
-    'box-sizing: border-box;',
-    'color: #fff;',
+  '.scratchEyedropper {',
+    'background: none;',
+    'outline: none;',
+    'border: none;',
+    'width: 100%;',
+    'text-align: center;',
+    'border-top: 1px solid #ddd;',
+    'padding-top: 5px;',
+    'cursor: pointer;',
+  '}',
+
+  '.scratchColorPickerLabel {',
+    'font-family: "Helvetica Neue", Helvetica, sans-serif;',
+    'font-size: 0.65rem;',
+    'color: $colour_toolboxText;',
+    'margin: 8px;',
+  '}',
+
+  '.scratchColorPickerLabelText {',
+    'font-weight: bold;',
+  '}',
+
+  '.scratchColorPickerReadout {',
+    'margin-left: 10px;',
   '}',
 
   /* Copied from: goog/css/menu.css */

--- a/core/field_colour.js
+++ b/core/field_colour.js
@@ -27,12 +27,10 @@
 goog.provide('Blockly.FieldColour');
 
 goog.require('Blockly.Field');
-goog.require('Blockly.DropDownDiv');
 goog.require('goog.dom');
 goog.require('goog.events');
 goog.require('goog.style');
-goog.require('goog.color');
-goog.require('goog.ui.Slider');
+goog.require('goog.ui.ColorPicker');
 
 /**
  * Class for a colour input field.
@@ -66,24 +64,25 @@ Blockly.FieldColour.prototype.colours_ = null;
 Blockly.FieldColour.prototype.columns_ = 0;
 
 /**
- * Function to be called if eyedropper can be activated.
- * If defined, an eyedropper button will be added to the color picker.
- * The button calls this function with a callback to update the field value.
- */
-Blockly.FieldColour.activateEyedropper = null;
-
-/**
- * Path to the eyedropper svg icon.
- */
-Blockly.FieldColour.EYEDROPPER_PATH = 'eyedropper.svg';
-
-/**
  * Install this field on a block.
  * @param {!Blockly.Block} block The block containing this field.
  */
 Blockly.FieldColour.prototype.init = function(block) {
   Blockly.FieldColour.superClass_.init.call(this, block);
   this.setValue(this.getValue());
+};
+
+/**
+ * Mouse cursor style when over the hotspot that initiates the editor.
+ */
+Blockly.FieldColour.prototype.CURSOR = 'default';
+
+/**
+ * Close the colour picker if this input is being deleted.
+ */
+Blockly.FieldColour.prototype.dispose = function() {
+  Blockly.WidgetDiv.hideIfOwner(this);
+  Blockly.FieldColour.superClass_.dispose.call(this);
 };
 
 /**
@@ -95,11 +94,10 @@ Blockly.FieldColour.prototype.getValue = function() {
 };
 
 /**
- * Set the colour. If opt_fromSliders is true, do not update the sliders.
+ * Set the colour.
  * @param {string} colour The new colour in '#rrggbb' format.
- * @param {boolea} opt_fromSliders Flag to prevent sliders from recursing on themselves.
  */
-Blockly.FieldColour.prototype.setValue = function(colour, opt_fromSliders) {
+Blockly.FieldColour.prototype.setValue = function(colour) {
   if (this.sourceBlock_ && Blockly.Events.isEnabled() &&
       this.colour_ != colour) {
     Blockly.Events.fire(new Blockly.Events.BlockChange(
@@ -109,84 +107,7 @@ Blockly.FieldColour.prototype.setValue = function(colour, opt_fromSliders) {
   if (this.sourceBlock_) {
     // Set the primary, secondary and tertiary colour to this value.
     // The renderer expects to be able to use the secondary color as the fill for a shadow.
-    this.sourceBlock_.setColour(colour, colour, this.sourceBlock_.getColourTertiary());
-  }
-  if (!opt_fromSliders) {
-    this.updateSliderHandles_();
-  }
-  this.updateDom_();
-};
-
-/**
- * Create the hue, saturation or value CSS gradient for the slide backgrounds.
- * @param {string} channel – Either "hue", "saturation" or "value".
- * @return {string} Array color hex color stops for the given channel
- */
-Blockly.FieldColour.prototype.createColorStops_ = function(channel) {
-  var hsv = goog.color.hexToHsv(this.getValue());
-  var stops = [];
-  for(var n = 0; n <= 360; n += 20) {
-    switch (channel) {
-      case 'hue':
-        stops.push(goog.color.hsvToHex(n, hsv[1], hsv[2]));
-        break;
-      case 'saturation':
-        stops.push(goog.color.hsvToHex(hsv[0], n / 360, hsv[2]));
-        break;
-      case 'brightness':
-        stops.push(goog.color.hsvToHex(hsv[0], hsv[1], 255 * n / 360));
-        break;
-    }
-  }
-  return stops;
-};
-
-/**
- * Set the gradient CSS properties for the given node and channel
- * @param {Node} node - The DOM node the gradient will be set on.
- * @param {string} channel – Either "hue", "saturation" or "value".
- */
-Blockly.FieldColour.prototype.setGradient_ = function(node, channel) {
-  var stops = this.createColorStops_(channel);
-  goog.style.setStyle(node, 'background',
-        '-moz-linear-gradient(left, ' + stops.join(',') + ')');
-  goog.style.setStyle(node, 'background',
-        '-webkit-linear-gradient(left, ' + stops.join(',') + ')');
-  goog.style.setStyle(node, 'background',
-        '-o-linear-gradient(left, ' + stops.join(',') + ')');
-  goog.style.setStyle(node, 'background',
-        '-ms-linear-gradient(left, ' + stops.join(',') + ')');
-  goog.style.setStyle(node, 'background',
-        'linear-gradient(left, ' + stops.join(',') + ')');
-};
-
-/**
- * Update the readouts and slider backgrounds after value has changed.
- */
-Blockly.FieldColour.prototype.updateDom_ = function() {
-  if (this.hueSlider_) {
-    // Update the slider backgrounds
-    this.setGradient_(this.hueSlider_.getElement(), 'hue');
-    this.setGradient_(this.saturationSlider_.getElement(), 'saturation');
-    this.setGradient_(this.brightnessSlider_.getElement(), 'brightness');
-
-    // Update the readouts
-    var hsv = goog.color.hexToHsv(this.getValue());
-    this.hueReadout_.innerHTML = Math.floor(100 * hsv[0] / 360).toFixed(0);
-    this.saturationReadout_.innerHTML = Math.floor(100 * hsv[1]).toFixed(0);
-    this.brightnessReadout_.innerHTML = Math.floor(100 * hsv[2] / 255).toFixed(0);
-  }
-};
-
-/**
- * Update the slider handle positions
- */
-Blockly.FieldColour.prototype.updateSliderHandles_ = function() {
-  if (this.hueSlider_) {
-    var hsv = goog.color.hexToHsv(this.getValue());
-    this.hueSlider_.animatedSetValue(hsv[0]);
-    this.saturationSlider_.animatedSetValue(hsv[1]);
-    this.brightnessSlider_.animatedSetValue(hsv[2]);
+    this.sourceBlock_.setColour(colour, colour, colour);
   }
 };
 
@@ -205,6 +126,27 @@ Blockly.FieldColour.prototype.getText = function() {
 };
 
 /**
+ * Returns the fixed height and width.
+ * @return {!goog.math.Size} Height and width.
+ */
+Blockly.FieldColour.prototype.getSize = function() {
+  return new goog.math.Size(Blockly.BlockSvg.FIELD_WIDTH, Blockly.BlockSvg.FIELD_HEIGHT);
+};
+
+/**
+ * An array of colour strings for the palette.
+ * See bottom of this page for the default:
+ * http://docs.closure-library.googlecode.com/git/closure_goog_ui_colorpicker.js.source.html
+ * @type {!Array.<string>}
+ */
+Blockly.FieldColour.COLOURS = goog.ui.ColorPicker.SIMPLE_GRID_COLORS;
+
+/**
+ * Number of columns in the palette.
+ */
+Blockly.FieldColour.COLUMNS = 7;
+
+/**
  * Function to be called if eyedropper can be activated.
  * If defined, an eyedropper button will be added to the color picker.
  * The button calls this function with a callback to update the field value.
@@ -218,54 +160,25 @@ Blockly.FieldColour.activateEyedropper_ = null;
 Blockly.FieldColour.EYEDROPPER_PATH = 'eyedropper.svg';
 
 /**
- * Create label and readout DOM elements, returning the readout
- * @param {string} labelText - Text for the label
- * @return {Array} The container node and the readout node.
- * @private
+ * Set a custom colour grid for this field.
+ * @param {Array.<string>} colours Array of colours for this block,
+ *     or null to use default (Blockly.FieldColour.COLOURS).
+ * @return {!Blockly.FieldColour} Returns itself (for method chaining).
  */
-Blockly.FieldColour.prototype.createLabelDom_ = function(labelText) {
-  var labelContainer = document.createElement('div');
-  labelContainer.setAttribute('class', 'scratchColorPickerLabel');
-  var readout = document.createElement('span');
-  readout.setAttribute('class', 'scratchColorPickerReadout');
-  var label = document.createElement('span');
-  label.setAttribute('class', 'scratchColorPickerLabelText');
-  label.innerHTML = labelText;
-  labelContainer.appendChild(label);
-  labelContainer.appendChild(readout);
-  return [labelContainer, readout];
+Blockly.FieldColour.prototype.setColours = function(colours) {
+  this.colours_ = colours;
+  return this;
 };
 
 /**
- * Factory for creating the different slider callbacks
- * @param {string} channel - One of "hue", "saturation" or "brightness"
- * @return {function} the callback for slider update
+ * Set a custom grid size for this field.
+ * @param {number} columns Number of columns for this block,
+ *     or 0 to use default (Blockly.FieldColour.COLUMNS).
+ * @return {!Blockly.FieldColour} Returns itself (for method chaining).
  */
-Blockly.FieldColour.prototype.sliderCallbackFactory = function(channel) {
-  var thisField = this;
-  return function(event) {
-    var channelValue = event.target.getValue();
-    var hsv = goog.color.hexToHsv(thisField.getValue());
-    switch (channel) {
-      case 'hue':
-        hsv[0] = channelValue;
-        break;
-      case 'saturation':
-        hsv[1] = channelValue;
-        break;
-      case 'brightness':
-        hsv[2] = channelValue;
-        break;
-    }
-    var colour = goog.color.hsvToHex(hsv[0], hsv[1], hsv[2]);
-    if (thisField.sourceBlock_) {
-         // Call any validation function, and allow it to override.
-      colour = thisField.callValidator(colour);
-    }
-    if (colour !== null) {
-      thisField.setValue(colour, true);
-    }
-  };
+Blockly.FieldColour.prototype.setColumns = function(columns) {
+  this.columns_ = columns;
+  return this;
 };
 
 /**
@@ -284,47 +197,47 @@ Blockly.FieldColour.prototype.activateEyedropperInternal_ = function() {
  * @private
  */
 Blockly.FieldColour.prototype.showEditor_ = function() {
-  Blockly.DropDownDiv.hideWithoutAnimation();
-  Blockly.DropDownDiv.clearContent();
-  var div = Blockly.DropDownDiv.getContentDiv();
+  Blockly.WidgetDiv.show(this, this.sourceBlock_.RTL,
+      Blockly.FieldColour.widgetDispose_);
+  // Create the palette using Closure.
+  var picker = new goog.ui.ColorPicker();
+  picker.setSize(this.columns_ || Blockly.FieldColour.COLUMNS);
+  picker.setColors(this.colours_ || Blockly.FieldColour.COLOURS);
 
-  var hueElements = this.createLabelDom_('Hue');
-  div.appendChild(hueElements[0]);
-  this.hueReadout_ = hueElements[1];
-  this.hueSlider_ = new goog.ui.Slider();
-  this.hueSlider_.setUnitIncrement(5);
-  this.hueSlider_.setMinimum(0);
-  this.hueSlider_.setMaximum(359);
-  this.hueSlider_.render(div);
+  // Position the palette to line up with the field.
+  // Record windowSize and scrollOffset before adding the palette.
+  var windowSize = goog.dom.getViewportSize();
+  var scrollOffset = goog.style.getViewportPageOffset(document);
+  var xy = this.getAbsoluteXY_();
+  var borderBBox = this.getScaledBBox_();
+  var div = Blockly.WidgetDiv.DIV;
+  picker.render(div);
+  picker.setSelectedColor(this.getValue());
+  // Record paletteSize after adding the palette.
+  var paletteSize = goog.style.getSize(picker.getElement());
 
-  var saturationElements = this.createLabelDom_('Saturation');
-  div.appendChild(saturationElements[0]);
-  this.saturationReadout_ = saturationElements[1];
-  this.saturationSlider_ = new goog.ui.Slider();
-  this.saturationSlider_.setUnitIncrement(0.01);
-  this.saturationSlider_.setStep(0.001);
-  this.saturationSlider_.setMinimum(0.01);
-  this.saturationSlider_.setMaximum(0.99);
-  this.saturationSlider_.render(div);
-
-  var brightnessElements = this.createLabelDom_('Brightness');
-  div.appendChild(brightnessElements[0]);
-  this.brightnessReadout_ = brightnessElements[1];
-  this.brightnessSlider_ = new goog.ui.Slider();
-  this.brightnessSlider_.setUnitIncrement(2);
-  this.brightnessSlider_.setMinimum(5);
-  this.brightnessSlider_.setMaximum(255);
-  this.brightnessSlider_.render(div);
-
-  Blockly.FieldColour.hueChangeEventKey_ = goog.events.listen(this.hueSlider_,
-        goog.ui.Component.EventType.CHANGE,
-        this.sliderCallbackFactory('hue'));
-  Blockly.FieldColour.saturationChangeEventKey_ = goog.events.listen(this.saturationSlider_,
-        goog.ui.Component.EventType.CHANGE,
-        this.sliderCallbackFactory('saturation'));
-  Blockly.FieldColour.brightnessChangeEventKey_ = goog.events.listen(this.brightnessSlider_,
-        goog.ui.Component.EventType.CHANGE,
-        this.sliderCallbackFactory('brightness'));
+  // Flip the palette vertically if off the bottom.
+  if (xy.y + paletteSize.height + borderBBox.height >=
+      windowSize.height + scrollOffset.y) {
+    xy.y -= paletteSize.height - 1;
+  } else {
+    xy.y += borderBBox.height - 1;
+  }
+  if (this.sourceBlock_.RTL) {
+    xy.x += borderBBox.width;
+    xy.x -= paletteSize.width;
+    // Don't go offscreen left.
+    if (xy.x < scrollOffset.x) {
+      xy.x = scrollOffset.x;
+    }
+  } else {
+    // Don't go offscreen right.
+    if (xy.x > windowSize.width + scrollOffset.x - paletteSize.width) {
+      xy.x = windowSize.width + scrollOffset.x - paletteSize.width;
+    }
+  }
+  Blockly.WidgetDiv.position(xy.x, xy.y, windowSize, scrollOffset,
+                             this.sourceBlock_.RTL);
 
   if (Blockly.FieldColour.activateEyedropper_) {
     var button = document.createElement('button');
@@ -339,11 +252,21 @@ Blockly.FieldColour.prototype.showEditor_ = function() {
     );
   }
 
-  Blockly.DropDownDiv.setColour('#ffffff', '#dddddd');
-  Blockly.DropDownDiv.setCategory(this.sourceBlock_.parentBlock_.getCategory());
-  Blockly.DropDownDiv.showPositionedByBlock(this, this.sourceBlock_);
-
-  this.setValue(this.getValue());
+  // Configure event handler.
+  var thisField = this;
+  Blockly.FieldColour.changeEventKey_ = goog.events.listen(picker,
+      goog.ui.ColorPicker.EventType.CHANGE,
+      function(event) {
+        var colour = event.target.getSelectedColor() || '#000000';
+        Blockly.WidgetDiv.hide();
+        if (thisField.sourceBlock_) {
+          // Call any validation function, and allow it to override.
+          colour = thisField.callValidator(colour);
+        }
+        if (colour !== null) {
+          thisField.setValue(colour);
+        }
+      });
 };
 
 /**
@@ -351,14 +274,8 @@ Blockly.FieldColour.prototype.showEditor_ = function() {
  * @private
  */
 Blockly.FieldColour.widgetDispose_ = function() {
-  if (Blockly.FieldColour.hueChangeEventKey_) {
-    goog.events.unlistenByKey(Blockly.FieldColour.hueChangeEventKey_);
-  }
-  if (Blockly.FieldColour.saturationChangeEventKey_) {
-    goog.events.unlistenByKey(Blockly.FieldColour.saturationChangeEventKey_);
-  }
-  if (Blockly.FieldColour.brightnessChangeEventKey_) {
-    goog.events.unlistenByKey(Blockly.FieldColour.brightnessChangeEventKey_);
+  if (Blockly.FieldColour.changeEventKey_) {
+    goog.events.unlistenByKey(Blockly.FieldColour.changeEventKey_);
   }
   if (Blockly.FieldColour.eyedropperEventData_) {
     Blockly.unbindEvent_(Blockly.FieldColour.eyedropperEventData_);

--- a/core/field_colour.js
+++ b/core/field_colour.js
@@ -27,10 +27,12 @@
 goog.provide('Blockly.FieldColour');
 
 goog.require('Blockly.Field');
+goog.require('Blockly.DropDownDiv');
 goog.require('goog.dom');
 goog.require('goog.events');
 goog.require('goog.style');
-goog.require('goog.ui.ColorPicker');
+goog.require('goog.color');
+goog.require('goog.ui.Slider');
 
 /**
  * Class for a colour input field.
@@ -64,25 +66,24 @@ Blockly.FieldColour.prototype.colours_ = null;
 Blockly.FieldColour.prototype.columns_ = 0;
 
 /**
+ * Function to be called if eyedropper can be activated.
+ * If defined, an eyedropper button will be added to the color picker.
+ * The button calls this function with a callback to update the field value.
+ */
+Blockly.FieldColour.activateEyedropper = null;
+
+/**
+ * Path to the eyedropper svg icon.
+ */
+Blockly.FieldColour.EYEDROPPER_PATH = 'eyedropper.svg';
+
+/**
  * Install this field on a block.
  * @param {!Blockly.Block} block The block containing this field.
  */
 Blockly.FieldColour.prototype.init = function(block) {
   Blockly.FieldColour.superClass_.init.call(this, block);
   this.setValue(this.getValue());
-};
-
-/**
- * Mouse cursor style when over the hotspot that initiates the editor.
- */
-Blockly.FieldColour.prototype.CURSOR = 'default';
-
-/**
- * Close the colour picker if this input is being deleted.
- */
-Blockly.FieldColour.prototype.dispose = function() {
-  Blockly.WidgetDiv.hideIfOwner(this);
-  Blockly.FieldColour.superClass_.dispose.call(this);
 };
 
 /**
@@ -94,10 +95,11 @@ Blockly.FieldColour.prototype.getValue = function() {
 };
 
 /**
- * Set the colour.
+ * Set the colour. If opt_fromSliders is true, do not update the sliders.
  * @param {string} colour The new colour in '#rrggbb' format.
+ * @param {boolea} opt_fromSliders Flag to prevent sliders from recursing on themselves.
  */
-Blockly.FieldColour.prototype.setValue = function(colour) {
+Blockly.FieldColour.prototype.setValue = function(colour, opt_fromSliders) {
   if (this.sourceBlock_ && Blockly.Events.isEnabled() &&
       this.colour_ != colour) {
     Blockly.Events.fire(new Blockly.Events.BlockChange(
@@ -107,7 +109,84 @@ Blockly.FieldColour.prototype.setValue = function(colour) {
   if (this.sourceBlock_) {
     // Set the primary, secondary and tertiary colour to this value.
     // The renderer expects to be able to use the secondary color as the fill for a shadow.
-    this.sourceBlock_.setColour(colour, colour, colour);
+    this.sourceBlock_.setColour(colour, colour, this.sourceBlock_.getColourTertiary());
+  }
+  if (!opt_fromSliders) {
+    this.updateSliderHandles_();
+  }
+  this.updateDom_();
+};
+
+/**
+ * Create the hue, saturation or value CSS gradient for the slide backgrounds.
+ * @param {string} channel – Either "hue", "saturation" or "value".
+ * @return {string} Array color hex color stops for the given channel
+ */
+Blockly.FieldColour.prototype.createColorStops_ = function(channel) {
+  var hsv = goog.color.hexToHsv(this.getValue());
+  var stops = [];
+  for(var n = 0; n <= 360; n += 20) {
+    switch (channel) {
+      case 'hue':
+        stops.push(goog.color.hsvToHex(n, hsv[1], hsv[2]));
+        break;
+      case 'saturation':
+        stops.push(goog.color.hsvToHex(hsv[0], n / 360, hsv[2]));
+        break;
+      case 'brightness':
+        stops.push(goog.color.hsvToHex(hsv[0], hsv[1], 255 * n / 360));
+        break;
+    }
+  }
+  return stops;
+};
+
+/**
+ * Set the gradient CSS properties for the given node and channel
+ * @param {Node} node - The DOM node the gradient will be set on.
+ * @param {string} channel – Either "hue", "saturation" or "value".
+ */
+Blockly.FieldColour.prototype.setGradient_ = function(node, channel) {
+  var stops = this.createColorStops_(channel);
+  goog.style.setStyle(node, 'background',
+        '-moz-linear-gradient(left, ' + stops.join(',') + ')');
+  goog.style.setStyle(node, 'background',
+        '-webkit-linear-gradient(left, ' + stops.join(',') + ')');
+  goog.style.setStyle(node, 'background',
+        '-o-linear-gradient(left, ' + stops.join(',') + ')');
+  goog.style.setStyle(node, 'background',
+        '-ms-linear-gradient(left, ' + stops.join(',') + ')');
+  goog.style.setStyle(node, 'background',
+        'linear-gradient(left, ' + stops.join(',') + ')');
+};
+
+/**
+ * Update the readouts and slider backgrounds after value has changed.
+ */
+Blockly.FieldColour.prototype.updateDom_ = function() {
+  if (this.hueSlider_) {
+    // Update the slider backgrounds
+    this.setGradient_(this.hueSlider_.getElement(), 'hue');
+    this.setGradient_(this.saturationSlider_.getElement(), 'saturation');
+    this.setGradient_(this.brightnessSlider_.getElement(), 'brightness');
+
+    // Update the readouts
+    var hsv = goog.color.hexToHsv(this.getValue());
+    this.hueReadout_.innerHTML = Math.floor(100 * hsv[0] / 360).toFixed(0);
+    this.saturationReadout_.innerHTML = Math.floor(100 * hsv[1]).toFixed(0);
+    this.brightnessReadout_.innerHTML = Math.floor(100 * hsv[2] / 255).toFixed(0);
+  }
+};
+
+/**
+ * Update the slider handle positions
+ */
+Blockly.FieldColour.prototype.updateSliderHandles_ = function() {
+  if (this.hueSlider_) {
+    var hsv = goog.color.hexToHsv(this.getValue());
+    this.hueSlider_.animatedSetValue(hsv[0]);
+    this.saturationSlider_.animatedSetValue(hsv[1]);
+    this.brightnessSlider_.animatedSetValue(hsv[2]);
   }
 };
 
@@ -126,27 +205,6 @@ Blockly.FieldColour.prototype.getText = function() {
 };
 
 /**
- * Returns the fixed height and width.
- * @return {!goog.math.Size} Height and width.
- */
-Blockly.FieldColour.prototype.getSize = function() {
-  return new goog.math.Size(Blockly.BlockSvg.FIELD_WIDTH, Blockly.BlockSvg.FIELD_HEIGHT);
-};
-
-/**
- * An array of colour strings for the palette.
- * See bottom of this page for the default:
- * http://docs.closure-library.googlecode.com/git/closure_goog_ui_colorpicker.js.source.html
- * @type {!Array.<string>}
- */
-Blockly.FieldColour.COLOURS = goog.ui.ColorPicker.SIMPLE_GRID_COLORS;
-
-/**
- * Number of columns in the palette.
- */
-Blockly.FieldColour.COLUMNS = 7;
-
-/**
  * Function to be called if eyedropper can be activated.
  * If defined, an eyedropper button will be added to the color picker.
  * The button calls this function with a callback to update the field value.
@@ -160,25 +218,54 @@ Blockly.FieldColour.activateEyedropper_ = null;
 Blockly.FieldColour.EYEDROPPER_PATH = 'eyedropper.svg';
 
 /**
- * Set a custom colour grid for this field.
- * @param {Array.<string>} colours Array of colours for this block,
- *     or null to use default (Blockly.FieldColour.COLOURS).
- * @return {!Blockly.FieldColour} Returns itself (for method chaining).
+ * Create label and readout DOM elements, returning the readout
+ * @param {string} labelText - Text for the label
+ * @return {Array} The container node and the readout node.
+ * @private
  */
-Blockly.FieldColour.prototype.setColours = function(colours) {
-  this.colours_ = colours;
-  return this;
+Blockly.FieldColour.prototype.createLabelDom_ = function(labelText) {
+  var labelContainer = document.createElement('div');
+  labelContainer.setAttribute('class', 'scratchColorPickerLabel');
+  var readout = document.createElement('span');
+  readout.setAttribute('class', 'scratchColorPickerReadout');
+  var label = document.createElement('span');
+  label.setAttribute('class', 'scratchColorPickerLabelText');
+  label.innerHTML = labelText;
+  labelContainer.appendChild(label);
+  labelContainer.appendChild(readout);
+  return [labelContainer, readout];
 };
 
 /**
- * Set a custom grid size for this field.
- * @param {number} columns Number of columns for this block,
- *     or 0 to use default (Blockly.FieldColour.COLUMNS).
- * @return {!Blockly.FieldColour} Returns itself (for method chaining).
+ * Factory for creating the different slider callbacks
+ * @param {string} channel - One of "hue", "saturation" or "brightness"
+ * @return {function} the callback for slider update
  */
-Blockly.FieldColour.prototype.setColumns = function(columns) {
-  this.columns_ = columns;
-  return this;
+Blockly.FieldColour.prototype.sliderCallbackFactory = function(channel) {
+  var thisField = this;
+  return function(event) {
+    var channelValue = event.target.getValue();
+    var hsv = goog.color.hexToHsv(thisField.getValue());
+    switch (channel) {
+      case 'hue':
+        hsv[0] = channelValue;
+        break;
+      case 'saturation':
+        hsv[1] = channelValue;
+        break;
+      case 'brightness':
+        hsv[2] = channelValue;
+        break;
+    }
+    var colour = goog.color.hsvToHex(hsv[0], hsv[1], hsv[2]);
+    if (thisField.sourceBlock_) {
+         // Call any validation function, and allow it to override.
+      colour = thisField.callValidator(colour);
+    }
+    if (colour !== null) {
+      thisField.setValue(colour, true);
+    }
+  };
 };
 
 /**
@@ -197,47 +284,47 @@ Blockly.FieldColour.prototype.activateEyedropperInternal_ = function() {
  * @private
  */
 Blockly.FieldColour.prototype.showEditor_ = function() {
-  Blockly.WidgetDiv.show(this, this.sourceBlock_.RTL,
-      Blockly.FieldColour.widgetDispose_);
-  // Create the palette using Closure.
-  var picker = new goog.ui.ColorPicker();
-  picker.setSize(this.columns_ || Blockly.FieldColour.COLUMNS);
-  picker.setColors(this.colours_ || Blockly.FieldColour.COLOURS);
+  Blockly.DropDownDiv.hideWithoutAnimation();
+  Blockly.DropDownDiv.clearContent();
+  var div = Blockly.DropDownDiv.getContentDiv();
 
-  // Position the palette to line up with the field.
-  // Record windowSize and scrollOffset before adding the palette.
-  var windowSize = goog.dom.getViewportSize();
-  var scrollOffset = goog.style.getViewportPageOffset(document);
-  var xy = this.getAbsoluteXY_();
-  var borderBBox = this.getScaledBBox_();
-  var div = Blockly.WidgetDiv.DIV;
-  picker.render(div);
-  picker.setSelectedColor(this.getValue());
-  // Record paletteSize after adding the palette.
-  var paletteSize = goog.style.getSize(picker.getElement());
+  var hueElements = this.createLabelDom_('Hue');
+  div.appendChild(hueElements[0]);
+  this.hueReadout_ = hueElements[1];
+  this.hueSlider_ = new goog.ui.Slider();
+  this.hueSlider_.setUnitIncrement(5);
+  this.hueSlider_.setMinimum(0);
+  this.hueSlider_.setMaximum(359);
+  this.hueSlider_.render(div);
 
-  // Flip the palette vertically if off the bottom.
-  if (xy.y + paletteSize.height + borderBBox.height >=
-      windowSize.height + scrollOffset.y) {
-    xy.y -= paletteSize.height - 1;
-  } else {
-    xy.y += borderBBox.height - 1;
-  }
-  if (this.sourceBlock_.RTL) {
-    xy.x += borderBBox.width;
-    xy.x -= paletteSize.width;
-    // Don't go offscreen left.
-    if (xy.x < scrollOffset.x) {
-      xy.x = scrollOffset.x;
-    }
-  } else {
-    // Don't go offscreen right.
-    if (xy.x > windowSize.width + scrollOffset.x - paletteSize.width) {
-      xy.x = windowSize.width + scrollOffset.x - paletteSize.width;
-    }
-  }
-  Blockly.WidgetDiv.position(xy.x, xy.y, windowSize, scrollOffset,
-                             this.sourceBlock_.RTL);
+  var saturationElements = this.createLabelDom_('Saturation');
+  div.appendChild(saturationElements[0]);
+  this.saturationReadout_ = saturationElements[1];
+  this.saturationSlider_ = new goog.ui.Slider();
+  this.saturationSlider_.setUnitIncrement(0.01);
+  this.saturationSlider_.setStep(0.001);
+  this.saturationSlider_.setMinimum(0.01);
+  this.saturationSlider_.setMaximum(0.99);
+  this.saturationSlider_.render(div);
+
+  var brightnessElements = this.createLabelDom_('Brightness');
+  div.appendChild(brightnessElements[0]);
+  this.brightnessReadout_ = brightnessElements[1];
+  this.brightnessSlider_ = new goog.ui.Slider();
+  this.brightnessSlider_.setUnitIncrement(2);
+  this.brightnessSlider_.setMinimum(5);
+  this.brightnessSlider_.setMaximum(255);
+  this.brightnessSlider_.render(div);
+
+  Blockly.FieldColour.hueChangeEventKey_ = goog.events.listen(this.hueSlider_,
+        goog.ui.Component.EventType.CHANGE,
+        this.sliderCallbackFactory('hue'));
+  Blockly.FieldColour.saturationChangeEventKey_ = goog.events.listen(this.saturationSlider_,
+        goog.ui.Component.EventType.CHANGE,
+        this.sliderCallbackFactory('saturation'));
+  Blockly.FieldColour.brightnessChangeEventKey_ = goog.events.listen(this.brightnessSlider_,
+        goog.ui.Component.EventType.CHANGE,
+        this.sliderCallbackFactory('brightness'));
 
   if (Blockly.FieldColour.activateEyedropper_) {
     var button = document.createElement('button');
@@ -252,21 +339,11 @@ Blockly.FieldColour.prototype.showEditor_ = function() {
     );
   }
 
-  // Configure event handler.
-  var thisField = this;
-  Blockly.FieldColour.changeEventKey_ = goog.events.listen(picker,
-      goog.ui.ColorPicker.EventType.CHANGE,
-      function(event) {
-        var colour = event.target.getSelectedColor() || '#000000';
-        Blockly.WidgetDiv.hide();
-        if (thisField.sourceBlock_) {
-          // Call any validation function, and allow it to override.
-          colour = thisField.callValidator(colour);
-        }
-        if (colour !== null) {
-          thisField.setValue(colour);
-        }
-      });
+  Blockly.DropDownDiv.setColour('#ffffff', '#dddddd');
+  Blockly.DropDownDiv.setCategory(this.sourceBlock_.parentBlock_.getCategory());
+  Blockly.DropDownDiv.showPositionedByBlock(this, this.sourceBlock_);
+
+  this.setValue(this.getValue());
 };
 
 /**
@@ -274,8 +351,14 @@ Blockly.FieldColour.prototype.showEditor_ = function() {
  * @private
  */
 Blockly.FieldColour.widgetDispose_ = function() {
-  if (Blockly.FieldColour.changeEventKey_) {
-    goog.events.unlistenByKey(Blockly.FieldColour.changeEventKey_);
+  if (Blockly.FieldColour.hueChangeEventKey_) {
+    goog.events.unlistenByKey(Blockly.FieldColour.hueChangeEventKey_);
+  }
+  if (Blockly.FieldColour.saturationChangeEventKey_) {
+    goog.events.unlistenByKey(Blockly.FieldColour.saturationChangeEventKey_);
+  }
+  if (Blockly.FieldColour.brightnessChangeEventKey_) {
+    goog.events.unlistenByKey(Blockly.FieldColour.brightnessChangeEventKey_);
   }
   if (Blockly.FieldColour.eyedropperEventData_) {
     Blockly.unbindEvent_(Blockly.FieldColour.eyedropperEventData_);

--- a/core/field_colour.js
+++ b/core/field_colour.js
@@ -147,19 +147,6 @@ Blockly.FieldColour.COLOURS = goog.ui.ColorPicker.SIMPLE_GRID_COLORS;
 Blockly.FieldColour.COLUMNS = 7;
 
 /**
- * Function to be called if eyedropper can be activated.
- * If defined, an eyedropper button will be added to the color picker.
- * The button calls this function with a callback to update the field value.
- * BEWARE: This is not a stable API, so it is being marked as private. It may change.
- */
-Blockly.FieldColour.activateEyedropper_ = null;
-
-/**
- * Path to the eyedropper svg icon.
- */
-Blockly.FieldColour.EYEDROPPER_PATH = 'eyedropper.svg';
-
-/**
  * Set a custom colour grid for this field.
  * @param {Array.<string>} colours Array of colours for this block,
  *     or null to use default (Blockly.FieldColour.COLOURS).
@@ -179,17 +166,6 @@ Blockly.FieldColour.prototype.setColours = function(colours) {
 Blockly.FieldColour.prototype.setColumns = function(columns) {
   this.columns_ = columns;
   return this;
-};
-
-/**
- * Activate the eyedropper, passing in a callback for setting the field value.
- * @private
- */
-Blockly.FieldColour.prototype.activateEyedropperInternal_ = function() {
-  var thisField = this;
-  Blockly.FieldColour.activateEyedropper_(function(value) {
-    thisField.setValue(value);
-  });
 };
 
 /**
@@ -239,19 +215,6 @@ Blockly.FieldColour.prototype.showEditor_ = function() {
   Blockly.WidgetDiv.position(xy.x, xy.y, windowSize, scrollOffset,
                              this.sourceBlock_.RTL);
 
-  if (Blockly.FieldColour.activateEyedropper_) {
-    var button = document.createElement('button');
-    var image = document.createElement('img');
-    image.src = Blockly.mainWorkspace.options.pathToMedia + Blockly.FieldColour.EYEDROPPER_PATH;
-    button.appendChild(image);
-    div.appendChild(button);
-    Blockly.FieldColour.eyedropperEventData_ = Blockly.bindEventWithChecks_(button,
-      'mousedown',
-      this,
-      this.activateEyedropperInternal_
-    );
-  }
-
   // Configure event handler.
   var thisField = this;
   Blockly.FieldColour.changeEventKey_ = goog.events.listen(picker,
@@ -276,9 +239,6 @@ Blockly.FieldColour.prototype.showEditor_ = function() {
 Blockly.FieldColour.widgetDispose_ = function() {
   if (Blockly.FieldColour.changeEventKey_) {
     goog.events.unlistenByKey(Blockly.FieldColour.changeEventKey_);
-  }
-  if (Blockly.FieldColour.eyedropperEventData_) {
-    Blockly.unbindEvent_(Blockly.FieldColour.eyedropperEventData_);
   }
   Blockly.Events.setGroup(false);
 };

--- a/core/field_colour_slider.js
+++ b/core/field_colour_slider.js
@@ -107,6 +107,7 @@ Blockly.FieldColourSlider.prototype.setValue = function(colour, opt_fromSliders)
  * Create the hue, saturation or value CSS gradient for the slide backgrounds.
  * @param {string} channel – Either "hue", "saturation" or "value".
  * @return {string} Array colour hex colour stops for the given channel
+ * @private
  */
 Blockly.FieldColourSlider.prototype.createColourStops_ = function(channel) {
   var hsv = goog.color.hexToHsv(this.getValue());
@@ -131,23 +132,25 @@ Blockly.FieldColourSlider.prototype.createColourStops_ = function(channel) {
  * Set the gradient CSS properties for the given node and channel
  * @param {Node} node - The DOM node the gradient will be set on.
  * @param {string} channel – Either "hue", "saturation" or "value".
+ * @private
  */
 Blockly.FieldColourSlider.prototype.setGradient_ = function(node, channel) {
-  var stops = this.createColourStops_(channel);
+  var gradient = this.createColourStops_(channel).join(',');
   goog.style.setStyle(node, 'background',
-        '-moz-linear-gradient(left, ' + stops.join(',') + ')');
+        '-moz-linear-gradient(left, ' + gradient + ')');
   goog.style.setStyle(node, 'background',
-        '-webkit-linear-gradient(left, ' + stops.join(',') + ')');
+        '-webkit-linear-gradient(left, ' + gradient + ')');
   goog.style.setStyle(node, 'background',
-        '-o-linear-gradient(left, ' + stops.join(',') + ')');
+        '-o-linear-gradient(left, ' + gradient + ')');
   goog.style.setStyle(node, 'background',
-        '-ms-linear-gradient(left, ' + stops.join(',') + ')');
+        '-ms-linear-gradient(left, ' + gradient + ')');
   goog.style.setStyle(node, 'background',
-        'linear-gradient(left, ' + stops.join(',') + ')');
+        'linear-gradient(left, ' + gradient + ')');
 };
 
 /**
  * Update the readouts and slider backgrounds after value has changed.
+ * @private
  */
 Blockly.FieldColourSlider.prototype.updateDom_ = function() {
   if (this.hueSlider_) {

--- a/core/field_colour_slider.js
+++ b/core/field_colour_slider.js
@@ -84,11 +84,10 @@ Blockly.FieldColourSlider.prototype.getValue = function() {
 };
 
 /**
- * Set the colour. If opt_fromSliders is true, do not update the sliders.
+ * Set the colour.
  * @param {string} colour The new colour in '#rrggbb' format.
- * @param {boolea} opt_fromSliders Flag to prevent sliders from recursing on themselves.
  */
-Blockly.FieldColourSlider.prototype.setValue = function(colour, opt_fromSliders) {
+Blockly.FieldColourSlider.prototype.setValue = function(colour) {
   if (this.sourceBlock_ && Blockly.Events.isEnabled() &&
       this.colour_ != colour) {
     Blockly.Events.fire(new Blockly.Events.BlockChange(
@@ -100,9 +99,7 @@ Blockly.FieldColourSlider.prototype.setValue = function(colour, opt_fromSliders)
     // The renderer expects to be able to use the secondary colour as the fill for a shadow.
     this.sourceBlock_.setColour(colour, colour, this.sourceBlock_.getColourTertiary());
   }
-  if (!opt_fromSliders) {
-    this.updateSliderHandles_();
-  }
+  this.updateSliderHandles_();
   this.updateDom_();
 };
 
@@ -173,14 +170,15 @@ Blockly.FieldColourSlider.prototype.updateDom_ = function() {
 };
 
 /**
- * Update the slider handle positions
+ * Update the slider handle positions from the current field value.
+ * @private
  */
 Blockly.FieldColourSlider.prototype.updateSliderHandles_ = function() {
   if (this.hueSlider_) {
     var hsv = goog.color.hexToHsv(this.getValue());
-    this.hueSlider_.animatedSetValue(hsv[0]);
-    this.saturationSlider_.animatedSetValue(hsv[1]);
-    this.brightnessSlider_.animatedSetValue(hsv[2]);
+    this.hueSlider_.setValue(hsv[0]);
+    this.saturationSlider_.setValue(hsv[1]);
+    this.brightnessSlider_.setValue(hsv[2]);
   }
 };
 
@@ -211,7 +209,7 @@ Blockly.FieldColourSlider.prototype.createLabelDom_ = function(labelText) {
   readout.setAttribute('class', 'scratchColourPickerReadout');
   var label = document.createElement('span');
   label.setAttribute('class', 'scratchColourPickerLabelText');
-  label.innerHTML = labelText;
+  label.textContent = labelText;
   labelContainer.appendChild(label);
   labelContainer.appendChild(readout);
   return [labelContainer, readout];
@@ -221,8 +219,9 @@ Blockly.FieldColourSlider.prototype.createLabelDom_ = function(labelText) {
  * Factory for creating the different slider callbacks
  * @param {string} channel - One of "hue", "saturation" or "brightness"
  * @return {function} the callback for slider update
+ * @private
  */
-Blockly.FieldColourSlider.prototype.sliderCallbackFactory = function(channel) {
+Blockly.FieldColourSlider.prototype.sliderCallbackFactory_ = function(channel) {
   var thisField = this;
   return function(event) {
     var channelValue = event.target.getValue();
@@ -261,7 +260,7 @@ Blockly.FieldColourSlider.prototype.activateEyedropperInternal_ = function() {
 };
 
 /**
- * Create a palette under the colour field.
+ * Create hue, saturation and brightness sliders under the colour field.
  * @private
  */
 Blockly.FieldColourSlider.prototype.showEditor_ = function() {
@@ -299,13 +298,13 @@ Blockly.FieldColourSlider.prototype.showEditor_ = function() {
 
   Blockly.FieldColourSlider.hueChangeEventKey_ = goog.events.listen(this.hueSlider_,
         goog.ui.Component.EventType.CHANGE,
-        this.sliderCallbackFactory('hue'));
+        this.sliderCallbackFactory_('hue'));
   Blockly.FieldColourSlider.saturationChangeEventKey_ = goog.events.listen(this.saturationSlider_,
         goog.ui.Component.EventType.CHANGE,
-        this.sliderCallbackFactory('saturation'));
+        this.sliderCallbackFactory_('saturation'));
   Blockly.FieldColourSlider.brightnessChangeEventKey_ = goog.events.listen(this.brightnessSlider_,
         goog.ui.Component.EventType.CHANGE,
-        this.sliderCallbackFactory('brightness'));
+        this.sliderCallbackFactory_('brightness'));
 
   if (Blockly.FieldColourSlider.activateEyedropper_) {
     var button = document.createElement('button');

--- a/core/field_colour_slider.js
+++ b/core/field_colour_slider.js
@@ -123,6 +123,8 @@ Blockly.FieldColourSlider.prototype.createColourStops_ = function(channel) {
       case 'brightness':
         stops.push(goog.color.hsvToHex(hsv[0], hsv[1], 255 * n / 360));
         break;
+      default:
+        throw new Error("Unknown channel for colour sliders: " + channel);
     }
   }
   return stops;

--- a/core/field_colour_slider.js
+++ b/core/field_colour_slider.js
@@ -1,0 +1,353 @@
+/**
+ * @license
+ * Visual Blocks Editor
+ *
+ * Copyright 2012 Google Inc.
+ * https://developers.google.com/blockly/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Colour input field.
+ * @author fraser@google.com (Neil Fraser)
+ */
+'use strict';
+
+goog.provide('Blockly.FieldColourSlider');
+
+goog.require('Blockly.Field');
+goog.require('Blockly.DropDownDiv');
+goog.require('goog.dom');
+goog.require('goog.events');
+goog.require('goog.style');
+goog.require('goog.color');
+goog.require('goog.ui.Slider');
+
+/**
+ * Class for a slider-based colour input field.
+ * @param {string} colour The initial colour in '#rrggbb' format.
+ * @param {Function=} opt_validator A function that is executed when a new
+ *     colour is selected.  Its sole argument is the new colour value.  Its
+ *     return value becomes the selected colour, unless it is undefined, in
+ *     which case the new colour stands, or it is null, in which case the change
+ *     is aborted.
+ * @extends {Blockly.Field}
+ * @constructor
+ */
+Blockly.FieldColourSlider = function(colour, opt_validator) {
+  Blockly.FieldColourSlider.superClass_.constructor.call(this, colour, opt_validator);
+  this.addArgType('colour');
+};
+goog.inherits(Blockly.FieldColourSlider, Blockly.Field);
+
+/**
+ * Function to be called if eyedropper can be activated.
+ * If defined, an eyedropper button will be added to the colour picker.
+ * The button calls this function with a callback to update the field value.
+ */
+Blockly.FieldColourSlider.activateEyedropper = null;
+
+/**
+ * Path to the eyedropper svg icon.
+ */
+Blockly.FieldColourSlider.EYEDROPPER_PATH = 'eyedropper.svg';
+
+/**
+ * Install this field on a block.
+ * @param {!Blockly.Block} block The block containing this field.
+ */
+Blockly.FieldColourSlider.prototype.init = function(block) {
+  Blockly.FieldColourSlider.superClass_.init.call(this, block);
+  this.setValue(this.getValue());
+};
+
+/**
+ * Return the current colour.
+ * @return {string} Current colour in '#rrggbb' format.
+ */
+Blockly.FieldColourSlider.prototype.getValue = function() {
+  return this.colour_;
+};
+
+/**
+ * Set the colour. If opt_fromSliders is true, do not update the sliders.
+ * @param {string} colour The new colour in '#rrggbb' format.
+ * @param {boolea} opt_fromSliders Flag to prevent sliders from recursing on themselves.
+ */
+Blockly.FieldColourSlider.prototype.setValue = function(colour, opt_fromSliders) {
+  if (this.sourceBlock_ && Blockly.Events.isEnabled() &&
+      this.colour_ != colour) {
+    Blockly.Events.fire(new Blockly.Events.BlockChange(
+        this.sourceBlock_, 'field', this.name, this.colour_, colour));
+  }
+  this.colour_ = colour;
+  if (this.sourceBlock_) {
+    // Set the primary, secondary and tertiary colour to this value.
+    // The renderer expects to be able to use the secondary colour as the fill for a shadow.
+    this.sourceBlock_.setColour(colour, colour, this.sourceBlock_.getColourTertiary());
+  }
+  if (!opt_fromSliders) {
+    this.updateSliderHandles_();
+  }
+  this.updateDom_();
+};
+
+/**
+ * Create the hue, saturation or value CSS gradient for the slide backgrounds.
+ * @param {string} channel – Either "hue", "saturation" or "value".
+ * @return {string} Array colour hex colour stops for the given channel
+ */
+Blockly.FieldColourSlider.prototype.createColourStops_ = function(channel) {
+  var hsv = goog.color.hexToHsv(this.getValue());
+  var stops = [];
+  for(var n = 0; n <= 360; n += 20) {
+    switch (channel) {
+      case 'hue':
+        stops.push(goog.color.hsvToHex(n, hsv[1], hsv[2]));
+        break;
+      case 'saturation':
+        stops.push(goog.color.hsvToHex(hsv[0], n / 360, hsv[2]));
+        break;
+      case 'brightness':
+        stops.push(goog.color.hsvToHex(hsv[0], hsv[1], 255 * n / 360));
+        break;
+    }
+  }
+  return stops;
+};
+
+/**
+ * Set the gradient CSS properties for the given node and channel
+ * @param {Node} node - The DOM node the gradient will be set on.
+ * @param {string} channel – Either "hue", "saturation" or "value".
+ */
+Blockly.FieldColourSlider.prototype.setGradient_ = function(node, channel) {
+  var stops = this.createColourStops_(channel);
+  goog.style.setStyle(node, 'background',
+        '-moz-linear-gradient(left, ' + stops.join(',') + ')');
+  goog.style.setStyle(node, 'background',
+        '-webkit-linear-gradient(left, ' + stops.join(',') + ')');
+  goog.style.setStyle(node, 'background',
+        '-o-linear-gradient(left, ' + stops.join(',') + ')');
+  goog.style.setStyle(node, 'background',
+        '-ms-linear-gradient(left, ' + stops.join(',') + ')');
+  goog.style.setStyle(node, 'background',
+        'linear-gradient(left, ' + stops.join(',') + ')');
+};
+
+/**
+ * Update the readouts and slider backgrounds after value has changed.
+ */
+Blockly.FieldColourSlider.prototype.updateDom_ = function() {
+  if (this.hueSlider_) {
+    // Update the slider backgrounds
+    this.setGradient_(this.hueSlider_.getElement(), 'hue');
+    this.setGradient_(this.saturationSlider_.getElement(), 'saturation');
+    this.setGradient_(this.brightnessSlider_.getElement(), 'brightness');
+
+    // Update the readouts
+    var hsv = goog.color.hexToHsv(this.getValue());
+    this.hueReadout_.textContent = Math.floor(100 * hsv[0] / 360).toFixed(0);
+    this.saturationReadout_.textContent = Math.floor(100 * hsv[1]).toFixed(0);
+    this.brightnessReadout_.textContent = Math.floor(100 * hsv[2] / 255).toFixed(0);
+  }
+};
+
+/**
+ * Update the slider handle positions
+ */
+Blockly.FieldColourSlider.prototype.updateSliderHandles_ = function() {
+  if (this.hueSlider_) {
+    var hsv = goog.color.hexToHsv(this.getValue());
+    this.hueSlider_.animatedSetValue(hsv[0]);
+    this.saturationSlider_.animatedSetValue(hsv[1]);
+    this.brightnessSlider_.animatedSetValue(hsv[2]);
+  }
+};
+
+/**
+ * Get the text from this field.  Used when the block is collapsed.
+ * @return {string} Current text.
+ */
+Blockly.FieldColourSlider.prototype.getText = function() {
+  var colour = this.colour_;
+  // Try to use #rgb format if possible, rather than #rrggbb.
+  var m = colour.match(/^#(.)\1(.)\2(.)\3$/);
+  if (m) {
+    colour = '#' + m[1] + m[2] + m[3];
+  }
+  return colour;
+};
+
+/**
+ * Function to be called if eyedropper can be activated.
+ * If defined, an eyedropper button will be added to the colour picker.
+ * The button calls this function with a callback to update the field value.
+ * BEWARE: This is not a stable API, so it is being marked as private. It may change.
+ */
+Blockly.FieldColourSlider.activateEyedropper_ = null;
+
+/**
+ * Path to the eyedropper svg icon.
+ */
+Blockly.FieldColourSlider.EYEDROPPER_PATH = 'eyedropper.svg';
+
+/**
+ * Create label and readout DOM elements, returning the readout
+ * @param {string} labelText - Text for the label
+ * @return {Array} The container node and the readout node.
+ * @private
+ */
+Blockly.FieldColourSlider.prototype.createLabelDom_ = function(labelText) {
+  var labelContainer = document.createElement('div');
+  labelContainer.setAttribute('class', 'scratchColourPickerLabel');
+  var readout = document.createElement('span');
+  readout.setAttribute('class', 'scratchColourPickerReadout');
+  var label = document.createElement('span');
+  label.setAttribute('class', 'scratchColourPickerLabelText');
+  label.innerHTML = labelText;
+  labelContainer.appendChild(label);
+  labelContainer.appendChild(readout);
+  return [labelContainer, readout];
+};
+
+/**
+ * Factory for creating the different slider callbacks
+ * @param {string} channel - One of "hue", "saturation" or "brightness"
+ * @return {function} the callback for slider update
+ */
+Blockly.FieldColourSlider.prototype.sliderCallbackFactory = function(channel) {
+  var thisField = this;
+  return function(event) {
+    var channelValue = event.target.getValue();
+    var hsv = goog.color.hexToHsv(thisField.getValue());
+    switch (channel) {
+      case 'hue':
+        hsv[0] = channelValue;
+        break;
+      case 'saturation':
+        hsv[1] = channelValue;
+        break;
+      case 'brightness':
+        hsv[2] = channelValue;
+        break;
+    }
+    var colour = goog.color.hsvToHex(hsv[0], hsv[1], hsv[2]);
+    if (thisField.sourceBlock_) {
+         // Call any validation function, and allow it to override.
+      colour = thisField.callValidator(colour);
+    }
+    if (colour !== null) {
+      thisField.setValue(colour, true);
+    }
+  };
+};
+
+/**
+ * Activate the eyedropper, passing in a callback for setting the field value.
+ * @private
+ */
+Blockly.FieldColourSlider.prototype.activateEyedropperInternal_ = function() {
+  var thisField = this;
+  Blockly.FieldColourSlider.activateEyedropper_(function(value) {
+    thisField.setValue(value);
+  });
+};
+
+/**
+ * Create a palette under the colour field.
+ * @private
+ */
+Blockly.FieldColourSlider.prototype.showEditor_ = function() {
+  Blockly.DropDownDiv.hideWithoutAnimation();
+  Blockly.DropDownDiv.clearContent();
+  var div = Blockly.DropDownDiv.getContentDiv();
+
+  var hueElements = this.createLabelDom_('Hue');
+  div.appendChild(hueElements[0]);
+  this.hueReadout_ = hueElements[1];
+  this.hueSlider_ = new goog.ui.Slider();
+  this.hueSlider_.setUnitIncrement(5);
+  this.hueSlider_.setMinimum(0);
+  this.hueSlider_.setMaximum(359);
+  this.hueSlider_.render(div);
+
+  var saturationElements = this.createLabelDom_('Saturation');
+  div.appendChild(saturationElements[0]);
+  this.saturationReadout_ = saturationElements[1];
+  this.saturationSlider_ = new goog.ui.Slider();
+  this.saturationSlider_.setUnitIncrement(0.01);
+  this.saturationSlider_.setStep(0.001);
+  this.saturationSlider_.setMinimum(0.01);
+  this.saturationSlider_.setMaximum(0.99);
+  this.saturationSlider_.render(div);
+
+  var brightnessElements = this.createLabelDom_('Brightness');
+  div.appendChild(brightnessElements[0]);
+  this.brightnessReadout_ = brightnessElements[1];
+  this.brightnessSlider_ = new goog.ui.Slider();
+  this.brightnessSlider_.setUnitIncrement(2);
+  this.brightnessSlider_.setMinimum(5);
+  this.brightnessSlider_.setMaximum(255);
+  this.brightnessSlider_.render(div);
+
+  Blockly.FieldColourSlider.hueChangeEventKey_ = goog.events.listen(this.hueSlider_,
+        goog.ui.Component.EventType.CHANGE,
+        this.sliderCallbackFactory('hue'));
+  Blockly.FieldColourSlider.saturationChangeEventKey_ = goog.events.listen(this.saturationSlider_,
+        goog.ui.Component.EventType.CHANGE,
+        this.sliderCallbackFactory('saturation'));
+  Blockly.FieldColourSlider.brightnessChangeEventKey_ = goog.events.listen(this.brightnessSlider_,
+        goog.ui.Component.EventType.CHANGE,
+        this.sliderCallbackFactory('brightness'));
+
+  if (Blockly.FieldColourSlider.activateEyedropper_) {
+    var button = document.createElement('button');
+    var image = document.createElement('img');
+    image.src = Blockly.mainWorkspace.options.pathToMedia + Blockly.FieldColourSlider.EYEDROPPER_PATH;
+    button.appendChild(image);
+    div.appendChild(button);
+    Blockly.FieldColourSlider.eyedropperEventData_ = Blockly.bindEventWithChecks_(button,
+      'mousedown',
+      this,
+      this.activateEyedropperInternal_
+    );
+  }
+
+  Blockly.DropDownDiv.setColour('#ffffff', '#dddddd');
+  Blockly.DropDownDiv.setCategory(this.sourceBlock_.parentBlock_.getCategory());
+  Blockly.DropDownDiv.showPositionedByBlock(this, this.sourceBlock_);
+
+  this.setValue(this.getValue());
+};
+
+/**
+ * Hide the colour palette.
+ * @private
+ */
+Blockly.FieldColourSlider.widgetDispose_ = function() {
+  if (Blockly.FieldColourSlider.hueChangeEventKey_) {
+    goog.events.unlistenByKey(Blockly.FieldColourSlider.hueChangeEventKey_);
+  }
+  if (Blockly.FieldColourSlider.saturationChangeEventKey_) {
+    goog.events.unlistenByKey(Blockly.FieldColourSlider.saturationChangeEventKey_);
+  }
+  if (Blockly.FieldColourSlider.brightnessChangeEventKey_) {
+    goog.events.unlistenByKey(Blockly.FieldColourSlider.brightnessChangeEventKey_);
+  }
+  if (Blockly.FieldColourSlider.eyedropperEventData_) {
+    Blockly.unbindEvent_(Blockly.FieldColourSlider.eyedropperEventData_);
+  }
+  Blockly.Events.setGroup(false);
+};

--- a/core/field_colour_slider.js
+++ b/core/field_colour_slider.js
@@ -335,11 +335,7 @@ Blockly.FieldColourSlider.prototype.showEditor_ = function() {
   this.setValue(this.getValue());
 };
 
-/**
- * Hide the colour palette.
- * @private
- */
-Blockly.FieldColourSlider.widgetDispose_ = function() {
+Blockly.FieldColourSlider.prototype.dispose = function() {
   if (Blockly.FieldColourSlider.hueChangeEventKey_) {
     goog.events.unlistenByKey(Blockly.FieldColourSlider.hueChangeEventKey_);
   }
@@ -353,4 +349,5 @@ Blockly.FieldColourSlider.widgetDispose_ = function() {
     Blockly.unbindEvent_(Blockly.FieldColourSlider.eyedropperEventData_);
   }
   Blockly.Events.setGroup(false);
+  Blockly.FieldColourSlider.superClass_.dispose.call(this);
 };

--- a/core/field_colour_slider.js
+++ b/core/field_colour_slider.js
@@ -51,12 +51,15 @@ Blockly.FieldColourSlider = function(colour, opt_validator) {
 };
 goog.inherits(Blockly.FieldColourSlider, Blockly.Field);
 
+
 /**
  * Function to be called if eyedropper can be activated.
- * If defined, an eyedropper button will be added to the colour picker.
+ * If defined, an eyedropper button will be added to the color picker.
  * The button calls this function with a callback to update the field value.
+ * BEWARE: This is not a stable API, so it is being marked as private. It may change.
+ * @private
  */
-Blockly.FieldColourSlider.activateEyedropper = null;
+Blockly.FieldColourSlider.activateEyedropper_ = null;
 
 /**
  * Path to the eyedropper svg icon.
@@ -196,19 +199,6 @@ Blockly.FieldColourSlider.prototype.getText = function() {
 };
 
 /**
- * Function to be called if eyedropper can be activated.
- * If defined, an eyedropper button will be added to the colour picker.
- * The button calls this function with a callback to update the field value.
- * BEWARE: This is not a stable API, so it is being marked as private. It may change.
- */
-Blockly.FieldColourSlider.activateEyedropper_ = null;
-
-/**
- * Path to the eyedropper svg icon.
- */
-Blockly.FieldColourSlider.EYEDROPPER_PATH = 'eyedropper.svg';
-
-/**
  * Create label and readout DOM elements, returning the readout
  * @param {string} labelText - Text for the label
  * @return {Array} The container node and the readout node.
@@ -319,6 +309,7 @@ Blockly.FieldColourSlider.prototype.showEditor_ = function() {
 
   if (Blockly.FieldColourSlider.activateEyedropper_) {
     var button = document.createElement('button');
+    button.setAttribute('class', 'scratchEyedropper');
     var image = document.createElement('img');
     image.src = Blockly.mainWorkspace.options.pathToMedia + Blockly.FieldColourSlider.EYEDROPPER_PATH;
     button.appendChild(image);


### PR DESCRIPTION
Only the last commit here is new, the others are the currently unmerged eyedropper pr, so ignore those. 


### Resolves

_What Github issue does this resolve (please include link)?_

This PR implements the hue, saturation, brightness color sliders instead of the color palette. 

![sliders](https://user-images.githubusercontent.com/654102/30130639-d1c1970a-9317-11e7-85d9-8b6aec52ea70.gif)

^ gifs quantize color space a lot, here is a still of those backgrounds

![image](https://user-images.githubusercontent.com/654102/30130734-32d69f04-9318-11e7-8c5f-b0952a36741f.png)


Resolves https://github.com/LLK/scratch-blocks/issues/460
