### PR TITLE
Use field_serializable instead of _editable for procedure blocks

### DIFF
--- a/blocks_vertical/procedures.js
+++ b/blocks_vertical/procedures.js
@@ -293,7 +293,7 @@ Blockly.Blocks['argument_reporter_boolean'] = {
     this.jsonInit({ "message0": " %1",
       "args0": [
         {
-          "type": "field_label_editable",
+          "type": "field_label_serializable",
           "name": "VALUE",
           "text": ""
         }
@@ -308,7 +308,7 @@ Blockly.Blocks['argument_reporter_string_number'] = {
     this.jsonInit({ "message0": " %1",
       "args0": [
         {
-          "type": "field_label_editable",
+          "type": "field_label_serializable",
           "name": "VALUE",
           "text": ""
         }


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes custom procedure blocks. 

### Proposed Changes

_Describe what this Pull Request does_

Use the new `field_label_serializable` instead of `field_label_editable` for procedure blocks.

Looks like this should have been part of https://github.com/LLK/scratch-blocks/pull/1165

