### PR TITLE
Make helper functions for context menu options

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -760,17 +760,17 @@ Blockly.BlockSvg.prototype.showContextMenu_ = function(e) {
   var menuOptions = [];
 
   if (this.isDeletable() && this.isMovable() && !block.isInFlyout) {
-    menuOptions.push(Blockly.ContextMenu.blockDuplicateOption_(block));
+    menuOptions.push(Blockly.ContextMenu.blockDuplicateOption(block));
     if (this.isEditable() && this.workspace.options.comments) {
-      menuOptions.push(Blockly.ContextMenu.blockCommentOption_(block));
+      menuOptions.push(Blockly.ContextMenu.blockCommentOption(block));
     }
-    menuOptions.push(Blockly.ContextMenu.blockDeleteOption_(block));
+    menuOptions.push(Blockly.ContextMenu.blockDeleteOption(block));
   } else if (this.parentBlock_ && this.isShadow_) {
     this.parentBlock_.showContextMenu_(e);
     return;
   }
 
-  menuOptions.push(Blockly.ContextMenu.blockHelpOption_(block));
+  menuOptions.push(Blockly.ContextMenu.blockHelpOption(block));
 
   // Allow the block to add or modify menuOptions.
   if (this.customContextMenu) {

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -760,17 +760,17 @@ Blockly.BlockSvg.prototype.showContextMenu_ = function(e) {
   var menuOptions = [];
 
   if (this.isDeletable() && this.isMovable() && !block.isInFlyout) {
-    menuOptions.push(Blockly.BlockSvg.makeDuplicateOption_(block));
+    menuOptions.push(Blockly.ContextMenu.blockDuplicateOption_(block));
     if (this.isEditable() && this.workspace.options.comments) {
-      menuOptions.push(Blockly.BlockSvg.makeCommentOption_(block));
+      menuOptions.push(Blockly.ContextMenu.blockCommentOption_(block));
     }
-    menuOptions.push(Blockly.BlockSvg.makeDeleteOption_(block));
+    menuOptions.push(Blockly.ContextMenu.blockDeleteOption_(block));
   } else if (this.parentBlock_ && this.isShadow_) {
     this.parentBlock_.showContextMenu_(e);
     return;
   }
 
-  menuOptions.push(Blockly.BlockSvg.makeHelpOption_(block));
+  menuOptions.push(Blockly.ContextMenu.blockHelpOption_(block));
 
   // Allow the block to add or modify menuOptions.
   if (this.customContextMenu) {
@@ -1446,93 +1446,3 @@ Blockly.BlockSvg.prototype.scheduleSnapAndBump = function() {
     Blockly.Events.setGroup(false);
   }, Blockly.BUMP_DELAY);
 };
-
-// Helper functions for context menus.
-
-/**
- * Make a context menu option for deleting the current block.
- * @param {!Blockly.BlockSvg} block The block where the right-click originated.
- * @return {!Object} A menu option, containing text, enabled, and a callback.
- * @private
- */
-Blockly.BlockSvg.makeDeleteOption_ = function(block) {
-  // Option to delete this block but not blocks lower in the stack.
-  // Count the number of blocks that are nested in this block.
-  var descendantCount = block.getDescendants(true).length;
-  var nextBlock = block.getNextBlock();
-  if (nextBlock) {
-    // Blocks in the current stack would survive this block's deletion.
-    descendantCount -= nextBlock.getDescendants(true).length;
-  }
-  var deleteOption = {
-    text: descendantCount == 1 ? Blockly.Msg.DELETE_BLOCK :
-        Blockly.Msg.DELETE_X_BLOCKS.replace('%1', String(descendantCount)),
-    enabled: true,
-    callback: function() {
-      Blockly.Events.setGroup(true);
-      block.dispose(true, true);
-      Blockly.Events.setGroup(false);
-    }
-  };
-  return deleteOption;
-};
-
-/**
- * Make a context menu option for showing help for the current block.
- * @param {!Blockly.BlockSvg} block The block where the right-click originated.
- * @return {!Object} A menu option, containing text, enabled, and a callback.
- * @private
- */
-Blockly.BlockSvg.makeHelpOption_ = function(block) {
-  var url = goog.isFunction(block.helpUrl) ? block.helpUrl() : block.helpUrl;
-  var helpOption = {
-    enabled: !!url,
-    text: Blockly.Msg.HELP,
-    callback: function() {
-      block.showHelp_();
-    }
-  };
-  return helpOption;
-};
-
-/**
- * Make a context menu option for duplicating the current block.
- * @param {!Blockly.BlockSvg} block The block where the right-click originated.
- * @return {!Object} A menu option, containing text, enabled, and a callback.
- * @private
- */
-Blockly.BlockSvg.makeDuplicateOption_ = function(block) {
-  var duplicateOption = {
-    text: Blockly.Msg.DUPLICATE_BLOCK,
-    enabled: true,
-    callback: block.duplicateAndDragCallback_()
-  };
-  return duplicateOption;
-};
-
-/**
- * Make a context menu option for adding or removing comments on the current
- * block.
- * @param {!Blockly.BlockSvg} block The block where the right-click originated.
- * @return {!Object} A menu option, containing text, enabled, and a callback.
- * @private
- */
-Blockly.BlockSvg.makeCommentOption_ = function(block) {
-  var commentOption = {enabled: !goog.userAgent.IE};
-  // If there's already a comment, add an option to delete it.
-  if (block.comment) {
-    commentOption.text = Blockly.Msg.REMOVE_COMMENT;
-    commentOption.callback = function() {
-      block.setCommentText(null);
-    };
-  } else {
-    // If there's no comment, add an option to create a comment.
-    commentOption.text = Blockly.Msg.ADD_COMMENT;
-    commentOption.callback = function() {
-      block.setCommentText('');
-    };
-  }
-  return commentOption;
-};
-
-// End helper functions for context menus.

--- a/core/contextmenu.js
+++ b/core/contextmenu.js
@@ -196,9 +196,9 @@ Blockly.ContextMenu.callbackFactory = function(block, xml) {
  * Make a context menu option for deleting the current block.
  * @param {!Blockly.BlockSvg} block The block where the right-click originated.
  * @return {!Object} A menu option, containing text, enabled, and a callback.
- * @private
+ * @package
  */
-Blockly.ContextMenu.blockDeleteOption_ = function(block) {
+Blockly.ContextMenu.blockDeleteOption = function(block) {
   // Option to delete this block but not blocks lower in the stack.
   // Count the number of blocks that are nested in this block.
   var descendantCount = block.getDescendants(true).length;
@@ -224,9 +224,9 @@ Blockly.ContextMenu.blockDeleteOption_ = function(block) {
  * Make a context menu option for showing help for the current block.
  * @param {!Blockly.BlockSvg} block The block where the right-click originated.
  * @return {!Object} A menu option, containing text, enabled, and a callback.
- * @private
+ * @package
  */
-Blockly.ContextMenu.blockHelpOption_ = function(block) {
+Blockly.ContextMenu.blockHelpOption = function(block) {
   var url = goog.isFunction(block.helpUrl) ? block.helpUrl() : block.helpUrl;
   var helpOption = {
     enabled: !!url,
@@ -242,9 +242,9 @@ Blockly.ContextMenu.blockHelpOption_ = function(block) {
  * Make a context menu option for duplicating the current block.
  * @param {!Blockly.BlockSvg} block The block where the right-click originated.
  * @return {!Object} A menu option, containing text, enabled, and a callback.
- * @private
+ * @package
  */
-Blockly.ContextMenu.blockDuplicateOption_ = function(block) {
+Blockly.ContextMenu.blockDuplicateOption = function(block) {
   var duplicateOption = {
     text: Blockly.Msg.DUPLICATE_BLOCK,
     enabled: true,
@@ -258,9 +258,9 @@ Blockly.ContextMenu.blockDuplicateOption_ = function(block) {
  * block.
  * @param {!Blockly.BlockSvg} block The block where the right-click originated.
  * @return {!Object} A menu option, containing text, enabled, and a callback.
- * @private
+ * @package
  */
-Blockly.ContextMenu.blockCommentOption_ = function(block) {
+Blockly.ContextMenu.blockCommentOption = function(block) {
   var commentOption = {
     enabled: !goog.userAgent.IE
   };

--- a/core/contextmenu.js
+++ b/core/contextmenu.js
@@ -189,3 +189,95 @@ Blockly.ContextMenu.callbackFactory = function(block, xml) {
     newBlock.select();
   };
 };
+
+// Helper functions for creating context menu options.
+
+/**
+ * Make a context menu option for deleting the current block.
+ * @param {!Blockly.BlockSvg} block The block where the right-click originated.
+ * @return {!Object} A menu option, containing text, enabled, and a callback.
+ * @private
+ */
+Blockly.ContextMenu.blockDeleteOption_ = function(block) {
+  // Option to delete this block but not blocks lower in the stack.
+  // Count the number of blocks that are nested in this block.
+  var descendantCount = block.getDescendants(true).length;
+  var nextBlock = block.getNextBlock();
+  if (nextBlock) {
+    // Blocks in the current stack would survive this block's deletion.
+    descendantCount -= nextBlock.getDescendants(true).length;
+  }
+  var deleteOption = {
+    text: descendantCount == 1 ? Blockly.Msg.DELETE_BLOCK :
+        Blockly.Msg.DELETE_X_BLOCKS.replace('%1', String(descendantCount)),
+    enabled: true,
+    callback: function() {
+      Blockly.Events.setGroup(true);
+      block.dispose(true, true);
+      Blockly.Events.setGroup(false);
+    }
+  };
+  return deleteOption;
+};
+
+/**
+ * Make a context menu option for showing help for the current block.
+ * @param {!Blockly.BlockSvg} block The block where the right-click originated.
+ * @return {!Object} A menu option, containing text, enabled, and a callback.
+ * @private
+ */
+Blockly.ContextMenu.blockHelpOption_ = function(block) {
+  var url = goog.isFunction(block.helpUrl) ? block.helpUrl() : block.helpUrl;
+  var helpOption = {
+    enabled: !!url,
+    text: Blockly.Msg.HELP,
+    callback: function() {
+      block.showHelp_();
+    }
+  };
+  return helpOption;
+};
+
+/**
+ * Make a context menu option for duplicating the current block.
+ * @param {!Blockly.BlockSvg} block The block where the right-click originated.
+ * @return {!Object} A menu option, containing text, enabled, and a callback.
+ * @private
+ */
+Blockly.ContextMenu.blockDuplicateOption_ = function(block) {
+  var duplicateOption = {
+    text: Blockly.Msg.DUPLICATE_BLOCK,
+    enabled: true,
+    callback: block.duplicateAndDragCallback_()
+  };
+  return duplicateOption;
+};
+
+/**
+ * Make a context menu option for adding or removing comments on the current
+ * block.
+ * @param {!Blockly.BlockSvg} block The block where the right-click originated.
+ * @return {!Object} A menu option, containing text, enabled, and a callback.
+ * @private
+ */
+Blockly.ContextMenu.blockCommentOption_ = function(block) {
+  var commentOption = {
+    enabled: !goog.userAgent.IE
+  };
+  // If there's already a comment, add an option to delete it.
+  if (block.comment) {
+    commentOption.text = Blockly.Msg.REMOVE_COMMENT;
+    commentOption.callback = function() {
+      block.setCommentText(null);
+    };
+  } else {
+    // If there's no comment, add an option to create a comment.
+    commentOption.text = Blockly.Msg.ADD_COMMENT;
+    commentOption.callback = function() {
+      block.setCommentText('');
+    };
+  }
+  return commentOption;
+};
+
+// End helper functions for creating context menu options.


### PR DESCRIPTION
### Resolves

None, just more cleanup while I'm working on custom context menus.

### Proposed Changes

Create helper functions for creating various context menu options, and move them into contextmenu.js

### Reason for Changes

Readability, and decreasing the amount of code in block_svg.js.

### Test Coverage

Right-click still works on blocks in the playground.