### PR TITLE
Hack to fix 1127 while we consider strict connection types

### DIFF
--- a/tests/jsunit/connection_test.js
+++ b/tests/jsunit/connection_test.js
@@ -343,3 +343,62 @@ function testCheckConnection_Okay() {
 
   connectionTest_tearDown();
 }
+
+function test_canConnectWithReason_Procedures_WrongBlockType() {
+  var sharedWorkspace = {};
+  var one = helper_createConnection(0, 0, Blockly.NEXT_STATEMENT);
+  one.sourceBlock_ = helper_makeSourceBlock(sharedWorkspace);
+  one.sourceBlock_.type = 'procedures_defnoreturn';
+  // Make one be the connection on its source block's input.
+  one.sourceBlock_.getInput = function() {
+    return {
+      connection: one
+    };
+  };
+
+  var two = helper_createConnection(0, 0, Blockly.PREVIOUS_STATEMENT);
+  two.sourceBlock_ = helper_makeSourceBlock(sharedWorkspace);
+  // Fail because two's source block is the wrong type.
+  two.sourceBlock_.type = 'wrong_type';
+  assertEquals(Blockly.Connection.REASON_CUSTOM_PROCEDURE,
+      one.canConnectWithReason_(two));
+}
+
+function test_canConnectWithReason_Procedures_Pass() {
+  var sharedWorkspace = {};
+  var one = helper_createConnection(0, 0, Blockly.NEXT_STATEMENT);
+  one.sourceBlock_ = helper_makeSourceBlock(sharedWorkspace);
+  one.sourceBlock_.type = 'procedures_defnoreturn';
+  // Make one be the connection on its source block's input.
+  one.sourceBlock_.getInput = function() {
+    return {
+      connection: one
+    };
+  };
+  var two = helper_createConnection(0, 0, Blockly.PREVIOUS_STATEMENT);
+  two.sourceBlock_ = helper_makeSourceBlock(sharedWorkspace);
+  two.sourceBlock_.type = 'procedures_callnoreturn_internal';
+  assertEquals(Blockly.Connection.CAN_CONNECT,
+      one.canConnectWithReason_(two));
+}
+
+function test_canConnectWithReason_Procedures_NextConnection() {
+  var sharedWorkspace = {};
+  var one = helper_createConnection(0, 0, Blockly.NEXT_STATEMENT);
+  one.sourceBlock_ = helper_makeSourceBlock(sharedWorkspace);
+  one.sourceBlock_.type = 'procedures_defnoreturn';
+  // One is the next connection, not an input connection
+  one.sourceBlock_.nextConnection = one;
+  one.sourceBlock_.getInput = function() {
+    return {
+      connection: null
+    };
+  };
+  var two = helper_createConnection(0, 0, Blockly.PREVIOUS_STATEMENT);
+  two.sourceBlock_ = helper_makeSourceBlock(sharedWorkspace);
+  // It should be okay, even if two's source block has the wrong type, because
+  // it's not trying to connect to the input.
+  two.sourceBlock_.type = 'wrong_type';
+  assertEquals(Blockly.Connection.CAN_CONNECT,
+      one.canConnectWithReason_(two));
+}


### PR DESCRIPTION
### Resolves

https://github.com/LLK/scratch-blocks/issues/1127

### Proposed Changes

Adds a check to `connection.canConnectWithReason_`, a corresponding error code, and a set of tests.

### Reason for Changes

#1127 is confusing to users, and it'll be a bit before we have a better solution in place upstream.

### Test Coverage

Added tests to connection_test.js