### PR TITLE
Remove executable from closure-library

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/vertical.js",
   "scripts": {
-    "deploy": "gh-pages -t -d gh-pages -m \"Build for $(git log --pretty=format:%H -n1)\"",
+    "deploy": "rimraf gh-pages/closure-library/scripts/ci/CloseAdobeDialog.exe && gh-pages -t -d gh-pages -m \"Build for $(git log --pretty=format:%H -n1)\"",
     "prepublish": "python build.py && webpack",
     "test:setup": "tests/scripts/test_setup.sh",
     "test:unit": "node tests/jsunit/test_runner.js",
@@ -28,6 +28,7 @@
     "graceful-fs": "4.1.11",
     "imports-loader": "0.6.5",
     "json": "9.0.4",
+    "rimraf": "2.6.2",
     "travis-after-all": "1.4.4",
     "webdriverio": "4.8.0",
     "webpack": "1.13.2"


### PR DESCRIPTION
Github is complaining about this file being deployed to `gh-pages`. We don't need it in our build, so remove it before publishing.

We have been receiving these emails after each build:

> The page build completed successfully, but returned the following warning for the `gh-pages` branch:
> 
> It looks like you're using GitHub Pages to distribute binary files. We strongly suggest that you use releases to ship projects on GitHub. Releases are GitHub's way of packaging and providing software to your users. You can think of it as a replacement to using downloads to provide software. We found the following file(s) which may be a good candidate for releases: closure-library/scripts/ci/CloseAdobeDialog.exe. For more information, see https://help.github.com/articles/about-releases/.
> 
> For information on troubleshooting Jekyll see:
> 
>   https://help.github.com/articles/troubleshooting-jekyll-builds
> 
> If you have any questions you can contact us by replying to this email.