### PR TITLE
Context menus on procedure definition blocks

### DIFF
--- a/blocks_vertical/procedures.js
+++ b/blocks_vertical/procedures.js
@@ -43,11 +43,10 @@ Blockly.Blocks['procedures_defnoreturn'] = {
           "name": "custom_block"
         }
       ],
-      "extensions": ["colours_more", "shape_hat"]
+      "extensions": ["colours_more", "shape_hat", "procedure_def_contextmenu"]
     });
   }
 };
-
 
 Blockly.Blocks['procedures_callnoreturn'] = {
   /**
@@ -122,6 +121,7 @@ Blockly.Blocks['procedures_callnoreturn'] = {
     }
   }
 };
+
 Blockly.Blocks['procedures_callnoreturn_internal'] = {
   /**
    * Block for calling a procedure with no return value, for rendering inside

--- a/blocks_vertical/vertical_extensions.js
+++ b/blocks_vertical/vertical_extensions.js
@@ -141,6 +141,52 @@ Blockly.ScratchBlocks.VerticalExtensions.OUTPUT_BOOLEAN = function() {
   this.setOutput(true, 'Boolean');
 };
 
+
+
+/**
+ * Mixin to add a context menu for a procedure definition block.
+ * It adds the "edit" option and removes the "duplicate" option.
+ * @mixin
+ * @augments Blockly.Block
+ * @package
+ * @readonly
+ */
+Blockly.ScratchBlocks.VerticalExtensions.PROCEDURE_DEF_CONTEXTMENU = {
+  /**
+   * Add the "edit" option and removes the "duplicate" option from the context
+   * menu.
+   * @param {!Array.<!Object>} menuOptions List of menu options to edit.
+   * @this Blockly.Block
+   */
+  customContextMenu: function(menuOptions) {
+    // Add the edit option at the end.
+    var editOption = {
+      enabled: true,
+      text: Blockly.Msg.EDIT_FUNCTION,
+      callback: function() {
+        alert('TODO(#603): implement function editing');
+      }
+    };
+    menuOptions.push(editOption);
+
+    // Find the delete option and update its callback to be specific to functions.
+    for (var i = 0, option; option = menuOptions[i]; i++) {
+      if (option.text == Blockly.Msg.DELETE_BLOCK) {
+        option.callback = function() {
+          alert('TODO(#1130): implement function deletion');
+        };
+      }
+    }
+    // Find and remove the duplicate option
+    for (var i = 0, option; option = menuOptions[i]; i++) {
+      if (option.text == Blockly.Msg.DUPLICATE_BLOCK) {
+        menuOptions.splice(i, 1);
+        break;
+      }
+    }
+  }
+};
+
 /**
  * Register all extensions for scratch-blocks.
  * @package
@@ -175,6 +221,10 @@ Blockly.ScratchBlocks.VerticalExtensions.registerAll = function() {
       Blockly.ScratchBlocks.VerticalExtensions.OUTPUT_STRING);
   Blockly.Extensions.register('output_boolean',
       Blockly.ScratchBlocks.VerticalExtensions.OUTPUT_BOOLEAN);
+
+  // Custom procedures have interesting context menus.
+  Blockly.Extensions.registerMixin('procedure_def_contextmenu',
+      Blockly.ScratchBlocks.VerticalExtensions.PROCEDURE_DEF_CONTEXTMENU);
 };
 
 Blockly.ScratchBlocks.VerticalExtensions.registerAll();

--- a/blocks_vertical/vertical_extensions.js
+++ b/blocks_vertical/vertical_extensions.js
@@ -162,7 +162,7 @@ Blockly.ScratchBlocks.VerticalExtensions.PROCEDURE_DEF_CONTEXTMENU = {
     // Add the edit option at the end.
     var editOption = {
       enabled: true,
-      text: Blockly.Msg.EDIT_FUNCTION,
+      text: Blockly.Msg.EDIT_PROCEDURE,
       callback: function() {
         alert('TODO(#603): implement function editing');
       }

--- a/msg/messages.js
+++ b/msg/messages.js
@@ -109,8 +109,8 @@ Blockly.Msg.HELP = 'Help';
 Blockly.Msg.UNDO = 'Undo';
 /// context menu - Undo the previous undo action.\n{{Identical|Redo}}
 Blockly.Msg.REDO = 'Redo';
-/// context menu - Edit the currently selected function
-Blockly.Msg.EDIT_FUNCTION = 'Edit';
+/// context menu - Edit the currently selected procedure.
+Blockly.Msg.EDIT_PROCEDURE = 'Edit';
 
 // Variable renaming.
 /// prompt - This message is only seen in the Opera browser.  With most browsers, users can edit numeric values in blocks by just clicking and typing.  Opera does not allows this, so we have to open a new window and prompt users with this message to chanage a value.

--- a/msg/messages.js
+++ b/msg/messages.js
@@ -109,6 +109,8 @@ Blockly.Msg.HELP = 'Help';
 Blockly.Msg.UNDO = 'Undo';
 /// context menu - Undo the previous undo action.\n{{Identical|Redo}}
 Blockly.Msg.REDO = 'Redo';
+/// context menu - Edit the currently selected function
+Blockly.Msg.EDIT_FUNCTION = 'Edit';
 
 // Variable renaming.
 /// prompt - This message is only seen in the Opera browser.  With most browsers, users can edit numeric values in blocks by just clicking and typing.  Opera does not allows this, so we have to open a new window and prompt users with this message to chanage a value.


### PR DESCRIPTION
### Resolves

#1118 

### Proposed Changes

Gives the `procedure_defnoreturn` block a custom context menu.  It has no duplicate option, but has an edit option.  

Function editing and deletion are not implemented, but there are placeholder callbacks for them.

### Reason for Changes

To make custom procedures work!

### Test Coverage

![image](https://user-images.githubusercontent.com/13686399/31471403-701d13ac-ae9d-11e7-9280-c78a5cce46b5.png)
