### PR TITLE
Don't allow cycles in gesture cancelation

### DIFF
--- a/core/gesture.js
+++ b/core/gesture.js
@@ -510,8 +510,10 @@ Blockly.Gesture.prototype.cancel = function() {
   // Disposing of a block cancels in-progress drags, but dragging to a delete
   // area disposes of a block and leads to recursive disposal. Break that cycle.
   if (this.isEnding_) {
+    console.log('Trying to cancel a gesture recursively.');
     return;
   }
+  this.isEnding_ = true;
   Blockly.longStop_();
   if (this.isDraggingBlock_) {
     this.blockDragger_.endBlockDrag(this.mostRecentEvent_,


### PR DESCRIPTION
### Resolves

https://github.com/LLK/scratch-blocks/issues/1043

### Proposed Changes

Set the `isEnding_` flag when canceling a gesture, as well as when ending one.

### Reason for Changes

There was a cycle in the gesture cancelation if the dragging block would be deleted by canceling the gesture.

### Test Coverage

Tested in the vertical playground.
In testing I discovered https://github.com/LLK/scratch-blocks/issues/1089
