### PR TITLE
Cleanup of workspace context menu code

### DIFF
--- a/core/contextmenu.js
+++ b/core/contextmenu.js
@@ -280,4 +280,114 @@ Blockly.ContextMenu.blockCommentOption = function(block) {
   return commentOption;
 };
 
+/**
+ * Make a context menu option for undoing the most recent action on the
+ * workspace.
+ * @param {!Blockly.WorkspaceSvg} ws The workspace where the right-click
+ *     originated.
+ * @return {!Object} A menu option, containing text, enabled, and a callback.
+ * @package
+ */
+Blockly.ContextMenu.wsUndoOption = function(ws) {
+  return {
+    text: Blockly.Msg.UNDO,
+    enabled: ws.hasUndoStack(),
+    callback: ws.undo.bind(ws, false)
+  };
+};
+
+/**
+ * Make a context menu option for redoing the most recent action on the
+ * workspace.
+ * @param {!Blockly.WorkspaceSvg} ws The workspace where the right-click
+ *     originated.
+ * @return {!Object} A menu option, containing text, enabled, and a callback.
+ * @package
+ */
+Blockly.ContextMenu.wsRedoOption = function(ws) {
+  return {
+    text: Blockly.Msg.REDO,
+    enabled: ws.hasRedoStack(),
+    callback: ws.undo.bind(ws, true)
+  };
+};
+
+/**
+ * Make a context menu option for cleaning up blocks on the workspace, by
+ * aligning them vertically.
+ * @param {!Blockly.WorkspaceSvg} ws The workspace where the right-click
+ *     originated.
+ * @param {number} numTopBlocks The number of top blocks on the workspace.
+ * @return {!Object} A menu option, containing text, enabled, and a callback.
+ * @package
+ */
+Blockly.ContextMenu.wsCleanupOption = function(ws, numTopBlocks) {
+  return {
+    text: Blockly.Msg.CLEAN_UP,
+    enabled: numTopBlocks > 1,
+    callback: ws.cleanUp.bind(ws, true)
+  };
+};
+
+/**
+ * Helper function for toggling delete state on blocks on the workspace, to be
+ * called from a right-click menu.
+ * @param {!Array.<!Blockly.BlockSvg>} topBlocks The list of top blocks on the
+ *     the workspace.
+ * @param {boolean} shouldCollapse True if the blocks should be collapsed, false
+ *     if they should be expanded.
+ * @private
+ */
+Blockly.ContextMenu.toggleCollapseFn_ = function(topBlocks, shouldCollapse) {
+  // Add a little animation to collapsing and expanding.
+  var DELAY = 10;
+  var ms = 0;
+  for (var i = 0; i < topBlocks.length; i++) {
+    var block = topBlocks[i];
+    while (block) {
+      setTimeout(block.setCollapsed.bind(block, shouldCollapse), ms);
+      block = block.getNextBlock();
+      ms += DELAY;
+    }
+  }
+};
+
+/**
+ * Make a context menu option for collapsing all block stacks on the workspace.
+ * @param {boolean} hasExpandedBlocks Whether there are any non-collapsed blocks
+ *     on the workspace.
+ * @param {!Array.<!Blockly.BlockSvg>} topBlocks The list of top blocks on the
+ *     the workspace.
+ * @return {!Object} A menu option, containing text, enabled, and a callback.
+ * @package
+ */
+Blockly.ContextMenu.wsCollapseOption = function(hasExpandedBlocks, topBlocks) {
+  return {
+    enabled: hasExpandedBlocks,
+    text: Blockly.Msg.COLLAPSE_ALL,
+    callback: function() {
+      Blockly.ContextMenu.toggleCollapseFn_(topBlocks, true);
+    }
+  };
+};
+
+/**
+ * Make a context menu option for expanding all block stacks on the workspace.
+ * @param {boolean} hasCollapsedBlocks Whether there are any collapsed blocks
+ *     on the workspace.
+ * @param {!Array.<!Blockly.BlockSvg>} topBlocks The list of top blocks on the
+ *     the workspace.
+ * @return {!Object} A menu option, containing text, enabled, and a callback.
+ * @package
+ */
+Blockly.ContextMenu.wsExpandOption = function(hasCollapsedBlocks, topBlocks) {
+  return {
+    enabled: hasCollapsedBlocks,
+    text: Blockly.Msg.EXPAND_ALL,
+    callback: function() {
+      Blockly.ContextMenu.toggleCollapseFn_(topBlocks, false);
+    }
+  };
+};
+
 // End helper functions for creating context menu options.

--- a/core/workspace.js
+++ b/core/workspace.js
@@ -516,6 +516,21 @@ Blockly.Workspace.prototype.clearUndo = function() {
 };
 
 /**
+ * @return {boolean} whether there are any events in the redo stack.
+ * @package
+ */
+Blockly.Workspace.prototype.hasRedoStack = function() {
+  return this.redoStack_.length != 0;
+};
+
+/**
+ * @return {boolean} whether there are any events in the undo stack.
+ * @package
+ */
+Blockly.Workspace.prototype.hasUndoStack = function() {
+  return this.undoStack_.length != 0;
+};
+/**
  * When something in this workspace changes, call a function.
  * @param {!Function} func Function to call.
  * @return {!Function} Function that can be passed to

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1294,28 +1294,15 @@ Blockly.WorkspaceSvg.prototype.showContextMenu_ = function(e) {
   var ws = this;
 
   // Options to undo/redo previous action.
-  var undoOption = {};
-  undoOption.text = Blockly.Msg.UNDO;
-  undoOption.enabled = this.undoStack_.length > 0;
-  undoOption.callback = this.undo.bind(this, false);
-  menuOptions.push(undoOption);
-  var redoOption = {};
-  redoOption.text = Blockly.Msg.REDO;
-  redoOption.enabled = this.redoStack_.length > 0;
-  redoOption.callback = this.undo.bind(this, true);
-  menuOptions.push(redoOption);
+  menuOptions.push(Blockly.ContextMenu.wsUndoOption(this));
+  menuOptions.push(Blockly.ContextMenu.wsRedoOption(this));
 
   // Option to clean up blocks.
   if (this.scrollbar) {
-    var cleanOption = {};
-    cleanOption.text = Blockly.Msg.CLEAN_UP;
-    cleanOption.enabled = topBlocks.length > 1;
-    cleanOption.callback = this.cleanUp.bind(this);
-    menuOptions.push(cleanOption);
+    menuOptions.push(
+        Blockly.ContextMenu.wsCleanupOption(this,topBlocks.length));
   }
 
-  // Add a little animation to collapsing and expanding.
-  var DELAY = 10;
   if (this.options.collapse) {
     var hasCollapsedBlocks = false;
     var hasExpandedBlocks = false;
@@ -1331,56 +1318,16 @@ Blockly.WorkspaceSvg.prototype.showContextMenu_ = function(e) {
       }
     }
 
-    /**
-     * Option to collapse or expand top blocks.
-     * @param {boolean} shouldCollapse Whether a block should collapse.
-     * @private
-     */
-    var toggleOption = function(shouldCollapse) {
-      var ms = 0;
-      for (var i = 0; i < topBlocks.length; i++) {
-        var block = topBlocks[i];
-        while (block) {
-          setTimeout(block.setCollapsed.bind(block, shouldCollapse), ms);
-          block = block.getNextBlock();
-          ms += DELAY;
-        }
-      }
-    };
+    menuOptions.push(Blockly.ContextMenu.wsCollapseOption(hasExpandedBlocks,
+        topBlocks));
 
-    // Option to collapse top blocks.
-    var collapseOption = {enabled: hasExpandedBlocks};
-    collapseOption.text = Blockly.Msg.COLLAPSE_ALL;
-    collapseOption.callback = function() {
-      toggleOption(true);
-    };
-    menuOptions.push(collapseOption);
-
-    // Option to expand top blocks.
-    var expandOption = {enabled: hasCollapsedBlocks};
-    expandOption.text = Blockly.Msg.EXPAND_ALL;
-    expandOption.callback = function() {
-      toggleOption(false);
-    };
-    menuOptions.push(expandOption);
+    menuOptions.push(Blockly.ContextMenu.wsExpandOption(hasCollapsedBlocks,
+        topBlocks));
   }
 
   // Option to delete all blocks.
   // Count the number of blocks that are deletable.
-  var deleteList = [];
-  function addDeletableBlocks(block) {
-    if (block.isDeletable()) {
-      deleteList = deleteList.concat(block.getDescendants());
-    } else {
-      var children = block.getChildren();
-      for (var i = 0; i < children.length; i++) {
-        addDeletableBlocks(children[i]);
-      }
-    }
-  }
-  for (var i = 0; i < topBlocks.length; i++) {
-    addDeletableBlocks(topBlocks[i]);
-  }
+  var deleteList = Blockly.WorkspaceSvg.buildDeleteList_(topBlocks);
   // Scratch-specific: don't count shadow blocks in delete count
   var deleteCount = 0;
   for (var i = 0; i < deleteList.length; i++) {
@@ -1388,6 +1335,8 @@ Blockly.WorkspaceSvg.prototype.showContextMenu_ = function(e) {
       deleteCount++;
     }
   }
+
+  var DELAY = 10;
   function deleteNext() {
     Blockly.Events.setGroup(eventGroup);
     var block = deleteList.shift();
@@ -1426,6 +1375,33 @@ Blockly.WorkspaceSvg.prototype.showContextMenu_ = function(e) {
   menuOptions.push(deleteOption);
 
   Blockly.ContextMenu.show(e, menuOptions, this.RTL);
+};
+
+/**
+ * Build a list of all deletable blocks that are reachable from the given
+ * list of top blocks.
+ * @param {!Array.<!Blockly.BlockSvg>} topBlocks The list of top blocks on the
+ *     workspace.
+ * @return {!Array.<!Blockly.BlockSvg>} A list of deletable blocks on the
+ *     workspace.
+ * @private
+ */
+Blockly.WorkspaceSvg.buildDeleteList_ = function(topBlocks) {
+  var deleteList = [];
+  function addDeletableBlocks(block) {
+    if (block.isDeletable()) {
+      deleteList = deleteList.concat(block.getDescendants());
+    } else {
+      var children = block.getChildren();
+      for (var i = 0; i < children.length; i++) {
+        addDeletableBlocks(children[i]);
+      }
+    }
+  }
+  for (var i = 0; i < topBlocks.length; i++) {
+    addDeletableBlocks(topBlocks[i]);
+  }
+  return deleteList;
 };
 
 /**


### PR DESCRIPTION
### Resolves

None, just more cleanup.

### Proposed Changes

Move workspace context menu functions into contextmenu.js and add comments.

### Reason for Changes

Cleanup while I'm working on context menus.

### Test Coverage

All context menu options still work in the playground.  I enabled collapsing to test expand and collapse.