### PR TITLE
Make shadow argument reporters pop out visually

### DIFF
--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -27,6 +27,7 @@
 goog.provide('Blockly.BlockSvg.render');
 
 goog.require('Blockly.BlockSvg');
+goog.require('Blockly.utils');
 
 
 // UI constants for rendering blocks.
@@ -490,7 +491,10 @@ Blockly.BlockSvg.DEFINE_BLOCK_TYPE = 'procedures_defnoreturn';
  */
 Blockly.BlockSvg.prototype.updateColour = function() {
   var strokeColour = this.getColourTertiary();
-  if (this.isShadow() && this.parentBlock_) {
+  var renderShadowed =
+      this.isShadow() && !Blockly.utils.isShadowArgumentReporter(this);
+
+  if (renderShadowed && this.parentBlock_) {
     // Pull shadow block stroke colour from parent block's tertiary if possible.
     strokeColour = this.parentBlock_.getColourTertiary();
     // Special case: if we contain a colour field, set to a special stroke colour.
@@ -506,8 +510,11 @@ Blockly.BlockSvg.prototype.updateColour = function() {
   this.svgPath_.setAttribute('stroke', strokeColour);
 
   // Render block fill
-  var fillColour = (this.isGlowingBlock_ || this.isShadow()) ?
-      this.getColourSecondary() : this.getColour();
+  if (this.isGlowingBlock_ || renderShadowed) {
+    var fillColour = this.getColourSecondary();
+  } else {
+    var fillColour = this.getColour();
+  }
   this.svgPath_.setAttribute('fill', fillColour);
 
   // Render opacity


### PR DESCRIPTION
### Resolves

Part of https://github.com/LLK/scratch-blocks/issues/1110

### Proposed Changes

Make shadow argument reporters render with non-shadow colors.

### Reason for Changes

To make shadow argument reporters stand out visually from their parent block.

### Test Coverage

Checked visually in the playground: All blocks are rendering normally, and a custom block definition now looks like this:
![image](https://user-images.githubusercontent.com/13686399/31408881-d025314c-adbe-11e7-9ae3-da5c99e55e11.png)
