### PR TITLE
Fix resizesEnabled flag from bulkUpdating change

### DIFF
--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1816,7 +1816,7 @@ Blockly.WorkspaceSvg.prototype.setResizesEnabled = function(enabled) {
  */
 Blockly.WorkspaceSvg.prototype.setBulkUpdate = function(enabled) {
   // This will trigger a resize if necessary.
-  this.setResizesEnabled(enabled);
+  this.setResizesEnabled(!enabled); // Disable resizes when enabling bulk update
   var stoppedUpdating = (this.isBulkUpdating_ && !enabled);
   this.isBulkUpdating_ = enabled;
   if (stoppedUpdating) {


### PR DESCRIPTION
@rachel-fenichel in the `bulkUpdating` change, the `resizesEnabled` flag was being set to be the same as the `isBulkUpdating` flag. However, they really should be opposites: `resizesEnabled = false` when `isBulkUpdating = true`, and vice versa. 