### PR TITLE
Tighten up the category menu

### DIFF
--- a/core/css.js
+++ b/core/css.js
@@ -1111,10 +1111,10 @@ Blockly.Css.CONTENT = [
   '}',
 
   '.scratchCategoryMenu {',
-    'width: 60px;',
+    'width: 3.25rem;',
     'background: $colour_toolbox;',
     'color: $colour_toolboxText;',
-    'font-size: .7em;',
+    'font-size: .7rem;',
     'user-select: none;',
     '-webkit-user-select: none;',
     '-moz-user-select: none;',
@@ -1141,18 +1141,9 @@ Blockly.Css.CONTENT = [
   '.scratchCategoryMenuRow {',
   '}',
 
-  '.scratchCategoryMenu .scratchCategoryMenuRow + .scratchCategoryMenuRow:before {',
-    'display: block;',
-    'border-top: 1px solid #ddd;',
-    'content: "";',
-    'width: 60%;',
-    'margin: 4px auto;',
-  '}',
-
   '.scratchCategoryMenuItem {',
-    'padding: 6px 0px;',
+    'padding: 0.375rem 0px;',
     'cursor: pointer;',
-    'margin: 0px 2px;',
     'text-align: center;',
   '}',
 
@@ -1162,15 +1153,14 @@ Blockly.Css.CONTENT = [
 
   '.scratchCategoryMenuItem.categorySelected {',
     'background: $colour_toolboxSelected;',
-    'border-radius: 6px;',
   '}',
 
   '.scratchCategoryItemBubble {',
-    'width: 16px;',
-    'height: 16px;',
+    'width: 1.25rem;',
+    'height: 1.25rem;',
     'border: 1px solid;',
     'border-radius: 100%;',
-    'margin: 0 auto 3px;',
+    'margin: 0 auto 0.125rem;',
   '}',
 
   '.scratchCategoryMenuItem:hover {',

--- a/core/css.js
+++ b/core/css.js
@@ -1111,7 +1111,7 @@ Blockly.Css.CONTENT = [
   '}',
 
   '.scratchCategoryMenu {',
-    'width: 3.25rem;',
+    'width: 52px;',
     'background: $colour_toolbox;',
     'color: $colour_toolboxText;',
     'font-size: .7rem;',

--- a/core/toolbox.js
+++ b/core/toolbox.js
@@ -85,9 +85,10 @@ Blockly.Toolbox = function(workspace) {
 
 /**
  * Width of the toolbox, which changes only in vertical layout.
+ * This is the sum of the width of the flyout (250) and the category menu (52).
  * @type {number}
  */
-Blockly.Toolbox.prototype.width = 310;
+Blockly.Toolbox.prototype.width = 302;
 
 /**
  * Height of the toolbox, which changes only in horizontal layout.


### PR DESCRIPTION
### Resolves

This is a workaround for https://github.com/LLK/scratch-blocks/issues/1116

### Proposed Changes

This change provides more blank space below the vertical category menu items, for adding extensions. It also makes the category menu a bit narrower. The goal is to allow room on a 768px high screen for at least two extensions (after we add the "my blocks" category). 

This change also requires a gui PR to shrink the "add extension" button to match: https://github.com/LLK/scratch-gui/pull/826

### Reason for Changes

We wanted to have enough vertical space in the category menu so that it is not necessary to scroll to see all its items, even after adding two extensions, on relatively small screens (such as 768px high).

### Test Coverage

No tests.