### PR TITLE
Update category menu selection when dragging flyout or scrollbar

### DIFF
--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -566,6 +566,11 @@ Blockly.Flyout.prototype.recordCategoryScrollPositions_ = function() {
  * @package
  */
 Blockly.Flyout.prototype.selectCategoryByScrollPosition = function(pos) {
+  // If we are currently auto-scrolling, due to selecting a category by clicking on it,
+  // do not update the category selection.
+  if (this.scrollTarget) {
+    return;
+  }
   var workspacePos = pos / this.workspace_.scale;
   // Traverse the array of scroll positions in reverse, so we can select the furthest
   // category that the scroll position is beyond.
@@ -591,6 +596,7 @@ Blockly.Flyout.prototype.stepScrollAnimation = function() {
   var diff = this.scrollTarget - scrollPos;
   if (Math.abs(diff) < 1) {
     this.scrollbar_.set(this.scrollTarget);
+    this.scrollTarget = null;
     return;
   }
   this.scrollbar_.set(scrollPos + diff * this.scrollAnimationFraction);

--- a/core/flyout_horizontal.js
+++ b/core/flyout_horizontal.js
@@ -134,6 +134,10 @@ Blockly.HorizontalFlyout.prototype.setMetrics_ = function(xyRatio) {
 
   this.workspace_.translate(this.workspace_.scrollX + metrics.absoluteLeft,
       this.workspace_.scrollY + metrics.absoluteTop);
+
+  if (this.categoryScrollPositions) {
+    this.selectCategoryByScrollPosition(-this.workspace_.scrollX);
+  }
 };
 
 /**
@@ -298,8 +302,6 @@ Blockly.HorizontalFlyout.prototype.wheel_ = function(e) {
     // When the flyout moves from a wheel event, hide WidgetDiv and DropDownDiv.
     Blockly.WidgetDiv.hide(true);
     Blockly.DropDownDiv.hideWithoutAnimation();
-
-    this.selectCategoryByScrollPosition(pos);
   }
 
   // Don't scroll the page.

--- a/core/flyout_vertical.js
+++ b/core/flyout_vertical.js
@@ -239,6 +239,10 @@ Blockly.VerticalFlyout.prototype.setMetrics_ = function(xyRatio) {
 
   this.clipRect_.setAttribute('height', Math.max(0, metrics.viewHeight) + 'px');
   this.clipRect_.setAttribute('width', metrics.viewWidth + 'px');
+
+  if (this.categoryScrollPositions) {
+    this.selectCategoryByScrollPosition(-this.workspace_.scrollY);
+  }
 };
 
 /**
@@ -375,8 +379,6 @@ Blockly.VerticalFlyout.prototype.wheel_ = function(e) {
     // When the flyout moves from a wheel event, hide WidgetDiv and DropDownDiv.
     Blockly.WidgetDiv.hide(true);
     Blockly.DropDownDiv.hideWithoutAnimation();
-
-    this.selectCategoryByScrollPosition(pos);
   }
 
   // Don't scroll the page.


### PR DESCRIPTION
### Resolves

Resolves https://github.com/LLK/scratch-blocks/issues/1070

### Proposed Changes

Move the call to selectCategoryByScrollPosition into setMetrics, so that it is called on all the different types of scroll event (mouse wheel / touchpad scroll, dragging the flyout, dragging the scrollbar). 

This change also requires disabling the updates to category selection during auto-scrolling, so that when you click on a category button, it highlights and stays that way (rather than selecting the categories in between as the scrolling animates).

### Reason for Changes

Without this change, the category menu selection state gets out of sync with the flyout position when you scroll by dragging the flyout or the scrollbar.