### PR TITLE
Add UMD target for use without "require"/"import"

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,6 +13,18 @@ module.exports = [{
     filename: '[name].js'
   }
 }, {
+  entry: {
+    horizontal: './shim/horizontal.js',
+    vertical: './shim/vertical.js'
+  },
+  output: {
+    library: 'Blockly',
+    libraryTarget: 'umd',
+    path: path.resolve(__dirname, 'dist', 'web'),
+    filename: '[name].js'
+  }
+},
+{
   output: {
     filename: '[name].js',
     path: path.resolve(__dirname, 'gh-pages')


### PR DESCRIPTION
### Proposed Changes

_Describe what this Pull Request does_
Adds `dist/web/[vertical,horizontal].js` for use in a web page like
```html
<script type="text/javascript" src="./dist/web/vertical.js"></script>
<script type="text/javascript">
    console.log('Blockly exists!', Blockly);
</script>
```

### Reason for Changes

_Explain why these changes should be made_
Some people don't want to use webpack to use `scratch-blocks`.

### Test Coverage

_Please show how you have added tests to cover your changes_
N/A