### PR TITLE
Re-fix the flyout variable block IDs

### DIFF
--- a/core/data_category.js
+++ b/core/data_category.js
@@ -98,6 +98,8 @@ Blockly.DataCategory.addDataVariable = function(xmlList, variable) {
   //    <field name="VARIABLE">variablename</field>
   // </block>
   Blockly.DataCategory.addBlock(xmlList, variable, 'data_variable', 'VARIABLE');
+  // In the flyout, this ID must match variable ID for monitor syncing reasons
+  xmlList[xmlList.length - 1].setAttribute('id', variable.getId());
 };
 
 /**

--- a/core/data_category.js
+++ b/core/data_category.js
@@ -94,7 +94,7 @@ Blockly.DataCategory = function(workspace) {
  * @param {?Blockly.VariableModel} variable Variable to select in the field.
  */
 Blockly.DataCategory.addDataVariable = function(xmlList, variable) {
-  // <block type="data_variable">
+  // <block id="variableId" type="data_variable">
   //    <field name="VARIABLE">variablename</field>
   // </block>
   Blockly.DataCategory.addBlock(xmlList, variable, 'data_variable', 'VARIABLE');


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Part of fixing https://github.com/LLK/scratch-vm/issues/723 by re-implementing https://github.com/LLK/scratch-blocks/pull/1002 which seems to have gotten lost in a merge/refactor shuffle. This makes it possible to update monitors correctly for variables by making the IDs for variable blocks in the flyout deterministic. 