### PR TITLE
Do not refresh the toolbox when a new variable is created on the work…

### DIFF
--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1076,9 +1076,14 @@ Blockly.WorkspaceSvg.prototype.deleteVariableById = function(id) {
  * @package
  */
 Blockly.WorkspaceSvg.prototype.createVariable = function(name, opt_type, opt_id) {
+  var variableInMap = (this.getVariable(name) != null);
   var newVar = Blockly.WorkspaceSvg.superClass_.createVariable.call(this, name,
     opt_type, opt_id);
-  this.refreshToolboxSelection_();
+  // For performance reaons, only refresh the the toolbox for new variables.
+  // Variables that already exist should already be there.
+  if (!variableInMap) {
+    this.refreshToolboxSelection_();
+  }
   return newVar;
 };
 

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1079,7 +1079,7 @@ Blockly.WorkspaceSvg.prototype.createVariable = function(name, opt_type, opt_id)
   var variableInMap = (this.getVariable(name) != null);
   var newVar = Blockly.WorkspaceSvg.superClass_.createVariable.call(this, name,
     opt_type, opt_id);
-  // For performance reaons, only refresh the the toolbox for new variables.
+  // For performance reasons, only refresh the the toolbox for new variables.
   // Variables that already exist should already be there.
   if (!variableInMap) {
     this.refreshToolboxSelection_();

--- a/tests/workspace_svg/workspace_svg_test.js
+++ b/tests/workspace_svg/workspace_svg_test.js
@@ -19,6 +19,9 @@
  */
 'use strict';
 
+goog.require('goog.testing');
+goog.require('goog.testing.MockControl');
+
 function helper_createWorkspaceWithToolbox() {
   var toolbox = document.getElementById('toolbox-categories');
   return Blockly.inject('blocklyDiv', {toolbox: toolbox});
@@ -89,6 +92,43 @@ function test_appendDomToWorkspace() {
     assertEquals('Block 1 position y',23,blocks[0].getRelativeToSurfaceXY().y);
     assertEquals('Block 2 position x',21,blocks[1].getRelativeToSurfaceXY().x);
     assertEquals('Block 2 position y',23 + blocks[0].getHeightWidth().height + Blockly.BlockSvg.SEP_SPACE_Y,blocks[1].getRelativeToSurfaceXY().y);
+  } finally {
+    workspace.dispose();
+  }
+}
+
+function test_addNewVariableRefreshToolbox() {
+  var workspace = helper_createWorkspaceWithToolbox();
+
+  var mockControl = new goog.testing.MockControl();
+  var mockMethod = mockControl.createMethodMock(Blockly.WorkspaceSvg.prototype,
+    'refreshToolboxSelection_');
+  try {
+    mockMethod().$once();
+    mockControl.$replayAll();
+  
+    workspace.createVariable('name1', 'type1', 'id1');
+    mockControl.$verifyAll();
+  } finally {
+    workspace.dispose();
+  }
+}
+
+function test_addDuplicateVariableDoNotRefreshToolbox() {
+  var workspace = helper_createWorkspaceWithToolbox();
+  
+  var mockControl = new goog.testing.MockControl();
+  var mockMethod = mockControl.createMethodMock(Blockly.WorkspaceSvg.prototype,
+    'refreshToolboxSelection_');
+  try {
+    mockMethod().$once();
+    mockControl.$replayAll();
+    // Create same variable twice. The first should refresh the toolbox,
+    // the second should not.
+    workspace.createVariable('name1', 'type1', 'id1');
+    workspace.createVariable('name1', 'type1', 'id1');
+
+    mockControl.$verifyAll();
   } finally {
     workspace.dispose();
   }


### PR DESCRIPTION
…space but it already exists in the variable map.  This gets rid of some calls to Toolbox.refreshSelection. e.g. when you drag a variable block out of the toolbox, we were refreshing the toolbox.  It will also help with xml loading for workspaces using multiple of the same variable reporter.  
### Resolves

More needs to be done to solve #879, but this helps a little.

### Proposed Changes
Stop some of our overaggressive updating of the toolbox.

### Reason for Changes

Speed!

### Test Coverage

I wrote 2 tests. woo!