### PR TITLE
Bring back the list data category

### DIFF
--- a/core/data_category.js
+++ b/core/data_category.js
@@ -62,8 +62,7 @@ Blockly.DataCategory = function(workspace) {
   }
 
   // Now add list variables to the flyout
-  // Disable new list button until it is supported in scratch-vm
-  // Blockly.DataCategory.addCreateButton(xmlList, workspace, 'LIST');
+  Blockly.DataCategory.addCreateButton(xmlList, workspace, 'LIST');
   variableModelList = workspace.getVariablesOfType('list');
   variableModelList.sort(Blockly.VariableModel.compareByName);
   for (var i = 0; i < variableModelList.length; i++) {


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Brings back the "create list" option and in doing so brings back lots of the functionality for working with lists. This depends on https://github.com/LLK/scratch-blocks/pull/1211

List block creation uses the typed variables features of scratch-blocks. The vm will need to be changed quite a bit to bring it up-to-date with typed variables. So we should not expect lists to actually "work" correctly yet with the vm/gui. But they are created and used properly in scratch-blocks (that is, they are created with the list type, are kept separate from the scalar variables in dropdowns, etc.)