### PR TITLE
Fix variables with XML names not appearing

### DIFF
--- a/core/variables.js
+++ b/core/variables.js
@@ -378,7 +378,7 @@ Blockly.Variables.generateVariableFieldXml_ = function(variableModel, opt_name) 
   var name = opt_name || "VARIABLE";
   var xmlString = '<field name="' + name + '" ' + 'variableType="' +
       variableModel.type + '" id="' + variableModel.getId() + '">'+
-      variableModel.name +
+      goog.string.htmlEscape(variableModel.name) +
       '</field>';
   return xmlString;
 };


### PR DESCRIPTION
### Resolves

LLK/scratch-gui#665

Variables with XML names do not work. Two variables named `test` and `<b>test</b>` will both display identically as `test`, and only the one without XML will be updated. Additionally, anything with an `&` in it won't display at all, simply fail with no error (not even in the console).

### Proposed Changes

Escapes the variable name when using it in an XML context.

### Reason for Changes

To fix stated bug. The bug is actually in this codebase, despite being reported on the other one.

### Test Coverage

I didn't see a test file for the `variable.js` file, so there wasn't a natural place to add a test. Please let me know if and where i should add one.
