### PR TITLE
Use graceful-fs to fix Webpack EMFILE errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "exports-loader": "0.6.3",
     "gh-pages": "0.12.0",
     "google-closure-library": "20160911.0.0",
+    "graceful-fs": "4.1.11",
     "imports-loader": "0.6.5",
     "json": "9.0.4",
     "travis-after-all": "1.4.4",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,3 +1,8 @@
+// patch 'fs' to fix EMFILE errors, for example on WSL
+var realFs = require('fs');
+var gracefulFs = require('graceful-fs');
+gracefulFs.gracefulify(realFs);
+
 var CopyWebpackPlugin = require('copy-webpack-plugin');
 var path = require('path');
 


### PR DESCRIPTION
### Reason for Changes

In some situations, including the Windows subsystem for Linux (WSL), Webpack can overwhelm the lazy file handle cleanup in Node.js and cause `EMFILE` errors. I believe this can also happen on non-Windows Linux systems if `ulimit` is used to impose a sufficiently small limit on file handles, though I haven't confirmed that personally. WSL is special because it currently has a relatively low file handle limit and doesn't yet support altering that limit.

### Proposed Changes

The [`graceful-fs`](https://github.com/isaacs/node-graceful-fs#readme) module handles this situation gracefully. This change asks `graceful-fs` to monkey-patch Node's `fs` module, allowing Webpack to complete.