### PR TITLE
Implement isCurrentlyEditable to return false for FieldVariableGetter…

### DIFF
--- a/core/field_label_editable.js
+++ b/core/field_label_editable.js
@@ -96,3 +96,12 @@ Blockly.FieldLabelEditable.prototype.render_ = function() {
     this.textElement_.setAttribute('x', centerTextX);
   }
 };
+
+
+/**
+ * Click events should not treat this like an editable field.
+ * Suppress default editable field behaviour.
+ */
+Blockly.FieldLabelEditable.prototype.isCurrentlyEditable = function() {
+  return false;
+};

--- a/core/field_label_editable.js
+++ b/core/field_label_editable.js
@@ -101,6 +101,7 @@ Blockly.FieldLabelEditable.prototype.render_ = function() {
 /**
  * Click events should not treat this like an editable field.
  * Suppress default editable field behaviour.
+ * @returns {boolean} - false.
  */
 Blockly.FieldLabelEditable.prototype.isCurrentlyEditable = function() {
   return false;

--- a/core/field_variable_getter.js
+++ b/core/field_variable_getter.js
@@ -94,6 +94,7 @@ Blockly.FieldVariableGetter.prototype.updateEditable = function() {
 /**
  * Click events should not treat this like an editable field.
  * Suppress default editable field behaviour.
+ * @returns {boolean} - false.
  */
 Blockly.FieldVariableGetter.prototype.isCurrentlyEditable = function() {
   return false;

--- a/core/field_variable_getter.js
+++ b/core/field_variable_getter.js
@@ -90,3 +90,11 @@ Blockly.FieldVariableGetter.prototype.showEditor_ = function() {
 Blockly.FieldVariableGetter.prototype.updateEditable = function() {
   // nop.
 };
+
+/**
+ * Click events should not treat this like an editable field.
+ * Suppress default editable field behaviour.
+ */
+Blockly.FieldVariableGetter.prototype.isCurrentlyEditable = function() {
+  return false;
+};


### PR DESCRIPTION
… and FieldLabelEditable

### Resolves

_What Github issue does this resolve (please include link)?_

Resolves https://github.com/LLK/scratch-blocks/issues/1160

### Proposed Changes

_Describe what this Pull Request does_

Implement `isCurrentlyEditable` to return false for FieldVariableGetter and FieldLabelEditable, to make it emit events like a block instead of an editable field. 

### Reason for Changes

_Explain why these changes should be made_

Those two types of blocks are "editable" in that they are serialized, but don't have editors and shouldn't be treated like regular editable fields. 

### Test Coverage

_Please show how you have added tests to cover your changes_

Checked the events in the playground.
