### PR TITLE
Only pick random colors with full saturation and brightness

### DIFF
--- a/blocks_common/colour.js
+++ b/blocks_common/colour.js
@@ -26,17 +26,18 @@
 
 goog.provide('Blockly.Blocks.colour');
 
+goog.require('goog.color');
+
 goog.require('Blockly.Blocks');
 
 goog.require('Blockly.constants');
 
 /**
- * Pick a random colour.
+ * Pick a random colour that has full saturation and brightness.
  * @return {string} #RRGGBB for random colour.
  */
 function randomColour() {
-  var num = Math.floor(Math.random() * Math.pow(2, 24));
-  return '#' + ('00000' + num.toString(16)).substr(-6);
+  return goog.color.hsvToHex(360 * Math.random(), 1, 255);
 }
 
 Blockly.Blocks['colour_picker'] = {


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Resolves https://github.com/LLK/scratch-gui/issues/770

### Proposed Changes

_Describe what this Pull Request does_

Make the random colors all have full saturation and brightness, to avoid a bunch of brown and also to make the color slider easier to adjust. 

### Reason for Changes

_Explain why these changes should be made_

See https://github.com/LLK/scratch-gui/issues/770

/cc @jwzimmer @thisandagain 