### PR TITLE
Add an xml utility to clear the workspace and then load xml into the …

### DIFF
--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -151,6 +151,14 @@ Blockly.WorkspaceSvg.prototype.isMutator = false;
 Blockly.WorkspaceSvg.prototype.resizesEnabled_ = true;
 
 /**
+ * Whether this workspace has toolbox/flyout refreshes enabled.
+ * Disable during batch operations for a performance improvement.
+ * @type {boolean}
+ * @private
+ */
+Blockly.WorkspaceSvg.prototype.toolboxRefreshEnabled_ = true;
+
+/**
  * Current horizontal scrolling offset in pixel units.
  * @type {number}
  */
@@ -1004,7 +1012,10 @@ Blockly.WorkspaceSvg.prototype.paste = function(xmlBlock) {
  * @private
  */
 Blockly.WorkspaceSvg.prototype.refreshToolboxSelection_ = function() {
-  if (this.toolbox_ && this.toolbox_.flyout_ && !this.currentGesture_) {
+  // Updating the toolbox can be expensive. Don't do it when when it is
+  // disabled.
+  if (this.toolbox_ && this.toolbox_.flyout_ && !this.currentGesture_ &&
+      this.toolboxRefreshEnabled_) {
     this.toolbox_.refreshSelection();
   }
 };
@@ -1863,6 +1874,22 @@ Blockly.WorkspaceSvg.prototype.setResizesEnabled = function(enabled) {
   if (reenabled) {
     // Newly enabled.  Trigger a resize.
     this.resizeContents();
+  }
+};
+
+/**
+ * Update whether this workspace has toolbox refreshes enabled.
+ * If enabled, the toolbox will refresh when appropriate.
+ * If disabled, workspace will not refresh until re-enabled.
+ * Use to avoid refreshing during a batch operation, for performance.
+ * @param {boolean} enabled Whether refreshes should be enabled.
+ */
+Blockly.WorkspaceSvg.prototype.setToolboxRefreshEnabled = function(enabled) {
+  var reenabled = (!this.toolboxRefreshEnabled_ && enabled);
+  this.toolboxRefreshEnabled_ = enabled;
+  if (reenabled) {
+    // Newly enabled.  Trigger a refresh.
+    this.refreshToolboxSelection_();
   }
 };
 

--- a/core/xml.js
+++ b/core/xml.js
@@ -302,6 +302,22 @@ Blockly.Xml.textToDom = function(text) {
 };
 
 /**
+ * Clear the given workspace then decode an XML DOM and
+ * create blocks on the workspace.
+ * @param {!Element} xml XML DOM.
+ * @param {!Blockly.Workspace} workspace The workspace.
+ * @return {Array.<string>} An array containing new block ids.
+ */
+Blockly.Xml.clearWorkspaceAndLoadFromXml = function(xml, workspace) {
+  workspace.setResizesEnabled(false);
+  workspace.setToolboxRefreshEnabled(false);
+  workspace.clear();
+  var blockIds = Blockly.Xml.domToWorkspace(xml, workspace);
+  workspace.setResizesEnabled(true);
+  workspace.setToolboxRefreshEnabled(true);
+  return blockIds;
+};
+/**
  * Decode an XML DOM and create blocks on the workspace.
  * @param {!Element} xml XML DOM.
  * @param {!Blockly.Workspace} workspace The workspace.


### PR DESCRIPTION
…dom.  In it, use a new toolbox refresh mechanism that allows for batch updates.  It mirrors the setResizesEnabled mechanism for managing batch updates to the workspace.

### Resolves

Adds scratch-blocks api as a toward resolving #1145
### Proposed Changes

Add a new xml utility that clears the workspace and loads from xml in one go.  This gives us the ability to batch up all the changes before doing things like updating the toolbox.

### Reason for Changes

Performance improvement to avoid refreshing the toolbox (which re-renders all the blocks) over and over again.
### Test Coverage

None for now.