### PR TITLE
Add a border for colorpicker's palette colorswatch

### DIFF
--- a/core/css.js
+++ b/core/css.js
@@ -827,6 +827,7 @@ Blockly.Css.CONTENT = [
     'position: relative;',
     'height: 13px;',
     'width: 15px;',
+    'border: 1px solid #ccc;',
   '}',
 
   '.blocklyWidgetDiv .goog-palette-cell-hover .goog-palette-colorswatch {',


### PR DESCRIPTION
### Proposed Changes

Add a border for colorpicker's palette colorswatch

Each color item has a boder to others.

### Reason for Changes

Make colorpicker has a friendly interface
