### PR TITLE
Block rendering performance

### DIFF
--- a/core/field.js
+++ b/core/field.js
@@ -84,6 +84,13 @@ Blockly.Field.cacheReference_ = 0;
 Blockly.Field.prototype.name = undefined;
 
 /**
+ * CSS class name for the text element.
+ * @type {string}
+ * @package
+ */
+Blockly.Field.prototype.className_ = 'blocklyText';
+
+/**
  * Visible text to display.
  * @type {string}
  * @private
@@ -166,7 +173,7 @@ Blockly.Field.prototype.init = function() {
   var fieldX = (this.sourceBlock_.RTL) ? -size.width / 2 : size.width / 2;
   /** @type {!Element} */
   this.textElement_ = Blockly.utils.createSvgElement('text',
-      {'class': 'blocklyText',
+      {'class': this.className_,
        'x': fieldX,
        'y': size.height / 2 + Blockly.BlockSvg.FIELD_TOP_PADDING,
        'dominant-baseline': 'middle',
@@ -575,9 +582,9 @@ Blockly.Field.prototype.updateTextNode_ = function() {
     // Truncate displayed string and add an ellipsis ('...').
     text = text.substring(0, this.maxDisplayLength - 2) + '\u2026';
     // Add special class for sizing font when truncated
-    this.textElement_.setAttribute('class', 'blocklyText blocklyTextTruncated');
+    this.textElement_.setAttribute('class', this.className_ + ' blocklyTextTruncated');
   } else {
-    this.textElement_.setAttribute('class', 'blocklyText');
+    this.textElement_.setAttribute('class', this.className_);
   }
   // Empty the text element.
   goog.dom.removeChildren(/** @type {!Element} */ (this.textElement_));

--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -122,6 +122,7 @@ Blockly.FieldDropdown.prototype.init = function() {
   });
   this.arrow_.setAttributeNS('http://www.w3.org/1999/xlink',
       'xlink:href', Blockly.mainWorkspace.options.pathToMedia + 'dropdown-arrow.svg');
+  this.className_ += ' blocklyDropdownText';
 
   Blockly.FieldDropdown.superClass_.init.call(this);
   // If not in a shadow block, draw a box.
@@ -431,11 +432,6 @@ Blockly.FieldDropdown.prototype.setText = function(text) {
   this.updateTextNode_();
 
   if (this.textElement_) {
-    // Update class for dropdown text.
-    // This class is reset every time updateTextNode_ is called.
-    this.textElement_.setAttribute('class',
-        this.textElement_.getAttribute('class') + ' blocklyDropdownText'
-    );
     this.textElement_.parentNode.appendChild(this.arrow_);
   }
   if (this.sourceBlock_ && this.sourceBlock_.rendered) {

--- a/core/flyout_button.js
+++ b/core/flyout_button.js
@@ -162,7 +162,7 @@ Blockly.FlyoutButton.prototype.createDom = function() {
       this.svgGroup_);
   svgText.textContent = this.text_;
 
-  this.width = svgText.getComputedTextLength();
+  this.width = Blockly.Field.getCachedWidth(svgText);
 
   if (!this.isLabel_) {
     this.width += 2 * Blockly.FlyoutButton.MARGIN;

--- a/core/flyout_button.js
+++ b/core/flyout_button.js
@@ -178,8 +178,6 @@ Blockly.FlyoutButton.prototype.createDom = function() {
   svgText.setAttribute('x', this.width / 2);
   svgText.setAttribute('y', this.height / 2);
 
-  this.updateTransform_();
-
   this.mouseUpWrapper_ = Blockly.bindEventWithChecks_(this.svgGroup_, 'mouseup',
       this, this.onMouseUp_);
   return this.svgGroup_;

--- a/core/tooltip.js
+++ b/core/tooltip.js
@@ -248,7 +248,9 @@ Blockly.Tooltip.hide = function() {
       Blockly.Tooltip.DIV.style.display = 'none';
     }
   }
-  clearTimeout(Blockly.Tooltip.showPid_);
+  if (Blockly.Tooltip.showPid_) {
+    clearTimeout(Blockly.Tooltip.showPid_);
+  }
 };
 
 /**


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Implements the suggestions from the end of https://github.com/LLK/scratch-blocks/issues/879

On my machine, knocks the time for `workspace.refreshToolboxSelection_` down from 200ms to around 140ms. ¯\_(ツ)_/¯

### Proposed Changes

_Describe what this Pull Request does_

The various changes are in individual commits. They are pretty unrelated to each other, so I wouldn't be opposed to splitting them into different PRs. Individually they are only a couple lines each. 

### Reason for Changes

_Explain why these changes should be made_

Rendering the full flyout of blocks, which has to be done fairly frequently, can take a very long time. We need it to... not.

### Test Coverage

_Please show how you have added tests to cover your changes_

Rendering appears unchanged in the playground. 

Before 
![image](https://user-images.githubusercontent.com/654102/31563222-280a5b5c-b02c-11e7-8547-5b844affdcb6.png)

After

![screen shot 2017-10-13 at 3 34 44 pm](https://user-images.githubusercontent.com/654102/31563241-375221b2-b02c-11e7-8333-7cbfe3e30dc6.png)


No more red!

