### PR TITLE
Add a function to duplicate a block and drag the duplicate

### DIFF
--- a/core/gesture.js
+++ b/core/gesture.js
@@ -793,6 +793,8 @@ Blockly.Gesture.prototype.hasStarted = function() {
   return this.hasStarted_;
 };
 
+/* Scratch-specific */
+
 /**
  * Don't even think about using this function before talking to rachel-fenichel.
  *
@@ -809,4 +811,34 @@ Blockly.Gesture.prototype.forceStartBlockDrag = function(fakeEvent, block) {
   this.isDraggingBlock_ = true;
   this.hasExceededDragRadius_ = true;
   this.startDraggingBlock_();
+};
+
+/**
+ * Duplicate the target block and start dragging the duplicated block.
+ * This should be done once we are sure that it is a block drag, and no earlier.
+ * @private
+ */
+Blockly.Gesture.prototype.duplicateOnDrag_ = function() {
+  var newBlock = null;
+  try {
+    // Note: targetBlock_ should have no children.  If it has children we would
+    // need to update shadow block IDs to avoid problems in the VM.
+    var xmlBlock = Blockly.Xml.blockToDom(this.targetBlock_);
+    newBlock = Blockly.Xml.domToBlock(xmlBlock, this.startWorkspace_);
+    // Move the duplicate to original position.
+    var xy = this.targetBlock_.getRelativeToSurfaceXY();
+    newBlock.moveBy(xy.x, xy.y);
+  } finally {
+    Blockly.Events.enable();
+  }
+  if (!newBlock) {
+    // Something went wrong.
+    console.error('Something went wrong while duplicating a block.');
+    return;
+  }
+  if (Blockly.Events.isEnabled()) {
+    Blockly.Events.fire(new Blockly.Events.BlockCreate(newBlock));
+  }
+  newBlock.select();
+  this.targetBlock_ = newBlock;
 };


### PR DESCRIPTION
### Resolves

#1092 

### Proposed Changes

Add a function that duplicates the gesture's target block and drags the new block instead of the original block.

I tested the function by using it on every drag, but in this PR I removed all calls to it.

### Reason for Changes

Custom procedure arguments need to have this behaviours.

### Test Coverage

Manually tested in chrome in the vertical playground by enabling it for all drags:
![ac1e9f4f-b0fa-430c-b23f-e7f1c0cd6965](https://user-images.githubusercontent.com/13686399/30759140-df72217a-9f89-11e7-8049-839fff827398.gif)

To enable it for all drags I inserted `this.duplicateOnDrag_()` as the first line of `Blockly.Gesture.prototype.startDraggingBlock_`.

I also checked that I can drag the duplicated block directly to the flyout to delete it with no issues.