### PR TITLE
Public function to select a category and scroll to it

### DIFF
--- a/core/toolbox.js
+++ b/core/toolbox.js
@@ -348,13 +348,21 @@ Blockly.Toolbox.prototype.setSelectedItem = function(item) {
     this.selectedItem_.setSelected(true);
     // Scroll flyout to the top of the selected category
     var categoryName = item.name_;
-    var scrollPositions = this.flyout_.categoryScrollPositions;
-    for (var i = 0; i < scrollPositions.length; i++) {
-      if (categoryName === scrollPositions[i].categoryName) {
-        this.flyout_.setVisible(true);
-        this.flyout_.scrollTo(scrollPositions[i].position);
-        return;
-      }
+    this.scrollToCategoryByName(categoryName);
+  }
+};
+/**
+ * Scroll to a category by name.
+ * @param {string} name The name of the category to scroll to.
+ * @package
+ */
+Blockly.Toolbox.prototype.scrollToCategoryByName = function(name) {
+  var scrollPositions = this.flyout_.categoryScrollPositions;
+  for (var i = 0; i < scrollPositions.length; i++) {
+    if (name === scrollPositions[i].categoryName) {
+      this.flyout_.setVisible(true);
+      this.flyout_.scrollTo(scrollPositions[i].position);
+      return;
     }
   }
 };

--- a/core/toolbox.js
+++ b/core/toolbox.js
@@ -351,6 +351,16 @@ Blockly.Toolbox.prototype.setSelectedItem = function(item) {
     this.scrollToCategoryByName(categoryName);
   }
 };
+
+/**
+ * Select and scroll to a category by name.
+ * @param {string} name The name of the category to select and scroll to.
+ */
+Blockly.Toolbox.prototype.setSelectedCategoryByName = function(name) {
+  this.selectCategoryByName(name);
+  this.scrollToCategoryByName(name);
+};
+
 /**
  * Scroll to a category by name.
  * @param {string} name The name of the category to scroll to.


### PR DESCRIPTION
### Proposed Changes

Add a package level function for scrolling to a category by name, and a public function that both scrolls to a category and selects it by name.

### Reason for Changes

This function is needed for work in scratch-gui on adding extensions. When you select an extension from the extension library, once the new category of blocks has been added, the gui calls this function to select and scroll to it.