### PR TITLE
Check workspace.isDragging() instead of Blockly.dragMode_

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -1394,7 +1394,7 @@ Blockly.BlockSvg.prototype.bumpNeighbours_ = function() {
   if (!this.workspace) {
     return;  // Deleted block.
   }
-  if (Blockly.dragMode_ != Blockly.DRAG_NONE) {
+  if (this.workspace.isDragging()) {
     return;  // Don't bump blocks during a drag.
   }
   var rootBlock = this.getRootBlock();


### PR DESCRIPTION
Scratch-blocks version of https://github.com/google/blockly/pull/1418
