### PR TITLE
Fix renaming variable from getter context menu

### DIFF
--- a/blocks_vertical/data.js
+++ b/blocks_vertical/data.js
@@ -531,7 +531,8 @@ Blockly.Constants.Data.RENAME_OPTION_CALLBACK_FACTORY = function(block) {
   return function() {
     var workspace = block.workspace;
     var currentName = block.getField('VARIABLE').text_;
-    Blockly.FieldVariable.renameVariablePrompt(workspace, currentName);
+    var variable = workspace.getVariable(currentName);
+    Blockly.Variables.renameVariable(workspace, variable);
   };
 };
 


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-gui/issues/832

### Proposed Changes

_Describe what this Pull Request does_

Looks like a bad merge or something pointed the rename function to a non-existent function. Updated to make it work similar to how the variable renaming from the field dropdown works (see https://github.com/LLK/scratch-blocks/blob/develop/core/field_variable.js#L230-L235)

### Reason for Changes

_Explain why these changes should be made_

Because it was broken!

### Test Coverage

_Please show how you have added tests to cover your changes_

Tested in the playground, made sure that a correct `VAR_RENAME` event was emitted with the correct variable ID and old/new name. 
