### PR TITLE
Revert "Only pick random colors with full saturation and brightness"

### DIFF
--- a/blocks_common/colour.js
+++ b/blocks_common/colour.js
@@ -26,18 +26,17 @@
 
 goog.provide('Blockly.Blocks.colour');
 
-goog.require('goog.color');
-
 goog.require('Blockly.Blocks');
 
 goog.require('Blockly.constants');
 
 /**
- * Pick a random colour that has full saturation and brightness.
+ * Pick a random colour.
  * @return {string} #RRGGBB for random colour.
  */
 function randomColour() {
-  return goog.color.hsvToHex(360 * Math.random(), 1, 255);
+  var num = Math.floor(Math.random() * Math.pow(2, 24));
+  return '#' + ('00000' + num.toString(16)).substr(-6);
 }
 
 Blockly.Blocks['colour_picker'] = {


### PR DESCRIPTION
Reverts LLK/scratch-blocks#1149

It breaks the build (silently) which breaks basically everything else. See issue https://github.com/LLK/scratch-blocks/issues/1154