### PR TITLE
Don't parse the default toolbox if it doesn't exist

### DIFF
--- a/core/options.js
+++ b/core/options.js
@@ -46,7 +46,7 @@ Blockly.Options = function(options) {
     var hasDisable = false;
     var hasSounds = false;
   } else {
-    if (!options['toolbox']) {
+    if (!options['toolbox'] && Blockly.Blocks.defaultToolbox) {
       var oParser = new DOMParser();
       var dom = oParser.parseFromString(Blockly.Blocks.defaultToolbox, 'text/xml');
       options['toolbox'] = dom.documentElement;


### PR DESCRIPTION
### Resolves

https://github.com/LLK/scratch-blocks/issues/1174

### Proposed Changes

Check whether `Blockly.Blocks.defaultToolbox exists before trying to parse it.

### Reason for Changes

When parsing failed the toolbox was still being created, when it should not have existed.

### Test Coverage

Tested using the custom procedures playground.