### PR TITLE
Use "Color" instead of "Hue" as the slider color input.

### DIFF
--- a/core/field_colour_slider.js
+++ b/core/field_colour_slider.js
@@ -272,7 +272,7 @@ Blockly.FieldColourSlider.prototype.showEditor_ = function() {
   this.saturation_ = hsv[1];
   this.brightness_ = hsv[2];
 
-  var hueElements = this.createLabelDom_('Hue');
+  var hueElements = this.createLabelDom_(Blockly.Msg.COLOUR_HUE_LABEL);
   div.appendChild(hueElements[0]);
   this.hueReadout_ = hueElements[1];
   this.hueSlider_ = new goog.ui.Slider();
@@ -281,7 +281,9 @@ Blockly.FieldColourSlider.prototype.showEditor_ = function() {
   this.hueSlider_.setMaximum(360);
   this.hueSlider_.render(div);
 
-  var saturationElements = this.createLabelDom_('Saturation');
+  var saturationElements = this.createLabelDom_(
+    Blockly.Msg.COLOUR_SATURATION_LABEL
+  );
   div.appendChild(saturationElements[0]);
   this.saturationReadout_ = saturationElements[1];
   this.saturationSlider_ = new goog.ui.Slider();
@@ -291,7 +293,9 @@ Blockly.FieldColourSlider.prototype.showEditor_ = function() {
   this.saturationSlider_.setMaximum(1.0);
   this.saturationSlider_.render(div);
 
-  var brightnessElements = this.createLabelDom_('Brightness');
+  var brightnessElements = this.createLabelDom_(
+    Blockly.Msg.COLOUR_BRIGHTNESS_LABEL
+  );
   div.appendChild(brightnessElements[0]);
   this.brightnessReadout_ = brightnessElements[1];
   this.brightnessSlider_ = new goog.ui.Slider();

--- a/msg/messages.js
+++ b/msg/messages.js
@@ -183,6 +183,12 @@ Blockly.Msg.COLOUR_BLEND_COLOUR2 = 'colour 2';
 Blockly.Msg.COLOUR_BLEND_RATIO = 'ratio';
 /// tooltip - See [https://github.com/google/blockly/wiki/Colour#blending-colours https://github.com/google/blockly/wiki/Colour#blending-colours].
 Blockly.Msg.COLOUR_BLEND_TOOLTIP = 'Blends two colours together with a given ratio (0.0 - 1.0).';
+/// dropdown - Label of the "hue" color component slider
+Blockly.Msg.COLOUR_HUE_LABEL = 'Color';
+/// dropdown - Label of the "saturation" color component slider
+Blockly.Msg.COLOUR_SATURATION_LABEL = 'Saturation';
+/// dropdown - Label of the "brightness" color component slider
+Blockly.Msg.COLOUR_BRIGHTNESS_LABEL = 'Brightness';
 
 // Loop Blocks.
 /// url - Describes 'repeat loops' in computer programs; consider using the translation of the page [https://en.wikipedia.org/wiki/Control_flow http://en.wikipedia.org/wiki/Control_flow].


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Resolves https://github.com/LLK/scratch-blocks/issues/1171

### Proposed Changes

_Describe what this Pull Request does_

![image](https://user-images.githubusercontent.com/654102/31912013-8c3556ea-b810-11e7-86da-c7bf34dae332.png)

### Reason for Changes

_Explain why these changes should be made_

The word "color" matches peoples expectations and is more widespread than the word "hue". We are changing the color components in the pen blocks to match. There is obviously a bit of "overlap" since we are referring to both the color as a whole and the hue component as "color". We'll see if that causes confusion.

