### PR TITLE
Add correct padding on argument reporters

### DIFF
--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -873,7 +873,8 @@ Blockly.BlockSvg.prototype.computeInputWidth_ = function(input) {
  */
 Blockly.BlockSvg.prototype.computeInputHeight_ = function(input, row,
     previousRow) {
-  if (this.inputList.length === 1 && this.isShadow() && this.outputConnection) {
+  if (this.inputList.length === 1 && this.outputConnection &&
+      (this.isShadow() &&  !Blockly.utils.shouldDuplicateOnDrag(this))) {
     // "Lone" field blocks are smaller.
     return Blockly.BlockSvg.MIN_BLOCK_Y_SINGLE_FIELD_OUTPUT;
   } else if (this.outputConnection) {
@@ -952,7 +953,8 @@ Blockly.BlockSvg.prototype.computeRightEdge_ = function(curEdge, hasStatement) {
  */
 Blockly.BlockSvg.prototype.computeOutputPadding_ = function(inputRows) {
   // Only apply to blocks with outputs and not single fields (shadows).
-  if (!this.getOutputShape() || !this.outputConnection || this.isShadow()) {
+  if (!this.getOutputShape() || !this.outputConnection ||
+      (this.isShadow() && !Blockly.utils.shouldDuplicateOnDrag(this))) {
     return;
   }
   // Blocks with outputs must have single row to be padded.

--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -874,7 +874,7 @@ Blockly.BlockSvg.prototype.computeInputWidth_ = function(input) {
 Blockly.BlockSvg.prototype.computeInputHeight_ = function(input, row,
     previousRow) {
   if (this.inputList.length === 1 && this.outputConnection &&
-      (this.isShadow() &&  !Blockly.utils.shouldDuplicateOnDrag(this))) {
+      (this.isShadow() &&  !Blockly.utils.isShadowArgumentReporter(this))) {
     // "Lone" field blocks are smaller.
     return Blockly.BlockSvg.MIN_BLOCK_Y_SINGLE_FIELD_OUTPUT;
   } else if (this.outputConnection) {
@@ -954,7 +954,7 @@ Blockly.BlockSvg.prototype.computeRightEdge_ = function(curEdge, hasStatement) {
 Blockly.BlockSvg.prototype.computeOutputPadding_ = function(inputRows) {
   // Only apply to blocks with outputs and not single fields (shadows).
   if (!this.getOutputShape() || !this.outputConnection ||
-      (this.isShadow() && !Blockly.utils.shouldDuplicateOnDrag(this))) {
+      (this.isShadow() && !Blockly.utils.isShadowArgumentReporter(this))) {
     return;
   }
   // Blocks with outputs must have single row to be padded.

--- a/core/field_label_editable.js
+++ b/core/field_label_editable.js
@@ -58,6 +58,6 @@ Blockly.FieldLabelEditable.prototype.EDITABLE = true;
  **/
 Blockly.FieldLabelEditable.prototype.updateWidth = function() {
   // Set width of the field.
-  // Unlike a the base Field class, this doesn't add space to editable fields.
+  // Unlike the base Field class, this doesn't add space to editable fields.
   this.size_.width = Blockly.Field.getCachedWidth(this.textElement_);
 };

--- a/core/gesture.js
+++ b/core/gesture.js
@@ -694,7 +694,7 @@ Blockly.Gesture.prototype.setStartField = function(field) {
 Blockly.Gesture.prototype.setStartBlock = function(block) {
   if (!this.startBlock_) {
     this.startBlock_ = block;
-    this.shouldDuplicateOnDrag_ = Blockly.utils.shouldDuplicateOnDrag(block);
+    this.shouldDuplicateOnDrag_ = Blockly.utils.isShadowArgumentReporter(block);
     if (block.isInFlyout && block != block.getRootBlock()) {
       this.setTargetBlock_(block.getRootBlock());
     } else {

--- a/core/gesture.js
+++ b/core/gesture.js
@@ -694,7 +694,7 @@ Blockly.Gesture.prototype.setStartField = function(field) {
 Blockly.Gesture.prototype.setStartBlock = function(block) {
   if (!this.startBlock_) {
     this.startBlock_ = block;
-    this.setShouldDuplicateOnDrag_(block);
+    this.shouldDuplicateOnDrag_ = Blockly.utils.shouldDuplicateOnDrag(block);
     if (block.isInFlyout && block != block.getRootBlock()) {
       this.setTargetBlock_(block.getRootBlock());
     } else {
@@ -855,20 +855,4 @@ Blockly.Gesture.prototype.duplicateOnDrag_ = function() {
   }
   newBlock.select();
   this.targetBlock_ = newBlock;
-};
-
-/**
- * Set whether to duplicate the target block at the beginning of a drag.  This
- * can be used to drag a shadow block out of a parent block and leave a copy
- * in place, e.g. in a for custom block argument reporters in Scratch.
- * As a side effect, the target block is set to be the start block instead of
- * the first non-shadow parent.
- * @param {!Blockly.BlockSvg} block The block that should be used to make this
- *     decision.
- * @private
- */
-Blockly.Gesture.prototype.setShouldDuplicateOnDrag_ = function(block) {
-  this.shouldDuplicateOnDrag_ =
-      block.isShadow() && (block.type == 'argument_reporter_boolean' ||
-      block.type == 'argument_reporter_string_number');
 };

--- a/core/utils.js
+++ b/core/utils.js
@@ -932,7 +932,6 @@ Blockly.utils.setCssTransform = function(node, transform) {
   node.style['-webkit-transform'] = transform;
 };
 
-
 /**
  * Re-assign obscured shadow blocks new IDs to prevent collisions
  * Scratch specific to help the VM handle deleting obscured shadows.
@@ -953,4 +952,20 @@ Blockly.utils.changeObscuredShadowIds = function(block) {
       }
     }
   }
+};
+
+/**
+ * Whether to duplicate this block at the beginning of a drag.  This can be used
+ * to drag a shadow block out of a parent block and leave a copy in place, e.g.
+ * for custom block argument reporters in Scratch.
+ * As a side effect, the target block is set to be the start block instead of
+ * the first non-shadow parent.
+ * @param {!Blockly.BlockSvg} block The block that should be used to make this
+ *     decision.
+ * @return {boolean} True if the block should be duplicated on drag.
+ * @package
+ */
+Blockly.utils.shouldDuplicateOnDrag = function(block) {
+  return (block.isShadow() && (block.type == 'argument_reporter_boolean' ||
+      block.type == 'argument_reporter_string_number'));
 };

--- a/core/utils.js
+++ b/core/utils.js
@@ -955,17 +955,16 @@ Blockly.utils.changeObscuredShadowIds = function(block) {
 };
 
 /**
- * Whether to duplicate this block at the beginning of a drag.  This can be used
- * to drag a shadow block out of a parent block and leave a copy in place, e.g.
- * for custom block argument reporters in Scratch.
- * As a side effect, the target block is set to be the start block instead of
- * the first non-shadow parent.
+ * Whether a block is both a shadow block and an argument reporter.  These
+ * blocks have special behaviour in scratch-blocks: they're duplicated when
+ * dragged, and they are rendered slightly differently from normal shadow
+ * blocks.
  * @param {!Blockly.BlockSvg} block The block that should be used to make this
  *     decision.
  * @return {boolean} True if the block should be duplicated on drag.
  * @package
  */
-Blockly.utils.shouldDuplicateOnDrag = function(block) {
+Blockly.utils.isShadowArgumentReporter = function(block) {
   return (block.isShadow() && (block.type == 'argument_reporter_boolean' ||
       block.type == 'argument_reporter_string_number'));
 };


### PR DESCRIPTION
### Resolves

#1111 

### Proposed Changes

Moves `shouldDuplicateOnDrag` into Blockly.utils and uses it to decide how much padding a field gets in render.

### Reason for Changes

Argument reporters weren't getting enough padding, because they are single-argument blocks that are shadows.  The padding was changing when the blocks were duplicated and unshadowed, which was very noticeable.

### Test Coverage

Checked visually in the playground.  Other blocks still look right.

![image](https://user-images.githubusercontent.com/13686399/31360535-b6a72b50-ad03-11e7-9205-273103c8df87.png)
