### PR TITLE
Fix argument reporter rendering with short text

### DIFF
--- a/blocks_vertical/procedures.js
+++ b/blocks_vertical/procedures.js
@@ -197,10 +197,14 @@ Blockly.Blocks['procedures_callnoreturn_internal'] = {
             break;
         }
         if (blockType) {
+          var argumentName = this.argumentNames_[inputCount];
+          var shadow = goog.dom.createDom('shadow');
+          shadow.setAttribute('type', blockType);
+          var field = goog.dom.createDom('field', null, argumentName);
+          field.setAttribute('name', 'VALUE');
+          shadow.appendChild(field);
           var input = this.appendValueInput(inputName);
-          var newBlock = this.workspace.newBlock(blockType);
-          newBlock.setShadow(true);
-          newBlock.setFieldValue(this.argumentNames_[inputCount], "VALUE");
+          var newBlock = Blockly.Xml.domToBlock(shadow, this.workspace);
           newBlock.outputConnection.connect(input.connection);
         }
         inputCount++;

--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -942,7 +942,7 @@ Blockly.BlockSvg.prototype.computeRightEdge_ = function(curEdge, hasStatement) {
     // Blocks with notches
     edge = Math.max(edge, Blockly.BlockSvg.MIN_BLOCK_X);
   } else if (this.outputConnection) {
-    if (this.isShadow()) {
+    if (this.isShadow() && !Blockly.utils.isShadowArgumentReporter(this)) {
       // Single-fields
       edge = Math.max(edge, Blockly.BlockSvg.MIN_BLOCK_X_SHADOW_OUTPUT);
     } else {

--- a/core/field_label_editable.js
+++ b/core/field_label_editable.js
@@ -61,3 +61,38 @@ Blockly.FieldLabelEditable.prototype.updateWidth = function() {
   // Unlike the base Field class, this doesn't add space to editable fields.
   this.size_.width = Blockly.Field.getCachedWidth(this.textElement_);
 };
+
+/**
+ * Draws the border with the correct width.
+ * Saves the computed width in a property.
+ * @private
+ */
+Blockly.FieldLabelEditable.prototype.render_ = function() {
+  if (this.visible_ && this.textElement_) {
+    // Replace the text.
+    goog.dom.removeChildren(/** @type {!Element} */ (this.textElement_));
+    var textNode = document.createTextNode(this.getDisplayText_());
+    this.textElement_.appendChild(textNode);
+    this.updateWidth();
+
+    // Update text centering, based on newly calculated width.
+    var centerTextX = this.size_.width / 2;
+
+    // If half the text length is not at least center of
+    // visible field (FIELD_WIDTH), center it there instead.
+    var minOffset = Blockly.BlockSvg.FIELD_WIDTH / 2;
+    if (this.sourceBlock_.RTL) {
+      // X position starts at the left edge of the block, in both RTL and LTR.
+      // First offset by the width of the block to move to the right edge,
+      // and then subtract to move to the same position as LTR.
+      var minCenter = this.size_.width - minOffset;
+      centerTextX = Math.min(minCenter, centerTextX);
+    } else {
+      // (width / 2) should exceed Blockly.BlockSvg.FIELD_WIDTH / 2
+      // if the text is longer.
+      centerTextX = Math.max(minOffset, centerTextX);
+    }
+    // Apply new text element x position.
+    this.textElement_.setAttribute('x', centerTextX);
+  }
+};

--- a/core/gesture.js
+++ b/core/gesture.js
@@ -836,8 +836,11 @@ Blockly.Gesture.prototype.duplicateOnDrag_ = function() {
   try {
     // Note: targetBlock_ should have no children.  If it has children we would
     // need to update shadow block IDs to avoid problems in the VM.
+    // Resizes will be reenabled at the end of the drag.
+    this.startWorkspace_.setResizesEnabled(false);
     var xmlBlock = Blockly.Xml.blockToDom(this.targetBlock_);
     newBlock = Blockly.Xml.domToBlock(xmlBlock, this.startWorkspace_);
+
     // Move the duplicate to original position.
     var xy = this.targetBlock_.getRelativeToSurfaceXY();
     newBlock.moveBy(xy.x, xy.y);


### PR DESCRIPTION
### Resolves

https://github.com/LLK/scratch-blocks/issues/1129

### Proposed Changes

Fix argument reporter width when the text is short:
1) give the text area a minimum width
2) use the normal min block width, not the shadow min block width

### Reason for Changes

Fixing #1129 

### Test Coverage

![image](https://user-images.githubusercontent.com/13686399/31525131-f495356c-af72-11e7-8f56-dd78652fbd72.png)

is a rendering of the following xml immediately after a load:
```
<xml xmlns="http://www.w3.org/1999/xhtml">
  <variables></variables>
  <block type="argument_reporter_string_number" id="dt3k(J)yIyA4%iipD2#=" x="121" y="1">
    <field name="VALUE">a</field>
  </block>
  <block type="procedures_defnoreturn" id="]){{Y!7N9ezN+j@Vr`8p" x="20" y="138">
    <statement name="custom_block">
      <shadow type="procedures_callnoreturn_internal" id="_m7RK@PTyvbq*RR:+u~^">
        <mutation proccode="do a barrel roll %n times" argumentnames="[&quot;x&quot;]" argumentdefaults="[1]" warp="false"></mutation>
        <value name="input0">
          <shadow type="argument_reporter_string_number" id="@r$9K1DqSuWg%e/)@i*1">
            <field name="VALUE">a</field>
          </shadow>
        </value>
      </shadow>
    </statement>
  </block>
</xml>
```