### PR TITLE
Fix comment and remove extension of the root block for custom procedure editing

### DIFF
--- a/blocks_vertical/procedures.js
+++ b/blocks_vertical/procedures.js
@@ -320,12 +320,12 @@ Blockly.Blocks['argument_reporter_string_number'] = {
 
 Blockly.Blocks['procedures_mutator_root'] = {
   /**
-   * Block for calling a procedure with no return value.
+   * The root block in the procedure editing workspace.
    * @this Blockly.Block
    */
   init: function() {
     this.jsonInit({
-      "extensions": ["colours_more", "shape_statement", "procedure_call_contextmenu"]
+      "extensions": ["colours_more", "shape_statement"]
     });
     this.procCode_ = '';
   }


### PR DESCRIPTION
The old version was inaccurate.

This block is mostly just a placeholder right now anyway.
