### PR TITLE
Render the internal custom block, and get the argument reporters right

### DIFF
--- a/blocks_vertical/procedures.js
+++ b/blocks_vertical/procedures.js
@@ -122,6 +122,95 @@ Blockly.Blocks['procedures_callnoreturn'] = {
     }
   }
 };
+Blockly.Blocks['procedures_callnoreturn_internal'] = {
+  /**
+   * Block for calling a procedure with no return value, for rendering inside
+   * define block.
+   * @this Blockly.Block
+   */
+  init: function() {
+    this.setPreviousStatement(true);
+    this.setNextStatement(true);
+    this.setCategory(Blockly.Categories.more);
+    this.setColour(Blockly.Colours.more.primary,
+      Blockly.Colours.more.secondary,
+      Blockly.Colours.more.tertiary);
+
+    /* Data known about the procedure. */
+    this.procCode_ = '';
+    this.argumentNames_ = [];
+    this.argumentDefaults_ = [];
+    this.warp_ = false;
+  },
+  /**
+   * Create XML to represent the (non-editable) name and arguments.
+   * @return {!Element} XML storage element.
+   * @this Blockly.Block
+   */
+  mutationToDom: function() {
+
+    var container = document.createElement('mutation');
+    container.setAttribute('proccode', this.procCode_);
+    container.setAttribute('argumentnames', JSON.stringify(this.argumentNames_));
+    container.setAttribute('argumentdefaults', JSON.stringify(this.argumentDefaults_));
+    container.setAttribute('warp', this.warp_);
+    return container;
+  },
+  /**
+   * Parse XML to restore the (non-editable) name and parameters.
+   * @param {!Element} xmlElement XML storage element.
+   * @this Blockly.Block
+   */
+  domToMutation: function(xmlElement) {
+    this.procCode_ = xmlElement.getAttribute('proccode');
+    this.argumentNames_ =  JSON.parse(xmlElement.getAttribute('argumentnames'));
+    this.argumentDefaults_ =  JSON.parse(xmlElement.getAttribute('argumentdefaults'));
+    this.warp_ = xmlElement.getAttribute('warp');
+    this.updateDisplay_();
+
+  },
+  updateDisplay_: function() {
+    // Split the proc into components, by %n, %b, and %s (ignoring escaped).
+    var procComponents = this.procCode_.split(/(?=[^\\]\%[nbs])/);
+    procComponents = procComponents.map(function(c) {
+      return c.trim(); // Strip whitespace.
+    });
+    // Create inputs and shadow blocks as appropriate.
+    var inputPrefix = 'input';
+    var inputCount = 0;
+    for (var i = 0, component; component = procComponents[i]; i++) {
+      var newLabel;
+      if (component.substring(0, 1) == '%') {
+        var inputType = component.substring(1, 2);
+        newLabel = component.substring(2).trim();
+        var inputName = inputPrefix + inputCount;
+        var blockType = '';
+        switch (inputType) {
+          case 'n':
+            blockType = 'argument_reporter_string_number';
+            break;
+          case 'b':
+            blockType = 'argument_reporter_boolean';
+            break;
+          case 's':
+            blockType = 'argument_reporter_string_number';
+            break;
+        }
+        if (blockType) {
+          var input = this.appendValueInput(inputName);
+          var newBlock = this.workspace.newBlock(blockType);
+          newBlock.setShadow(true);
+          newBlock.setFieldValue(this.argumentNames_[inputCount], "VALUE");
+          newBlock.outputConnection.connect(input.connection);
+        }
+        inputCount++;
+      } else {
+        newLabel = component.trim();
+      }
+      this.appendDummyInput().appendField(newLabel.replace(/\\%/, '%'));
+    }
+  }
+};
 
 Blockly.Blocks['procedures_param'] = {
   /**
@@ -182,9 +271,30 @@ Blockly.Blocks['procedures_param'] = {
 
 Blockly.Blocks['argument_reporter_boolean'] = {
   init: function() {
-    this.jsonInit({
-      "message0": "boolean1",
-      "extensions": ["colours_control", "output_boolean"]
+    this.jsonInit({ "message0": " %1",
+      "args0": [
+        {
+          "type": "field_label_editable",
+          "name": "VALUE",
+          "text": ""
+        }
+      ],
+      "extensions": ["colours_more", "output_boolean"]
+    });
+  }
+};
+
+Blockly.Blocks['argument_reporter_string_number'] = {
+  init: function() {
+    this.jsonInit({ "message0": " %1",
+      "args0": [
+        {
+          "type": "field_label_editable",
+          "name": "VALUE",
+          "text": ""
+        }
+      ],
+      "extensions": ["colours_more", "output_number", "output_string"]
     });
   }
 };

--- a/core/block.js
+++ b/core/block.js
@@ -31,6 +31,7 @@ goog.require('Blockly.Colours');
 goog.require('Blockly.Comment');
 goog.require('Blockly.Connection');
 goog.require('Blockly.Extensions');
+goog.require('Blockly.FieldLabelEditable');
 goog.require('Blockly.FieldVariableGetter');
 goog.require('Blockly.Input');
 goog.require('Blockly.Mutator');
@@ -1335,6 +1336,9 @@ Blockly.Block.prototype.interpolate_ = function(message, args, lastDummyAlign) {
             case 'field_label':
               field = Blockly.Block.newFieldLabelFromJson_(element);
               break;
+            case 'field_label_editable':
+              field = Blockly.Block.newFieldLabelEditableFromJson_(element);
+              break;
             case 'field_input':
               field = Blockly.Block.newFieldTextInputFromJson_(element);
               break;
@@ -1442,6 +1446,18 @@ Blockly.Block.newFieldImageFromJson_ = function(options) {
 Blockly.Block.newFieldLabelFromJson_ = function(options) {
   var text = Blockly.utils.replaceMessageReferences(options['text']);
   return new Blockly.FieldLabel(text, options['class']);
+};
+
+/**
+ * Helper function to construct a FieldLabelEditable from a JSON arg object,
+ * dereferencing any string table references.
+ * @param {!Object} options A JSON object with options (text, and class).
+ * @returns {!Blockly.FieldLabelEditable} The new label.
+ * @private
+ */
+Blockly.Block.newFieldLabelEditableFromJson_ = function(options) {
+  var text = Blockly.utils.replaceMessageReferences(options['text']);
+  return new Blockly.FieldLabelEditable(text, options['class']);
 };
 
 /**

--- a/core/field_label_editable.js
+++ b/core/field_label_editable.js
@@ -52,30 +52,12 @@ goog.inherits(Blockly.FieldLabelEditable, Blockly.FieldLabel);
 Blockly.FieldLabelEditable.prototype.EDITABLE = true;
 
 /**
- * Returns the height and width of the field.
- * @return {!goog.math.Size} Height and width.
- */
-Blockly.FieldLabelEditable.prototype.getSize = function() {
-  if (!this.size_.width) {
-    this.render_();
-  }
-  return this.size_;
-};
-
-/**
  * Updates the width of the field. This calls getCachedWidth which won't cache
  * the approximated width on IE/Edge when `getComputedTextLength` fails. Once
  * it eventually does succeed, the result will be cached.
  **/
 Blockly.FieldLabelEditable.prototype.updateWidth = function() {
-  // Calculate width of field
-  var width = Blockly.Field.getCachedWidth(this.textElement_);
-
-  // Add padding to any drawn box.
-  if (this.box_) {
-    width += 2 * Blockly.BlockSvg.BOX_FIELD_PADDING;
-  }
-
   // Set width of the field.
-  this.size_.width = width;
+  // Unlike a the base Field class, this doesn't add space to editable fields.
+  this.size_.width = Blockly.Field.getCachedWidth(this.textElement_);
 };

--- a/core/field_label_editable.js
+++ b/core/field_label_editable.js
@@ -1,0 +1,81 @@
+/**
+ * @license
+ * Visual Blocks Editor
+ *
+ * Copyright 2017 Google Inc.
+ * https://developers.google.com/blockly/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Serialized label field.  Behaves like a normal label but is
+ *     always serialized to XML.
+ * @author fenichel@google.com (Rachel Fenichel)
+ */
+'use strict';
+
+goog.provide('Blockly.FieldLabelEditable');
+
+goog.require('Blockly.FieldLabel');
+
+
+/**
+ * Class for a variable getter field.
+ * @param {string} text The initial content of the field.
+ * @param {string} opt_class Optional CSS class for the field's text.
+ * @extends {Blockly.FieldLabel}
+ * @constructor
+ *
+ */
+Blockly.FieldLabelEditable = function(text, opt_class) {
+  Blockly.FieldLabelEditable.superClass_.constructor.call(this, text,
+      opt_class);
+  // Used in base field rendering, but we don't need it.
+  this.arrowWidth_ = 0;
+};
+goog.inherits(Blockly.FieldLabelEditable, Blockly.FieldLabel);
+
+/**
+ * Editable fields are saved by the XML renderer, non-editable fields are not.
+ */
+Blockly.FieldLabelEditable.prototype.EDITABLE = true;
+
+/**
+ * Returns the height and width of the field.
+ * @return {!goog.math.Size} Height and width.
+ */
+Blockly.FieldLabelEditable.prototype.getSize = function() {
+  if (!this.size_.width) {
+    this.render_();
+  }
+  return this.size_;
+};
+
+/**
+ * Updates the width of the field. This calls getCachedWidth which won't cache
+ * the approximated width on IE/Edge when `getComputedTextLength` fails. Once
+ * it eventually does succeed, the result will be cached.
+ **/
+Blockly.FieldLabelEditable.prototype.updateWidth = function() {
+  // Calculate width of field
+  var width = Blockly.Field.getCachedWidth(this.textElement_);
+
+  // Add padding to any drawn box.
+  if (this.box_) {
+    width += 2 * Blockly.BlockSvg.BOX_FIELD_PADDING;
+  }
+
+  // Set width of the field.
+  this.size_.width = width;
+};

--- a/core/gesture.js
+++ b/core/gesture.js
@@ -828,6 +828,7 @@ Blockly.Gesture.prototype.forceStartBlockDrag = function(fakeEvent, block) {
 /**
  * Duplicate the target block and start dragging the duplicated block.
  * This should be done once we are sure that it is a block drag, and no earlier.
+ * Specifically for argument reporters in custom block defintions.
  * @private
  */
 Blockly.Gesture.prototype.duplicateOnDrag_ = function() {
@@ -841,6 +842,9 @@ Blockly.Gesture.prototype.duplicateOnDrag_ = function() {
     var xy = this.targetBlock_.getRelativeToSurfaceXY();
     newBlock.moveBy(xy.x, xy.y);
     newBlock.setShadow(false);
+    // Preserve the label when copying
+    //newBlock.getField("VALUE").setValue(this.targetBlock_.getFieldValue("VALUE"));
+    //newBlock.getField("VALUE").EDITABLE = true;
   } finally {
     Blockly.Events.enable();
   }
@@ -868,5 +872,6 @@ Blockly.Gesture.prototype.duplicateOnDrag_ = function() {
  */
 Blockly.Gesture.prototype.setShouldDuplicateOnDrag_ = function(block) {
   this.shouldDuplicateOnDrag_ =
-      block.isShadow() && block.type == 'argument_reporter_boolean';
+      block.isShadow() && (block.type == 'argument_reporter_boolean' ||
+      block.type == 'argument_reporter_string_number');
 };

--- a/core/gesture.js
+++ b/core/gesture.js
@@ -842,9 +842,6 @@ Blockly.Gesture.prototype.duplicateOnDrag_ = function() {
     var xy = this.targetBlock_.getRelativeToSurfaceXY();
     newBlock.moveBy(xy.x, xy.y);
     newBlock.setShadow(false);
-    // Preserve the label when copying
-    //newBlock.getField("VALUE").setValue(this.targetBlock_.getFieldValue("VALUE"));
-    //newBlock.getField("VALUE").EDITABLE = true;
   } finally {
     Blockly.Events.enable();
   }


### PR DESCRIPTION
### Resolves

Part of https://github.com/LLK/scratch-blocks/issues/1110 and part of https://github.com/LLK/scratch-blocks/issues/1102 and https://github.com/LLK/scratch-blocks/issues/1092

### Proposed Changes

Define a version of the custom command block for rendering inside the define block.  It uses the same mutation structure as the procedure_defnoreturn block was using before, so it should be easy to integrate into scratch-vm and scratch-gui--I'm happy to chat with someone about that tomorrow.

I've also added field_label_editable.js.  It represents a label that should be serialized when saving blocks, since the text of the argument reporters is always set programmatically.

There are also new argument reporters, which duplicate correctly.  And they get their text set according to the name in the procedure definition.

### Reason for Changes

Part of implementing custom procedures.

### Test Coverage

To test, open up the vertical playground and put this in the text box:
```
<xml xmlns="http://www.w3.org/1999/xhtml">
<variables>
</variables>
<block id="]){{Y!7N9ezN+j@Vr`8p" type="procedures_defnoreturn" x="47.175" y="91.96000000000001">
    <statement name="custom_block">
        <shadow type="procedures_callnoreturn_internal">
            <mutation proccode="say %s %n times if %b" argumentnames="[&quot;something&quot;,&quot;this many&quot;,&quot;this is true&quot;]" argumentdefaults="[&quot;&quot;,42,false]" warp="false"/>
        </shadow>
    </statement>
    <next>
        <block id="tIVT2u+!X}IS8z4nu1x9" type="procedures_callnoreturn">
            <mutation proccode="say %s %n times if %b"/>
            <value name="input0">
                <shadow id="V0~M:TxRk0Ua%osjGzh," type="text">
                    <field name="TEXT"/>
                </shadow>
            </value>
            <value name="input1">
                <shadow id="uPx3si(KkbL1)-XpbXoQ" type="math_number">
                    <field name="NUM">1</field>
                </shadow>
            </value>
        </block>
    </next>
</block>
</xml>
```

Hit "Import from XML".  It should look like this: 
![image](https://user-images.githubusercontent.com/13686399/31263737-023ff2ce-aa19-11e7-92d3-2f7bb1ce87d1.png)

You can drag the "something", "this many", and "this is true" blocks out, and they'll duplicate on drag.  When used elsewhere they will not duplicate on drag.

![679ca3a3-c5af-4d0d-846d-e30994556392](https://user-images.githubusercontent.com/13686399/31263798-65a82840-aa19-11e7-89de-47aca768d61d.gif)
