### PR TITLE
Remove "fake some drags!" button from playground

### DIFF
--- a/tests/vertical_playground.html
+++ b/tests/vertical_playground.html
@@ -27,7 +27,6 @@
     <script>
       'use strict';
 
-      var fakeDragStack = [];
       var workspace = null;
 
       function start() {
@@ -290,65 +289,6 @@
         }
       }
 
-      function fakeDrag(id, dx, dy, opt_workspace) {
-        var ws = opt_workspace || Blockly.getMainWorkspace();
-        var blockToDrag = ws.getBlockById(id);
-
-        if (!blockToDrag) {
-          fakeDragWrapper();
-          return;
-        }
-        var blockTop = blockToDrag.svgGroup_.getBoundingClientRect().top;
-        var blockLeft = blockToDrag.svgGroup_.getBoundingClientRect().left;
-
-        // Click somewhere on the block.
-        var mouseDownEvent = new MouseEvent('mousedown',
-            {clientX: blockLeft + 5, clientY: blockTop + 5});
-        blockToDrag.onMouseDown_(mouseDownEvent);
-
-        // Throw in a move for good measure.
-        setTimeout(
-          function() {
-            var mouseMoveEvent = new MouseEvent('mousemove',
-                {clientX: blockLeft + dx,
-                clientY: blockTop + dy});
-            blockToDrag.onMouseMove_(mouseMoveEvent);
-
-            // Drop at dx, dy.
-            setTimeout(
-              function() {
-                var mouseUpEvent = new MouseEvent('mouseup',
-                    {clientX: blockLeft + dx,
-                    clientY: blockTop + dy});
-                blockToDrag.onMouseUp_(mouseUpEvent);
-
-                setTimeout(fakeDragWrapper(), 100);
-              }, 30);
-          }, 30);
-      };
-
-      function fakeDragWrapper() {
-        var dragInfo = fakeDragStack.pop();
-        if (dragInfo) {
-          fakeDrag(dragInfo.id, dragInfo.dx, dragInfo.dy, dragInfo.workspace);
-        }
-      }
-
-      function fakeManyDrags() {
-        var blockList = workspace.getAllBlocks();
-        for (var i = 0; i < 2 * blockList.length; i++) {
-          fakeDragStack.push(
-            {
-              id: blockList[Math.round(Math.random() * (blockList.length - 1))].id,
-              // Move some blocks up and to the left, but mostly down and to the right.
-              dx: Math.round((Math.random() - 0.25) * 200),
-              dy: Math.round((Math.random() - 0.25) * 200),
-              workspace: workspace
-            });
-        }
-        fakeDragWrapper();
-      }
-
       function reportDemo() {
         if (Blockly.selected) {
           workspace.reportValue(
@@ -565,7 +505,6 @@
       Stress test: &nbsp;
       <input type="button" value="Sprinkles!" onclick="sprinkles(100)">
       <input type="button" value="Spaghetti!" onclick="spaghetti(3)">
-      <input type="button" value="Fake some drags!" onclick="fakeManyDrags()">
     </p>
 
     <p>


### PR DESCRIPTION
### Resolves

Resolves #1159 

### Proposed Changes

Removed the "fakeManyDrags", "fakeDrag", "fakeDragWrapper" functions; removed button input that called "fakeManyDrags"

### Reason for Changes

>that button shouldn't be there anymore, since it was for debugging a drag framework that no longer exists.