### PR TITLE
Handle mutating procedure calls multiple times

### DIFF
--- a/blocks_vertical/procedures.js
+++ b/blocks_vertical/procedures.js
@@ -226,16 +226,21 @@ Blockly.ScratchBlocks.ProcedureUtils.createAllInputs_ = function(connectionMap) 
  * @this Blockly.Block
  */
 Blockly.ScratchBlocks.ProcedureUtils.buildShadowDom_ = function(type) {
-  var xmlStart = '<xml xmlns="http://www.w3.org/1999/xhtml">';
-  var xmlEnd = '</xml>';
+  var shadowDom = goog.dom.createDom('shadow');
   if (type == 'n') {
-    var shadow = '<shadow type="math_number">' +
-        '<field name="NUM">10</field>' +
-        '</shadow>';
+    var shadowType = 'math_number';
+    var fieldName = 'NUM';
+    var fieldValue = '10';
   } else {
-    var shadow = '<shadow type="text"></shadow>';
+    var shadowType = 'text';
+    var fieldName = 'TEXT';
+    var fieldValue = 'hello world';
   }
-  return Blockly.Xml.textToDom(xmlStart + shadow + xmlEnd).firstChild;
+  shadowDom.setAttribute('type', shadowType);
+  var fieldDom = goog.dom.createDom('field', null, fieldValue);
+  fieldDom.setAttribute('name', fieldName);
+  shadowDom.appendChild(fieldDom);
+  return shadowDom;
 };
 
 /**
@@ -274,6 +279,11 @@ Blockly.ScratchBlocks.ProcedureUtils.attachShadow_ = function(input, inputType) 
   if (inputType == 'n' || inputType == 's') {
     var blockType = inputType == 'n' ? 'math_number' : 'text';
     var newBlock = this.workspace.newBlock(blockType);
+    if (inputType == 'n') {
+      newBlock.setFieldValue('99', 'NUM');
+    } else {
+      newBlock.setFieldValue('hello world', 'TEXT');
+    }
     newBlock.setShadow(true);
     if (!this.isInsertionMarker()) {
       newBlock.initSvg();

--- a/blocks_vertical/procedures.js
+++ b/blocks_vertical/procedures.js
@@ -43,31 +43,64 @@ Blockly.ScratchBlocks.ProcedureUtils.getProcCode = function() {
 };
 
 /**
- * Create XML to represent the (non-editable) name and arguments.
+ * Create XML to represent the (non-editable) name and arguments of a procedure
+ * call block (procedures_callnoreturn block).
  * @return {!Element} XML storage element.
  * @this Blockly.Block
  */
 Blockly.ScratchBlocks.ProcedureUtils.callerMutationToDom = function() {
   var container = document.createElement('mutation');
   container.setAttribute('proccode', this.procCode_);
-  container.setAttribute('argumentnames', JSON.stringify(this.argumentNames_));
-  container.setAttribute('argumentdefaults', JSON.stringify(this.argumentDefaults_));
   container.setAttribute('argumentids', JSON.stringify(this.argumentIds_));
   container.setAttribute('warp', this.warp_);
   return container;
 };
 
 /**
- * Parse XML to restore the (non-editable) name and parameters.
+ * Parse XML to restore the (non-editable) name and parameters of a procedure
+ * call block (procedures_callnoreturn block).
  * @param {!Element} xmlElement XML storage element.
  * @this Blockly.Block
  */
 Blockly.ScratchBlocks.ProcedureUtils.callerDomToMutation = function(xmlElement) {
   this.procCode_ = xmlElement.getAttribute('proccode');
-  this.argumentNames_ =  JSON.parse(xmlElement.getAttribute('argumentnames'));
-  this.argumentDefaults_ =  JSON.parse(xmlElement.getAttribute('argumentdefaults'));
   this.argumentIds_ = JSON.parse(xmlElement.getAttribute('argumentids'));
   this.warp_ = xmlElement.getAttribute('warp');
+  this.updateDisplay_();
+};
+
+/**
+ * Create XML to represent the (non-editable) name and arguments of a procedure
+ * definition block (procedures_callnoreturn_internal, which is part of a definition,
+ * or procedures_mutator_root).
+ * @return {!Element} XML storage element.
+ * @this Blockly.Block
+ */
+Blockly.ScratchBlocks.ProcedureUtils.definitionMutationToDom = function() {
+  var container = document.createElement('mutation');
+  container.setAttribute('proccode', this.procCode_);
+  container.setAttribute('argumentids', JSON.stringify(this.argumentIds_));
+  container.setAttribute('argumentnames', JSON.stringify(this.argumentNames_));
+  container.setAttribute('argumentdefaults',
+      JSON.stringify(this.argumentDefaults_));
+  container.setAttribute('warp', this.warp_);
+  return container;
+};
+
+/**
+ * Parse XML to restore the (non-editable) name and parameters of a procedure
+ * definition block (procedures_callnoreturn_internal, which is part of a definition,
+ * or procedures_mutator_root).
+ * @param {!Element} xmlElement XML storage element.
+ * @this Blockly.Block
+ */
+Blockly.ScratchBlocks.ProcedureUtils.definitionDomToMutation = function(xmlElement) {
+  this.procCode_ = xmlElement.getAttribute('proccode');
+  this.argumentIds_ = JSON.parse(xmlElement.getAttribute('argumentids'));
+  this.warp_ = xmlElement.getAttribute('warp');
+  this.argumentNames_ = JSON.parse(xmlElement.getAttribute('argumentnames'));
+  this.argumentDefaults_ = JSON.parse(
+      xmlElement.getAttribute('argumentdefaults'));
   this.updateDisplay_();
 };
 
@@ -369,8 +402,8 @@ Blockly.Blocks['procedures_callnoreturn_internal'] = {
     this.warp_ = false;
   },
   getProcCode: Blockly.ScratchBlocks.ProcedureUtils.getProcCode,
-  mutationToDom: Blockly.ScratchBlocks.ProcedureUtils.callerMutationToDom,
-  domToMutation: Blockly.ScratchBlocks.ProcedureUtils.callerDomToMutation,
+  mutationToDom: Blockly.ScratchBlocks.ProcedureUtils.definitionMutationToDom,
+  domToMutation: Blockly.ScratchBlocks.ProcedureUtils.definitionDomToMutation,
   updateDisplay_: function() {
     var params = {};
     // Split the proc into components, by %n, %b, and %s (ignoring escaped).
@@ -526,8 +559,8 @@ Blockly.Blocks['procedures_mutator_root'] = {
     this.warp_ = false;
   },
   getProcCode: Blockly.ScratchBlocks.ProcedureUtils.getProcCode,
-  mutationToDom: Blockly.ScratchBlocks.ProcedureUtils.callerMutationToDom,
-  domToMutation: Blockly.ScratchBlocks.ProcedureUtils.callerDomToMutation,
+  mutationToDom: Blockly.ScratchBlocks.ProcedureUtils.definitionMutationToDom,
+  domToMutation: Blockly.ScratchBlocks.ProcedureUtils.definitionDomToMutation,
   removeAllInputs_: Blockly.ScratchBlocks.ProcedureUtils.removeAllInputs_,
   disconnectOldBlocks_: Blockly.ScratchBlocks.ProcedureUtils.disconnectOldBlocks_,
   deleteShadows_: Blockly.ScratchBlocks.ProcedureUtils.deleteShadows_,

--- a/blocks_vertical/procedures.js
+++ b/blocks_vertical/procedures.js
@@ -61,7 +61,7 @@ Blockly.ScratchBlocks.ProcedureUtils.callerMutationToDom = function() {
 Blockly.ScratchBlocks.ProcedureUtils.callerDomToMutation = function(xmlElement) {
   this.procCode_ = xmlElement.getAttribute('proccode');
   this.argumentIds_ = JSON.parse(xmlElement.getAttribute('argumentids'));
-  this._updateDisplay();
+  this.updateDisplay_();
 };
 // TODO: Doc
 Blockly.ScratchBlocks.ProcedureUtils.removeAllInputs_ = function() {
@@ -204,7 +204,7 @@ Blockly.ScratchBlocks.ProcedureUtils.createInput_ = function(inputType,
   return input;
 };
 // TODO: Doc, move underscore to end.
-Blockly.ScratchBlocks.ProcedureUtils._updateDisplay = function() {
+Blockly.ScratchBlocks.ProcedureUtils.updateDisplay_ = function() {
   var wasRendered = this.rendered;
   this.rendered = false;
 
@@ -264,7 +264,7 @@ Blockly.Blocks['procedures_callnoreturn'] = {
   createAllInputs_: Blockly.ScratchBlocks.ProcedureUtils.createAllInputs_,
   buildShadowDom_: Blockly.ScratchBlocks.ProcedureUtils.buildShadowDom_,
   createInput_: Blockly.ScratchBlocks.ProcedureUtils.createInput_,
-  _updateDisplay: Blockly.ScratchBlocks.ProcedureUtils._updateDisplay,
+  updateDisplay_: Blockly.ScratchBlocks.ProcedureUtils.updateDisplay_,
   reattachBlock_: Blockly.ScratchBlocks.ProcedureUtils.reattachBlock_,
   attachShadow_: Blockly.ScratchBlocks.ProcedureUtils.attachShadow_
 };
@@ -289,44 +289,9 @@ Blockly.Blocks['procedures_callnoreturn_internal'] = {
     this.argumentDefaults_ = [];
     this.warp_ = false;
   },
-  /**
-   * Returns the name of the procedure this block calls, or the empty string if
-   * it has not yet been set.
-   * @return {string} Procedure name.
-   * @this Blockly.Block
-   */
-  getProcCode: function() {
-    return this.procCode_;
-  },
-  /**
-   * Create XML to represent the (non-editable) name and arguments.
-   * @return {!Element} XML storage element.
-   * @this Blockly.Block
-   */
-  mutationToDom: function() {
-
-    var container = document.createElement('mutation');
-    container.setAttribute('proccode', this.procCode_);
-    container.setAttribute('argumentnames', JSON.stringify(this.argumentNames_));
-    container.setAttribute('argumentdefaults', JSON.stringify(this.argumentDefaults_));
-    container.setAttribute('argumentids', JSON.stringify(this.argumentIds_));
-    container.setAttribute('warp', this.warp_);
-    return container;
-  },
-  /**
-   * Parse XML to restore the (non-editable) name and parameters.
-   * @param {!Element} xmlElement XML storage element.
-   * @this Blockly.Block
-   */
-  domToMutation: function(xmlElement) {
-    this.procCode_ = xmlElement.getAttribute('proccode');
-    this.argumentNames_ =  JSON.parse(xmlElement.getAttribute('argumentnames'));
-    this.argumentDefaults_ =  JSON.parse(xmlElement.getAttribute('argumentdefaults'));
-    this.argumentIds_ = JSON.parse(xmlElement.getAttribute('argumentids'));
-    this.warp_ = xmlElement.getAttribute('warp');
-    this.updateDisplay_();
-
-  },
+  getProcCode: Blockly.ScratchBlocks.ProcedureUtils.getProcCode,
+  mutationToDom: Blockly.ScratchBlocks.ProcedureUtils.callerMutationToDom,
+  domToMutation: Blockly.ScratchBlocks.ProcedureUtils.callerDomToMutation,
   updateDisplay_: function() {
     // Remove old stuff
     if (this.params_) {
@@ -424,9 +389,9 @@ Blockly.Blocks['procedures_param'] = {
   domToMutation: function(xmlElement) {
     this._paramName = xmlElement.getAttribute('paramname');
     this._shape = xmlElement.getAttribute('shape');
-    this._updateDisplay();
+    this.updateDisplay_();
   },
-  _updateDisplay: function() {
+  updateDisplay_: function() {
     this.setFieldValue(this._paramName, 'paramName');
     switch (this._shape) {
       case 'b':
@@ -487,42 +452,17 @@ Blockly.Blocks['procedures_mutator_root'] = {
     this.argumentDefaults_ = [];
     this.warp_ = false;
   },
-  /**
-   * Returns the name of the procedure this block calls, or the empty string if
-   * it has not yet been set.
-   * @return {string} Procedure name.
-   * @this Blockly.Block
-   */
-  getProcCode: function() {
-    return this.procCode_;
-  },
-  /**
-   * Create XML to represent the (non-editable) name and arguments.
-   * @return {!Element} XML storage element.
-   * @this Blockly.Block
-   */
-  mutationToDom: function() {
-
-    var container = document.createElement('mutation');
-    container.setAttribute('proccode', this.procCode_);
-    container.setAttribute('argumentnames', JSON.stringify(this.argumentNames_));
-    container.setAttribute('argumentdefaults', JSON.stringify(this.argumentDefaults_));
-    container.setAttribute('argumentids', JSON.stringify(this.argumentIds_));
-    container.setAttribute('warp', this.warp_);
-    return container;
-  },
-  /**
-   * Parse XML to restore the (non-editable) name and parameters.
-   * @param {!Element} xmlElement XML storage element.
-   * @this Blockly.Block
-   */
-  domToMutation: function(xmlElement) {
-    this.procCode_ = xmlElement.getAttribute('proccode');
-    this.argumentNames_ =  JSON.parse(xmlElement.getAttribute('argumentnames'));
-    this.argumentDefaults_ =  JSON.parse(xmlElement.getAttribute('argumentdefaults'));
-    this.argumentIds_ = JSON.parse(xmlElement.getAttribute('argumentids'));
-    this.warp_ = xmlElement.getAttribute('warp');
-    //this.updateDisplay_();
-  }
+  getProcCode: Blockly.ScratchBlocks.ProcedureUtils.getProcCode,
+  mutationToDom: Blockly.ScratchBlocks.ProcedureUtils.callerMutationToDom,
+  domToMutation: Blockly.ScratchBlocks.ProcedureUtils.callerDomToMutation,
+  removeAllInputs_: Blockly.ScratchBlocks.ProcedureUtils.removeAllInputs_,
+  disconnectOldBlocks_: Blockly.ScratchBlocks.ProcedureUtils.disconnectOldBlocks_,
+  deleteOldShadows_: Blockly.ScratchBlocks.ProcedureUtils.deleteOldShadows_,
+  createAllInputs_: Blockly.ScratchBlocks.ProcedureUtils.createAllInputs_,
+  buildShadowDom_: Blockly.ScratchBlocks.ProcedureUtils.buildShadowDom_,
+  createInput_: Blockly.ScratchBlocks.ProcedureUtils.createInput_,
+  updateDisplay_: Blockly.ScratchBlocks.ProcedureUtils.updateDisplay_,
+  reattachBlock_: Blockly.ScratchBlocks.ProcedureUtils.reattachBlock_,
+  attachShadow_: Blockly.ScratchBlocks.ProcedureUtils.attachShadow_
 };
 

--- a/blocks_vertical/procedures.js
+++ b/blocks_vertical/procedures.js
@@ -28,6 +28,195 @@ goog.provide('Blockly.Blocks.procedures');
 goog.require('Blockly.Blocks');
 goog.require('Blockly.constants');
 
+// TODO: Create a namespace properly.
+Blockly.ScratchBlocks.ProcedureUtils = {};
+
+/**
+ * Returns the name of the procedure this block calls, or the empty string if
+ * it has not yet been set.
+ * @return {string} Procedure name.
+ * @this Blockly.Block
+ */
+Blockly.ScratchBlocks.ProcedureUtils.getProcCode = function() {
+  return this.procCode_;
+};
+
+/**
+ * Create XML to represent the (non-editable) name and arguments.
+ * @return {!Element} XML storage element.
+ * @this Blockly.Block
+ */
+Blockly.ScratchBlocks.ProcedureUtils.callerMutationToDom = function() {
+  var container = document.createElement('mutation');
+  container.setAttribute('proccode', this.procCode_);
+  container.setAttribute('argumentids', JSON.stringify(this.argumentIds_));
+  return container;
+};
+
+/**
+ * Parse XML to restore the (non-editable) name and parameters.
+ * @param {!Element} xmlElement XML storage element.
+ * @this Blockly.Block
+ */
+Blockly.ScratchBlocks.ProcedureUtils.callerDomToMutation = function(xmlElement) {
+  this.procCode_ = xmlElement.getAttribute('proccode');
+  this.argumentIds_ = JSON.parse(xmlElement.getAttribute('argumentids'));
+  this._updateDisplay();
+};
+// TODO: Doc
+Blockly.ScratchBlocks.ProcedureUtils.removeAllInputs_ = function() {
+  // remove all inputs, including dummy inputs.
+  for (var i = 0, input; input = this.inputList[i]; i++) {
+    if (input.connection && input.connection.targetBlock()) {
+      console.warn("connection was still attached?!");
+    }
+    input.dispose();
+  }
+  this.inputList = [];
+};
+// TODO: Doc
+Blockly.ScratchBlocks.ProcedureUtils.disconnectOldBlocks_ = function() {
+  // Remove old stuff
+  var connectionMap = {};
+  for (var id in this.paramMap_) {
+    var input = this.paramMap_[id];
+    console.log(id + ' ' + input);
+    if (input.connection) {
+      // Remove the shadow DOM.  Otherwise a shadow block will respawn
+      // instantly, and we'd have to remove it when we remove the input.
+      input.connection.setShadowDom(null);
+      var target = input.connection.targetBlock();
+      connectionMap[id] = target;
+      if (target) {
+        input.connection.disconnect();
+      }
+    }
+  }
+  return connectionMap;
+};
+// TODO: Doc.
+Blockly.ScratchBlocks.ProcedureUtils.deleteOldShadows_ = function(connectionMap) {
+  // Get rid of all of the old shadow blocks if they aren't connected.
+  if (connectionMap) {
+    for (var id in connectionMap) {
+      var block = connectionMap[id];
+      if (block && block.isShadow()) {
+        block.dispose();
+        connectionMap[id] = null;
+      }
+    }
+  }
+};
+// TODO: Doc.
+Blockly.ScratchBlocks.ProcedureUtils.createAllInputs_ = function(connectionMap) {
+  var params = {};
+  // Split the proc into components, by %n, %b, and %s (ignoring escaped).
+  var procComponents = this.procCode_.split(/(?=[^\\]\%[nbs])/);
+  procComponents = procComponents.map(function(c) {
+    return c.trim(); // Strip whitespace.
+  });
+  // Create inputs and shadow blocks as appropriate.
+  var inputPrefix = 'input';
+  var inputCount = 0;
+  for (var i = 0, component; component = procComponents[i]; i++) {
+    var newLabel;
+    if (component.substring(0, 1) == '%') {
+      var inputType = component.substring(1, 2);
+      newLabel = component.substring(2).trim();
+
+      var id = this.argumentIds_[inputCount];
+      if (connectionMap && (id in connectionMap)) {
+        var oldBlock = connectionMap[id];
+      }
+
+      var inputName = inputPrefix + (inputCount++);
+      var input = this.createInput_(inputType, inputName, oldBlock, id,
+          connectionMap);
+      params[id] = input;
+    } else {
+      newLabel = component.trim();
+    }
+    this.appendDummyInput().appendField(newLabel.replace(/\\%/, '%'));
+  }
+  return params;
+};
+// TODO: Doc, refactor.
+Blockly.ScratchBlocks.ProcedureUtils.buildNumberShadowDom_ = function() {
+  return Blockly.Xml.textToDom(
+      '<xml xmlns="http://www.w3.org/1999/xhtml">' +
+      '<shadow type="math_number">' +
+      '<field name="NUM">10</field>' +
+      '</shadow>' +
+      '</xml>').firstChild;
+};
+// TODO: Doc.
+Blockly.ScratchBlocks.ProcedureUtils.createInput_ = function(inputType, inputName, oldBlock, id, connectionMap) {
+  switch (inputType) {
+    case 'n':
+      var input = this.appendValueInput(inputName);
+      if (oldBlock) {
+        var num = oldBlock;
+        connectionMap[id] = null;
+        input.connection.setShadowDom(this.buildNumberShadowDom_());
+      } else {
+        var num = this.workspace.newBlock('math_number');
+        num.setShadow(true);
+      }
+      num.outputConnection.connect(input.connection);
+      if (!this.isInsertionMarker()) {
+        num.initSvg();
+        num.render(false);
+      }
+      break;
+    case 'b':
+      var input = this.appendValueInput(inputName);
+      input.setCheck('Boolean');
+      if (oldBlock) {
+        oldBlock.outputConnection.connect(input.connection);
+        connectionMap[id] = null;
+        // No shadow DOM.
+      }
+      break;
+    case 's':
+      var input = this.appendValueInput(inputName);
+      if (oldBlock) {
+        var text = oldBlock;
+        connectionMap[id] = null;
+        // TODO: Attach shadow DOM.
+      } else {
+        var text = this.workspace.newBlock('text');
+        text.setShadow(true);
+      }
+      text.outputConnection.connect(input.connection);
+      if (!this.isInsertionMarker()) {
+        text.initSvg();
+        text.render(false);
+      }
+      break;
+  }
+  return input;
+};
+// TODO: Doc, move underscore to end.
+Blockly.ScratchBlocks.ProcedureUtils._updateDisplay = function() {
+  var wasRendered = this.rendered;
+  this.rendered = false;
+
+  if (this.paramMap_) {
+    var connectionMap = this.disconnectOldBlocks_();
+    this.removeAllInputs_();
+  }
+
+  this.paramMap_ = this.createAllInputs_(connectionMap);
+  this.deleteOldShadows_(connectionMap);
+
+  // TODO: Maybe also bump all old non-shadow blocks explicitly.
+
+  this.rendered = wasRendered;
+  if (wasRendered && !this.isInsertionMarker()) {
+    this.initSvg();
+    this.render();
+  }
+};
 
 Blockly.Blocks['procedures_defnoreturn'] = {
   /**
@@ -59,181 +248,16 @@ Blockly.Blocks['procedures_callnoreturn'] = {
     });
     this.procCode_ = '';
   },
-  /**
-   * Returns the name of the procedure this block calls, or the empty string if
-   * it has not yet been set.
-   * @return {string} Procedure name.
-   * @this Blockly.Block
-   */
-  getProcCode: function() {
-    return this.procCode_;
-  },
-  /**
-   * Create XML to represent the (non-editable) name and arguments.
-   * @return {!Element} XML storage element.
-   * @this Blockly.Block
-   */
-  mutationToDom: function() {
-    var container = document.createElement('mutation');
-    container.setAttribute('proccode', this.procCode_);
-    container.setAttribute('argumentids', JSON.stringify(this.argumentIds_));
-    return container;
-  },
-  /**
-   * Parse XML to restore the (non-editable) name and parameters.
-   * @param {!Element} xmlElement XML storage element.
-   * @this Blockly.Block
-   */
-  domToMutation: function(xmlElement) {
-    this.procCode_ = xmlElement.getAttribute('proccode');
-    this.argumentIds_ = JSON.parse(xmlElement.getAttribute('argumentids'));
-    this._updateDisplay();
-  },
-  // TODO: Doc
-  removeAllInputs_: function() {
-    // remove all inputs, including dummy inputs.
-    for (var i = 0, input; input = this.inputList[i]; i++) {
-      if (input.connection && input.connection.targetBlock()) {
-        console.warn("connection was still attached?!");
-      }
-      input.dispose();
-    }
-    this.inputList = [];
-  },
-  // TODO: Doc
-  disconnectOldBlocks_: function() {
-    // Remove old stuff
-    var connectionMap = {};
-    for (var id in this.paramMap_) {
-      var input = this.paramMap_[id];
-      console.log(id + ' ' + input);
-      if (input.connection) {
-        // Remove the shadow DOM.  Otherwise a shadow block will respawn
-        // instantly, and we'd have to remove it when we remove the input.
-        input.connection.setShadowDom(null);
-        var target = input.connection.targetBlock();
-        connectionMap[id] = target;
-        if (target) {
-          input.connection.disconnect();
-        }
-      }
-    }
-    return connectionMap;
-  },
-  // TODO: Doc.
-  deleteOldShadows_: function(connectionMap) {
-    // Get rid of all of the old shadow blocks if they aren't connected.
-    if (connectionMap) {
-      for (var id in connectionMap) {
-        var block = connectionMap[id];
-        if (block && block.isShadow()) {
-          block.dispose();
-          connectionMap[id] = null;
-        }
-      }
-    }
-  },
-  // TODO: Doc.
-  createAllInputs_: function(connectionMap) {
-    var params = {};
-    // Split the proc into components, by %n, %b, and %s (ignoring escaped).
-    var procComponents = this.procCode_.split(/(?=[^\\]\%[nbs])/);
-    procComponents = procComponents.map(function(c) {
-      return c.trim(); // Strip whitespace.
-    });
-    // Create inputs and shadow blocks as appropriate.
-    var inputPrefix = 'input';
-    var inputCount = 0;
-    for (var i = 0, component; component = procComponents[i]; i++) {
-      var newLabel;
-      if (component.substring(0, 1) == '%') {
-        var inputType = component.substring(1, 2);
-        newLabel = component.substring(2).trim();
-
-        var id = this.argumentIds_[inputCount];
-        if (connectionMap && (id in connectionMap)) {
-          var oldBlock = connectionMap[id];
-        }
-
-        var inputName = inputPrefix + (inputCount++);
-        var input = this.createInput_(inputType, inputName, oldBlock, id,
-            connectionMap);
-        params[id] = input;
-      } else {
-        newLabel = component.trim();
-      }
-      this.appendDummyInput().appendField(newLabel.replace(/\\%/, '%'));
-    }
-    return params;
-  },
-  // TODO: Doc.
-  createInput_: function(inputType, inputName, oldBlock, id, connectionMap) {
-    switch (inputType) {
-      case 'n':
-        var input = this.appendValueInput(inputName);
-        if (oldBlock) {
-          var num = oldBlock;
-          connectionMap[id] = null;
-          // TODO: Attach shadow DOM.
-        } else {
-          var num = this.workspace.newBlock('math_number');
-          num.setShadow(true);
-        }
-        num.outputConnection.connect(input.connection);
-        if (!this.isInsertionMarker()) {
-          num.initSvg();
-          num.render(false);
-        }
-        break;
-      case 'b':
-        var input = this.appendValueInput(inputName);
-        input.setCheck('Boolean');
-        if (oldBlock) {
-          oldBlock.outputConnection.connect(input.connection);
-          connectionMap[id] = null;
-          // No shadow DOM.
-        }
-        break;
-      case 's':
-        var input = this.appendValueInput(inputName);
-        if (oldBlock) {
-          var text = oldBlock;
-          connectionMap[id] = null;
-          // TODO: Attach shadow DOM.
-        } else {
-          var text = this.workspace.newBlock('text');
-          text.setShadow(true);
-        }
-        text.outputConnection.connect(input.connection);
-        if (!this.isInsertionMarker()) {
-          text.initSvg();
-          text.render(false);
-        }
-        break;
-    }
-    return input;
-  },
-  // TODO: Doc, move underscore to end.
-  _updateDisplay: function() {
-    var wasRendered = this.rendered;
-    this.rendered = false;
-
-    if (this.paramMap_) {
-      var connectionMap = this.disconnectOldBlocks_();
-      this.removeAllInputs_();
-    }
-
-    this.paramMap_ = this.createAllInputs_(connectionMap);
-    this.deleteOldShadows_(connectionMap);
-
-    // TODO: Maybe also bump all old non-shadow blocks explicitly.
-
-    this.rendered = wasRendered;
-    if (wasRendered && !this.isInsertionMarker()) {
-      this.initSvg();
-      this.render();
-    }
-  }
+  getProcCode: Blockly.ScratchBlocks.ProcedureUtils.getProcCode,
+  mutationToDom: Blockly.ScratchBlocks.ProcedureUtils.callerMutationToDom,
+  domToMutation: Blockly.ScratchBlocks.ProcedureUtils.callerDomToMutation,
+  removeAllInputs_: Blockly.ScratchBlocks.ProcedureUtils.removeAllInputs_,
+  disconnectOldBlocks_: Blockly.ScratchBlocks.ProcedureUtils.disconnectOldBlocks_,
+  deleteOldShadows_: Blockly.ScratchBlocks.ProcedureUtils.deleteOldShadows_,
+  createAllInputs_: Blockly.ScratchBlocks.ProcedureUtils.createAllInputs_,
+  buildNumberShadowDom_: Blockly.ScratchBlocks.ProcedureUtils.buildNumberShadowDom_,
+  createInput_: Blockly.ScratchBlocks.ProcedureUtils.createInput_,
+  _updateDisplay: Blockly.ScratchBlocks.ProcedureUtils._updateDisplay
 };
 
 Blockly.Blocks['procedures_callnoreturn_internal'] = {

--- a/tests/custom_procedure_playground.html
+++ b/tests/custom_procedure_playground.html
@@ -79,7 +79,7 @@
       </statement>
       <next>
           <block id="caller_external" type="procedures_callnoreturn">
-              <mutation proccode="say %s %n times if %b"/>
+              <mutation proccode="say %s %n times if %b" argumentnames="[&quot;something&quot;,&quot;this many&quot;,&quot;this is true&quot;]" argumentdefaults="[&quot;&quot;,1,false]" warp="false" argumentids="[&quot;a42&quot;, &quot;b23&quot;, &quot;c99&quot;]"/>
               <value name="input0">
                   <shadow id="V0~M:TxRk0Ua%osjGzh," type="text">
                       <field name="TEXT"/>
@@ -122,7 +122,7 @@
     var secondaryWorkspace = Blockly.inject('secondaryDiv',
         {media: '../media/'});
 
-    Blockly.Xml.domToWorkspace(document.getElementById('main_ws_blocks_simpler'),
+    Blockly.Xml.domToWorkspace(document.getElementById('main_ws_blocks'),
         secondaryWorkspace);
 
     function applyMutation() {

--- a/tests/custom_procedure_playground.html
+++ b/tests/custom_procedure_playground.html
@@ -66,7 +66,7 @@
 
   <xml id="mutator_blocks" style="display:none">
     <block type="procedures_mutator_root" x="25" y="25" deletable="false">
-    <mutation proccode="say %s %n times if %b" argumentnames="[&quot;something&quot;,&quot;this many&quot;,&quot;this is true&quot;]" argumentdefaults="[&quot;&quot;,1,false]" warp="false"/>
+    <mutation proccode="say %s %n times if %b" argumentnames="[&quot;something&quot;,&quot;this many&quot;,&quot;this is true&quot;]" argumentdefaults="[&quot;&quot;,1,false]" warp="false" argumentids="[&quot;a42&quot;, &quot;b23&quot;, &quot;c99&quot;]"/>
     </block>
   </xml>
 
@@ -74,7 +74,7 @@
     <block id="]){{Y!7N9ezN+j@Vr`8p" type="procedures_defnoreturn" x="25" y="25">
       <statement name="custom_block">
           <shadow type="procedures_callnoreturn_internal" id="caller_internal">
-              <mutation proccode="say %s %n times if %b" argumentnames="[&quot;something&quot;,&quot;this many&quot;,&quot;this is true&quot;]" argumentdefaults="[&quot;&quot;,1,false]" warp="false"/>
+              <mutation proccode="say %s %n times if %b" argumentnames="[&quot;something&quot;,&quot;this many&quot;,&quot;this is true&quot;]" argumentdefaults="[&quot;&quot;,1,false]" warp="false" argumentids="[&quot;a42&quot;, &quot;b23&quot;, &quot;c99&quot;]"/>
           </shadow>
       </statement>
       <next>
@@ -99,7 +99,7 @@
     <block id="]){{Y!7N9ezN+j@Vr`8p" type="procedures_defnoreturn" x="25" y="25">
       <statement name="custom_block">
           <shadow type="procedures_callnoreturn_internal" id="caller_internal">
-              <mutation proccode="say %s %n times if %b" argumentnames="[&quot;something&quot;,&quot;this many&quot;,&quot;this is true&quot;]" argumentdefaults="[&quot;&quot;,1,false]" warp="false"/>
+              <mutation proccode="say %s %n times if %b" argumentnames="[&quot;something&quot;,&quot;this many&quot;,&quot;this is true&quot;]" argumentdefaults="[&quot;&quot;,1,false]" warp="false" argumentids="[&quot;a42&quot;, &quot;b23&quot;, &quot;c99&quot;]"/>
           </shadow>
       </statement>
       <next>

--- a/tests/custom_procedure_playground.html
+++ b/tests/custom_procedure_playground.html
@@ -82,7 +82,7 @@
               <mutation proccode="say %s %n times if %b" argumentnames="[&quot;something&quot;,&quot;this many&quot;,&quot;this is true&quot;]" argumentdefaults="[&quot;&quot;,1,false]" warp="false" argumentids="[&quot;a42&quot;, &quot;b23&quot;, &quot;c99&quot;]"/>
               <value name="input0">
                   <shadow id="V0~M:TxRk0Ua%osjGzh," type="text">
-                      <field name="TEXT"/>
+                      <field name="TEXT"/></field>
                   </shadow>
               </value>
               <value name="input1">

--- a/tests/custom_procedure_playground.html
+++ b/tests/custom_procedure_playground.html
@@ -129,6 +129,7 @@
       var mutation = primaryWorkspace.getTopBlocks()[0].mutationToDom();
       console.log(mutation);
       secondaryWorkspace.getBlockById('caller_external').domToMutation(mutation);
+      secondaryWorkspace.getBlockById('caller_internal').domToMutation(mutation);
     }
 </script>
 


### PR DESCRIPTION
### Resolves

Part of #1185

procedure_callnoreturn blocks can now be updated multiple times, but procedure_callnoreturn_internal blocks cannot.

### Proposed Changes

- Moves procedure functions into a Blockly.ScratchBlocks.ProcedureUtils object that lives in blocks/procedures.js
- Decomposes procedure functions
- Adds comments to procedure mutation functions
- Make procedure_callnoreturn blocks handle mutations being called multiple times
- Adds argumentid to mutations (see https://github.com/LLK/scratch-blocks/issues/1200)
- Keeps shadow blocks and real blocks attached when applying the same mutation twice.

This doesn't yet handle the case where a mutation restructures the procedure call (e.g. moving parameters around.

### Reason for Changes

Make custom procedures better!

### Test Coverage

Tested in custom_procedure_playground.html.  Hitting "ok" applies a mutation to the blocks in the right-side workspace.