### PR TITLE
Add a way to specify which blocks should be duplicated on drag, and e…

### DIFF
--- a/blocks_vertical/procedures.js
+++ b/blocks_vertical/procedures.js
@@ -179,3 +179,12 @@ Blockly.Blocks['procedures_param'] = {
     }
   }
 };
+
+Blockly.Blocks['argument_reporter_boolean'] = {
+  init: function() {
+    this.jsonInit({
+      "message0": "boolean1",
+      "extensions": ["colours_control", "output_boolean"]
+    });
+  }
+};


### PR DESCRIPTION
…nable it for the new argument_reporter_boolean block when it's a shadow

### Resolves

Part of #1110 

### Proposed Changes

Add a "shouldDuplicateOnDrag" property to gestures, and set it while setting the start block.
Set the target block to the start block (even if it's a shadow) if it should be duplicated on drag, and call gesture.duplicateOnDrag_ to update the drag target when a block drag starts.

Deciding which blocks to duplicate is currently done by inspecting the block type, but could later be generalized.

### Reason for Changes

Argument reporters have special behaviour.

### Test Coverage

Tested in the playground with the new argument_reporter_boolean block.