### PR TITLE
Find all callers of a procedure by procCode

### DIFF
--- a/blocks_vertical/procedures.js
+++ b/blocks_vertical/procedures.js
@@ -60,6 +60,15 @@ Blockly.Blocks['procedures_callnoreturn'] = {
     this.procCode_ = '';
   },
   /**
+   * Returns the name of the procedure this block calls, or the empty string if
+   * it has not yet been set.
+   * @return {string} Procedure name.
+   * @this Blockly.Block
+   */
+  getProcCode: function() {
+    return this.procCode_;
+  },
+  /**
    * Create XML to represent the (non-editable) name and arguments.
    * @return {!Element} XML storage element.
    * @this Blockly.Block

--- a/core/procedures.js
+++ b/core/procedures.js
@@ -263,20 +263,23 @@ Blockly.Procedures.getCallers = function(name, ws, definitionRoot,
     allowRecursive) {
   var allBlocks = [];
   var topBlocks = ws.getTopBlocks();
+
+  // Start by deciding which stacks to investigate.
   for (var i = 0; i < topBlocks.length; i++) {
     var block = topBlocks[i];
     if (block.id == definitionRoot.id && !allowRecursive) {
       continue;
     }
-    allBlocks.push.apply(allBlocks, block.getChildren());
+    allBlocks.push.apply(allBlocks, block.getDescendants());
   }
 
   var callers = [];
   for (var i = 0; i < allBlocks.length; i++) {
+    var block = allBlocks[i];
     if (block.type == 'procedure_callnoreturn') {
       var procCode = block.getProcCode();
       if (procCode && procCode == name) {
-        callers.push[block];
+        callers.push(block);
       }
     }
   }

--- a/core/procedures.js
+++ b/core/procedures.js
@@ -248,21 +248,35 @@ Blockly.Procedures.flyoutCategory = function(workspace) {
 };
 
 /**
- * Find all the callers of a named procedure.
- * @param {string} name Name of procedure.
- * @param {!Blockly.Workspace} workspace The workspace to find callers in.
+ * Find all callers of a named procedure.
+ * @param {string} name Name of procedure (procCode in scratch-blocks).
+ * @param {!Blockly.Workspace} ws The workspace to find callers in.
+ * @param {!Blockly.Block} definitionRoot The root of the stack where the
+ *     procedure is defined.
+ * @param {boolean} allowRecursive True if the search should include recursive
+ *     procedure calls.  False if the search should ignore the stack starting
+ *     with definitionRoot.
  * @return {!Array.<!Blockly.Block>} Array of caller blocks.
+ * @package
  */
-Blockly.Procedures.getCallers = function(name, workspace) {
+Blockly.Procedures.getCallers = function(name, ws, definitionRoot,
+    allowRecursive) {
+  var allBlocks = [];
+  var topBlocks = ws.getTopBlocks();
+  for (var i = 0; i < topBlocks.length; i++) {
+    var block = topBlocks[i];
+    if (block.id == definitionRoot.id && !allowRecursive) {
+      continue;
+    }
+    allBlocks.push.apply(allBlocks, block.getChildren());
+  }
+
   var callers = [];
-  var blocks = workspace.getAllBlocks();
-  // Iterate through every block and check the name.
-  for (var i = 0; i < blocks.length; i++) {
-    if (blocks[i].getProcedureCall) {
-      var procName = blocks[i].getProcedureCall();
-      // Procedure name may be null if the block is only half-built.
-      if (procName && Blockly.Names.equals(procName, name)) {
-        callers.push(blocks[i]);
+  for (var i = 0; i < allBlocks.length; i++) {
+    if (block.type == 'procedure_callnoreturn') {
+      var procCode = block.getProcCode();
+      if (procCode && procCode == name) {
+        callers.push[block];
       }
     }
   }
@@ -275,6 +289,7 @@ Blockly.Procedures.getCallers = function(name, workspace) {
  * @param {!Blockly.Block} defBlock Procedure definition block.
  */
 Blockly.Procedures.mutateCallers = function(defBlock) {
+  // TODO(#1143) Update this for scratch procedures.
   var oldRecordUndo = Blockly.Events.recordUndo;
   var name = defBlock.getProcedureDef()[0];
   var xmlElement = defBlock.mutationToDom(true);

--- a/tests/jsunit/horizontal_tests.html
+++ b/tests/jsunit/horizontal_tests.html
@@ -7,7 +7,7 @@
     <script>goog.require('goog.testing.jsunit');</script>
   </head>
   <body>
-    <script src="utils_test.js"></script>
+    <script src="test_utilities.js"></script>
     <script src="blockly_test.js"></script>
     <script src="block_test.js"></script>
     <script src="connection_test.js"></script>
@@ -18,11 +18,13 @@
     <script src="field_number_test.js"></script>
     <script src="generator_test.js"></script>
     <script src="input_test.js"></script>
+    <script src="json_test.js"></script>
     <script src="names_test.js"></script>
+    <script src="procedure_test.js"></script>
+    <script src="svg_test.js"></script>
+    <script src="utils_test.js"></script>
     <script src="workspace_test.js"></script>
     <script src="xml_test.js"></script>
-    <script src="svg_test.js"></script>
-    <script src="json_test.js"></script>
 
     <div id="blocklyDiv" style="display: none; height: 480px; width: 600px;"></div>
     <xml id="toolbox" style="display: none"></xml>

--- a/tests/jsunit/procedure_test.js
+++ b/tests/jsunit/procedure_test.js
@@ -1,0 +1,253 @@
+/**
+ * @license
+ * Blockly Tests
+ *
+ * Copyright 2017 Google Inc.
+ * https://developers.google.com/blockly/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+goog.require('goog.testing');
+goog.require('goog.testing.MockControl');
+
+var workspace;
+//var mockControl_;
+
+function procedureTest_setUp() {
+  Blockly.Blocks['procedure_callnoreturn'] = {
+    init: function() {
+      this.procCode_ = '';
+      this.setPreviousStatement(true);
+      this.setNextStatement(true);
+    },
+    getProcCode: function() {
+      return this.procCode_;
+    }
+  };
+  Blockly.Blocks['foo'] = {
+    init: function() {
+      this.jsonInit({
+        "message0": "foo",
+        "previousStatement": null,
+        "nextStatement": null
+      });
+      this.setNextStatement(true);
+    }
+  };
+  Blockly.Blocks['loop'] = {
+    init: function() {
+      this.jsonInit({ message0: 'forever %1',
+      "args0": [
+        {
+          "type": "input_statement",
+          "name": "SUBSTACK"
+        }
+      ]});
+    }
+  };
+
+
+  workspace = new Blockly.Workspace();
+  //mockControl_ = new goog.testing.MockControl();
+}
+
+function procedureTest_tearDown() {
+  delete Blockly.Blocks['procedure_callnoreturn'];
+  delete Blockly.Blocks['foo'];
+  delete Blockly.Blocks['loop'];
+  //mockControl_.$tearDown();
+  workspace.dispose();
+}
+
+function test_findCallers_simple_oneCaller() {
+  var xml = '<xml xmlns="http://www.w3.org/1999/xhtml">' +
+    '<variables></variables>' +
+    '<block type="procedure_callnoreturn" id="test_1" x="301" y="516">' +
+    '</block>' +
+  '</xml>';
+  procedureTest_setUp();
+  try {
+    Blockly.Xml.domToWorkspace(Blockly.Xml.textToDom(xml), workspace);
+    workspace.getBlockById('test_1').procCode_ = 'test_procedure';
+    var callers = Blockly.Procedures.getCallers('test_procedure', workspace,
+        {id: ''}, false);
+    assertEquals(1, callers.length);
+    assertEquals('test_1', callers[0].id);
+  }
+  finally {
+    procedureTest_tearDown();
+  }
+}
+
+function test_findCallers_noRecursion() {
+  var xml = '<xml xmlns="http://www.w3.org/1999/xhtml">' +
+    '<variables></variables>' +
+    '<block type="procedure_callnoreturn" id="test_1" x="301" y="516">' +
+    '</block>' +
+  '</xml>';
+  procedureTest_setUp();
+  try {
+    Blockly.Xml.domToWorkspace(Blockly.Xml.textToDom(xml), workspace);
+    workspace.getBlockById('test_1').procCode_ = 'test_procedure';
+    var rootBlock = workspace.getBlockById('test_1');
+    var callers = Blockly.Procedures.getCallers('test_procedure', workspace,
+        rootBlock, false /* allowRecursion */);
+
+    // There was a single call to this function, but it was in a stack that
+    // should be ignored.
+    assertEquals(0, callers.length);
+  }
+  finally {
+    procedureTest_tearDown();
+  }
+}
+
+function test_findCallers_allowRecursion() {
+  var xml = '<xml xmlns="http://www.w3.org/1999/xhtml">' +
+    '<variables></variables>' +
+    '<block type="procedure_callnoreturn" id="test_1" x="301" y="516">' +
+    '</block>' +
+  '</xml>';
+  procedureTest_setUp();
+  try {
+    Blockly.Xml.domToWorkspace(Blockly.Xml.textToDom(xml), workspace);
+    workspace.getBlockById('test_1').procCode_ = 'test_procedure';
+    var rootBlock = workspace.getBlockById('test_1');
+    var callers = Blockly.Procedures.getCallers('test_procedure', workspace,
+        rootBlock, true /* allowRecursion */);
+
+    // There was a single call to this function, in the same stack as the
+    // definition root.  Recursion is allowed, so it should be found.
+    assertEquals(1, callers.length);
+    assertEquals('test_1', callers[0].id);
+  }
+  finally {
+    procedureTest_tearDown();
+  }
+}
+
+function test_findCallers_simple_noCallers() {
+  var xml = '<xml xmlns="http://www.w3.org/1999/xhtml">' +
+    '<variables></variables>' +
+    '<block type="foo" id="test_1" x="301" y="516">' +
+    '</block>' +
+  '</xml>';
+  procedureTest_setUp();
+  try {
+    Blockly.Xml.domToWorkspace(Blockly.Xml.textToDom(xml), workspace);
+    var callers = Blockly.Procedures.getCallers('test_procedure', workspace,
+        {id: ''}, false);
+
+    // There weren't even blocks of type procedure_callnoreturn.
+    assertEquals(0, callers.length);
+  }
+  finally {
+    procedureTest_tearDown();
+  }
+}
+
+function test_findCallers_wrongProcCode() {
+  var xml = '<xml xmlns="http://www.w3.org/1999/xhtml">' +
+    '<variables></variables>' +
+    '<block type="procedure_callnoreturn" id="test_1" x="301" y="516">' +
+    '</block>' +
+  '</xml>';
+  procedureTest_setUp();
+  try {
+    Blockly.Xml.domToWorkspace(Blockly.Xml.textToDom(xml), workspace);
+    workspace.getBlockById('test_1').procCode_ = 'wrong procedure';
+    var callers = Blockly.Procedures.getCallers('test_procedure', workspace,
+        {id: ''}, false);
+
+    // There was a procedure_callnoreturn call, but it had the wrong procCode.
+    assertEquals(0, callers.length);
+  }
+  finally {
+    procedureTest_tearDown();
+  }
+}
+
+function test_findCallers_onStatementInput() {
+  var xml = '<xml xmlns="http://www.w3.org/1999/xhtml">' +
+    '<block type="loop" id="test_1">' +
+      '<statement name="SUBSTACK">' +
+        '<block type="foo" id="test_2">' +
+          '<next>' +
+            '<block type="procedure_callnoreturn" id="test_3"></block>' +
+          '</next></block>' +
+      '</statement>' +
+    '</block>' +
+  '</xml>';
+  procedureTest_setUp();
+  try {
+    Blockly.Xml.domToWorkspace(Blockly.Xml.textToDom(xml), workspace);
+    workspace.getBlockById('test_3').procCode_ = 'test_procedure';
+    var callers = Blockly.Procedures.getCallers('test_procedure', workspace,
+        {id: ''}, false);
+
+    // There should be one caller, connected to a stack on a statement input.
+    assertEquals(1, callers.length);
+    assertEquals('test_3', callers[0].id);
+  }
+  finally {
+    procedureTest_tearDown();
+  }
+}
+
+function test_findCallers_multipleStacks() {
+  var xml = '<xml xmlns="http://www.w3.org/1999/xhtml">' +
+    '<block type="foo" id="test_1"></block>' +
+    '<block type="procedure_callnoreturn" id="test_2"></block>'+
+    '<block type="foo" id="test_1"></block>' +
+  '</xml>';
+  procedureTest_setUp();
+  try {
+    Blockly.Xml.domToWorkspace(Blockly.Xml.textToDom(xml), workspace);
+    workspace.getBlockById('test_2').procCode_ = 'test_procedure';
+    var callers = Blockly.Procedures.getCallers('test_procedure', workspace,
+        {id: ''}, false);
+
+    // There should be one caller, but multiple stacks in the workspace.
+    assertEquals(1, callers.length);
+    assertEquals('test_2', callers[0].id);
+  }
+  finally {
+    procedureTest_tearDown();
+  }
+}
+
+function test_findCallers_multipleCallers() {
+  var xml = '<xml xmlns="http://www.w3.org/1999/xhtml">' +
+    '<block type="procedure_callnoreturn" id="test_1"></block>' +
+    '<block type="procedure_callnoreturn" id="test_2"></block>'+
+  '</xml>';
+  procedureTest_setUp();
+  try {
+    Blockly.Xml.domToWorkspace(Blockly.Xml.textToDom(xml), workspace);
+    workspace.getBlockById('test_2').procCode_ = 'test_procedure';
+    workspace.getBlockById('test_1').procCode_ = 'test_procedure';
+    var callers = Blockly.Procedures.getCallers('test_procedure', workspace,
+        {id: ''}, false);
+
+    // There should be two callers, on two different stacks.
+    assertEquals(2, callers.length);
+    // Order doesn't matter.
+    assertTrue(callers[0].id == 'test_1' || callers[0].id == 'test_2');
+    assertTrue(callers[1].id == 'test_1' || callers[1].id == 'test_2');
+  }
+  finally {
+    procedureTest_tearDown();
+  }
+}

--- a/tests/jsunit/vertical_tests.html
+++ b/tests/jsunit/vertical_tests.html
@@ -8,8 +8,8 @@
   </head>
   <body>
     <script src="test_utilities.js"></script>
-    <script src="utils_test.js"></script>
     <script src="block_test.js"></script>
+    <script src="connection_db_test.js"></script>
     <script src="connection_test.js"></script>
     <script src="extensions_test.js"></script>
     <script src="field_test.js"></script>
@@ -17,14 +17,13 @@
     <script src="field_number_test.js"></script>
     <script src="field_variable_getter_test.js"></script>
     <script src="generator_test.js"></script>
-    <script src="connection_db_test.js"></script>
     <script src="input_test.js"></script>
+    <script src="json_test.js"></script>
     <script src="names_test.js"></script>
+    <script src="svg_test.js"></script>
+    <script src="utils_test.js"></script>
     <script src="workspace_test.js"></script>
     <script src="xml_test.js"></script>
-    <script src="svg_test.js"></script>
-    <script src="json_test.js"></script>
-
     <div id="blocklyDiv" style="display: none; height: 480px; width: 600px;"></div>
     <xml id="toolbox" style="display: none"></xml>
   </body>

--- a/tests/jsunit/vertical_tests.html
+++ b/tests/jsunit/vertical_tests.html
@@ -20,6 +20,7 @@
     <script src="input_test.js"></script>
     <script src="json_test.js"></script>
     <script src="names_test.js"></script>
+    <script src="procedure_test.js"></script>
     <script src="svg_test.js"></script>
     <script src="utils_test.js"></script>
     <script src="workspace_test.js"></script>


### PR DESCRIPTION
### Resolves

https://github.com/LLK/scratch-blocks/issues/1143
https://github.com/LLK/scratch-blocks/issues/1130

This finds (but does not update or delete) callers of a custom procedure.

### Proposed Changes

Finds callers of a custom procedure based on `procCode`, and returns a list.
`findCallers` now takes a `definitionRoot` and optionally skips the stack starting with `definitionRoot`--behaviour needed for #1130.  

Adds tests for `getCallers`.
Reorders test loading (alphabetical order).

### Reason for Changes
Part of implementing custom procedure deletion and updates.

### Test Coverage

`procedure_test.js`