### PR TITLE
Add a bulkUpdate flag to avoid expensive operations (such as toolbox …

### DIFF
--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -453,7 +453,7 @@ Blockly.Flyout.prototype.hide = function() {
  *     Variables and procedures have a custom set of blocks.
  */
 Blockly.Flyout.prototype.show = function(xmlList) {
-  this.workspace_.setResizesEnabled(false);
+  this.workspace_.setBulkUpdate(true);
   this.hide();
   this.clearOldBlocks_();
 
@@ -529,7 +529,7 @@ Blockly.Flyout.prototype.show = function(xmlList) {
   this.listeners_.push(Blockly.bindEvent_(this.svgBackground_, 'mouseover',
       this, deselectAll));
 
-  this.workspace_.setResizesEnabled(true);
+  this.workspace_.setBulkUpdate(false);
   this.reflow();
 
   // Correctly position the flyout's scrollbar when it opens.

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1818,7 +1818,7 @@ Blockly.WorkspaceSvg.prototype.setBulkUpdate = function(enabled) {
   // This will trigger a resize if necessary.
   this.setResizesEnabled(enabled);
   var stoppedUpdating = (this.isBulkUpdating_ && !enabled);
-  this.isBulkUpdating_ = stoppedUpdating;
+  this.isBulkUpdating_ = enabled;
   if (stoppedUpdating) {
     // Refresh the toolbox.
     if (this.toolbox_) {

--- a/core/xml.js
+++ b/core/xml.js
@@ -331,8 +331,8 @@ Blockly.Xml.domToWorkspace = function(xml, workspace) {
   }
 
   // Disable workspace resizes as an optimization.
-  if (workspace.setResizesEnabled) {
-    workspace.setResizesEnabled(false);
+  if (workspace.setBulkUpdate) {
+    workspace.setBulkUpdate(true);
   }
   var variablesFirst = true;
   try {
@@ -376,8 +376,8 @@ Blockly.Xml.domToWorkspace = function(xml, workspace) {
   }
   workspace.updateVariableStore(false);
   // Re-enable workspace resizing.
-  if (workspace.setResizesEnabled) {
-    workspace.setResizesEnabled(true);
+  if (workspace.setBulkUpdate) {
+    workspace.setBulkUpdate(false);
   }
   return newBlockIds;
 };


### PR DESCRIPTION
…refresh) during workspace loading.

### Resolves

This is a new version of #925, which fixes #887.

### Proposed Changes

Add a bulkUpdate flag to workspaceSvg.  Use it to toggle resizeEnabled as well as other behaviours, such as refreshing the toolbox selection.

### Reason for Changes

The toolbox is getting thrashed by relayout every time a new variable is added during a workspace load.  It's better to wait until the end and do a single large update.

### Test Coverage

Tested by running sprinkles, exporting to xml, clearing the workspace, and importing from XML.  It felt faster.