### PR TITLE
Custom context menu for procedure calls

### DIFF
--- a/blocks_vertical/procedures.js
+++ b/blocks_vertical/procedures.js
@@ -54,13 +54,10 @@ Blockly.Blocks['procedures_callnoreturn'] = {
    * @this Blockly.Block
    */
   init: function() {
-    this.setPreviousStatement(true);
-    this.setNextStatement(true);
-    this.setCategory(Blockly.Categories.more);
-    this.setColour(Blockly.Colours.more.primary,
-      Blockly.Colours.more.secondary,
-      Blockly.Colours.more.tertiary);
-    this._procCode = '';
+    this.jsonInit({
+      "extensions": ["colours_more", "shape_statement", "procedure_call_contextmenu"]
+    });
+    this.procCode_ = '';
   },
   /**
    * Create XML to represent the (non-editable) name and arguments.
@@ -69,7 +66,7 @@ Blockly.Blocks['procedures_callnoreturn'] = {
    */
   mutationToDom: function() {
     var container = document.createElement('mutation');
-    container.setAttribute('proccode', this._procCode);
+    container.setAttribute('proccode', this.procCode_);
     return container;
   },
   /**
@@ -78,12 +75,12 @@ Blockly.Blocks['procedures_callnoreturn'] = {
    * @this Blockly.Block
    */
   domToMutation: function(xmlElement) {
-    this._procCode = xmlElement.getAttribute('proccode');
+    this.procCode_ = xmlElement.getAttribute('proccode');
     this._updateDisplay();
   },
   _updateDisplay: function() {
     // Split the proc into components, by %n, %b, and %s (ignoring escaped).
-    var procComponents = this._procCode.split(/(?=[^\\]\%[nbs])/);
+    var procComponents = this.procCode_.split(/(?=[^\\]\%[nbs])/);
     procComponents = procComponents.map(function(c) {
       return c.trim(); // Strip whitespace.
     });

--- a/blocks_vertical/vertical_extensions.js
+++ b/blocks_vertical/vertical_extensions.js
@@ -141,8 +141,6 @@ Blockly.ScratchBlocks.VerticalExtensions.OUTPUT_BOOLEAN = function() {
   this.setOutput(true, 'Boolean');
 };
 
-
-
 /**
  * Mixin to add a context menu for a procedure definition block.
  * It adds the "edit" option and removes the "duplicate" option.
@@ -160,14 +158,7 @@ Blockly.ScratchBlocks.VerticalExtensions.PROCEDURE_DEF_CONTEXTMENU = {
    */
   customContextMenu: function(menuOptions) {
     // Add the edit option at the end.
-    var editOption = {
-      enabled: true,
-      text: Blockly.Msg.EDIT_PROCEDURE,
-      callback: function() {
-        alert('TODO(#603): implement function editing');
-      }
-    };
-    menuOptions.push(editOption);
+    menuOptions.push(Blockly.Procedures.makeEditOption(this));
 
     // Find the delete option and update its callback to be specific to functions.
     for (var i = 0, option; option = menuOptions[i]; i++) {
@@ -187,6 +178,25 @@ Blockly.ScratchBlocks.VerticalExtensions.PROCEDURE_DEF_CONTEXTMENU = {
   }
 };
 
+/**
+ * Mixin to add a context menu for a procedure call block.
+ * It adds the "edit" option and the "define" option.
+ * @mixin
+ * @augments Blockly.Block
+ * @package
+ * @readonly
+ */
+Blockly.ScratchBlocks.VerticalExtensions.PROCEDURE_CALL_CONTEXTMENU = {
+  /**
+   * Add the "edit" and "go to definition" options to the context menu.
+   * @param {!Array.<!Object>} menuOptions List of menu options to edit.
+   * @this Blockly.Block
+   */
+  customContextMenu: function(menuOptions) {
+    menuOptions.push(Blockly.Procedures.makeEditOption(this));
+    menuOptions.push(Blockly.Procedures.makeShowDefinitionOption(this));
+  }
+};
 /**
  * Register all extensions for scratch-blocks.
  * @package
@@ -225,6 +235,8 @@ Blockly.ScratchBlocks.VerticalExtensions.registerAll = function() {
   // Custom procedures have interesting context menus.
   Blockly.Extensions.registerMixin('procedure_def_contextmenu',
       Blockly.ScratchBlocks.VerticalExtensions.PROCEDURE_DEF_CONTEXTMENU);
+  Blockly.Extensions.registerMixin('procedure_call_contextmenu',
+      Blockly.ScratchBlocks.VerticalExtensions.PROCEDURE_CALL_CONTEXTMENU);
 };
 
 Blockly.ScratchBlocks.VerticalExtensions.registerAll();

--- a/core/procedures.js
+++ b/core/procedures.js
@@ -316,3 +316,81 @@ Blockly.Procedures.getDefinition = function(name, workspace) {
   }
   return null;
 };
+
+/**
+ * Callback to open the modal for editing custom procedures.
+ * TODO(#603): Implement.
+ * @param {!Blockly.Block} block The block that was right-clicked.
+ * @private
+ */
+Blockly.Procedures.editProcedureCallback_ = function(block) {
+  if (block.type == 'procedures_defnoreturn') {
+    var input = block.getInput('custom_block');
+    if (!input) {
+      alert('Bad input'); // TODO: Decide what to do about this.
+      return;
+    }
+    var conn = input.connection;
+    if (!conn) {
+      alert('Bad connection'); // TODO: Decide what to do about this.
+      return;
+    }
+    var innerBlock = conn.targetBlock();
+    if (!innerBlock || !innerBlock.type == 'procedures_callnoreturn_internal') {
+      alert('Bad inner block'); // TODO: Decide what to do about this.
+      return;
+    }
+    block = innerBlock;
+  }
+  alert('TODO(#603): implement function editing (procCode was "' +
+      block.procCode_ + '")');
+};
+
+/**
+ * Make a context menu option for editing a custom procedure.
+ * This appears in the context menu for procedure definitions and procedure
+ * calls.
+ * @param {!Blockly.BlockSvg} block The block where the right-click originated.
+ * @return {!Object} A menu option, containing text, enabled, and a callback.
+ * @package
+ */
+Blockly.Procedures.makeEditOption = function(block) {
+  var editOption = {
+    enabled: true,
+    text: Blockly.Msg.EDIT_PROCEDURE,
+    callback: function() {
+      Blockly.Procedures.editProcedureCallback_(block);
+    }
+  };
+  return editOption;
+};
+
+/**
+ * Callback to show the procedure definition corresponding to a custom command
+ * block.
+ * TODO(#1136): Implement.
+ * @param {!Blockly.Block} block The block that was right-clicked.
+ * @private
+ */
+Blockly.Procedures.showProcedureDefCallback_ = function(block) {
+  alert('TODO(#1136): implement showing procedure definition (procCode was "' +
+      block.procCode_ + '")');
+};
+
+/**
+ * Make a context menu option for showing the definition for a custom procedure,
+ * based on a right-click on a custom command block.
+ * @param {!Blockly.BlockSvg} block The block where the right-click originated.
+ * @return {!Object} A menu option, containing text, enabled, and a callback.
+ * @package
+ */
+Blockly.Procedures.makeShowDefinitionOption = function(block) {
+  var option = {
+    enabled: true,
+    text: Blockly.Msg.SHOW_PROCEDURE_DEFINITION,
+    callback: function() {
+      Blockly.Procedures.showProcedureDefCallback_(block);
+    }
+  };
+  return option;
+};

--- a/msg/messages.js
+++ b/msg/messages.js
@@ -112,6 +112,10 @@ Blockly.Msg.REDO = 'Redo';
 /// context menu - Edit the currently selected procedure.
 Blockly.Msg.EDIT_PROCEDURE = 'Edit';
 
+// TODO(#1136): Pick text for this.
+/// context menu - Bring the definition of the procedure into view.
+Blockly.Msg.SHOW_PROCEDURE_DEFINITION = 'Go to definition';
+
 // Variable renaming.
 /// prompt - This message is only seen in the Opera browser.  With most browsers, users can edit numeric values in blocks by just clicking and typing.  Opera does not allows this, so we have to open a new window and prompt users with this message to chanage a value.
 Blockly.Msg.CHANGE_VALUE_TITLE = 'Change value:';


### PR DESCRIPTION
### Resolves

https://github.com/LLK/scratch-blocks/issues/1135, except for comments

### Proposed Changes

Add "edit" and "go to definition" options to the context menu for custom command blocks.
Share code for the "edit" option for both types of procedure blocks.

### Reason for Changes

Match the Scratch 2.0 behaviour for custom command blocks.

### Test Coverage

Tested that I get the right alerts when I click 'edit' on both types of procedure blocks and 'go to definition' on custom command blocks.  Tested that `block` is correct in the callbacks, and that the way I'm getting the procCode works.