### PR TITLE
Enable bulk updating during duplication

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -682,14 +682,12 @@ Blockly.BlockSvg.prototype.duplicateAndDragCallback_ = function() {
 
       // Create the new block by cloning the block in the flyout (via XML).
       var xml = Blockly.Xml.blockToDom(oldBlock);
-      // The target workspace would normally resize during domToBlock, which
-      // will lead to weird jumps.
-      // Resizing will be enabled when the drag ends.
-      ws.setResizesEnabled(false);
 
       // Using domToBlock instead of domToWorkspace means that the new block
       // will be placed at position (0, 0) in main workspace units.
+      ws.setBulkUpdate(true);
       var newBlock = Blockly.Xml.domToBlock(xml, ws);
+      ws.setBulkUpdate(false);
 
       // Scratch-specific: Give shadow dom new IDs to prevent duplicating on paste
       Blockly.utils.changeObscuredShadowIds(newBlock);


### PR DESCRIPTION
### Resolves

Fixes https://github.com/LLK/scratch-blocks/issues/1133

### Proposed Changes

Set the bulk updating flag when duplicating blocks, instead of just disabling workspace resizing.

### Reason for Changes

Duplicating blocks with variable references can lead to toolbox layout thrashing otherwise.

