### PR TITLE
Open field cache and leave it open

### DIFF
--- a/core/inject.js
+++ b/core/inject.js
@@ -58,6 +58,10 @@ Blockly.inject = function(container, opt_options) {
   var subContainer = goog.dom.createDom('div', 'injectionDiv');
   container.appendChild(subContainer);
 
+  // Open the Field text cache and leave it open. See this issue for more information
+  // https://github.com/LLK/scratch-blocks/issues/1004
+  Blockly.Field.startCache();
+
   var svg = Blockly.createDom_(subContainer, options);
 
   // Create surfaces for dragging things. These are optimizations


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Related issue https://github.com/LLK/scratch-blocks/issues/1004

### Proposed Changes

_Describe what this Pull Request does_

Open the field cache and leave it open. As @rachel-fenichel said:

>  I expect that something will break but don't know what. I've asked around and we don't know what problems aggressive caching has caused in the past.

We can see what breaks / if anything breaks and use this as a stepping stone to fixing caching. 
