### PR TITLE
Make inputs own input shapes, and dispose of them correctly

### DIFF
--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -531,8 +531,10 @@ Blockly.BlockSvg.prototype.updateColour = function() {
   this.svgPath_.setAttribute('fill-opacity', this.getOpacity());
 
   // Update colours of input shapes.
-  for (var shape in this.inputShapes_) {
-    this.inputShapes_[shape].setAttribute('fill', this.getColourTertiary());
+  for (var i = 0, input; input = this.inputList[i]; i++) {
+    if (input.outlinePath) {
+      input.outlinePath.setAttribute('fill', this.getColourTertiary());
+    }
   }
 
   // Render icon(s) if applicable
@@ -577,13 +579,16 @@ Blockly.BlockSvg.prototype.highlightShapeForInput = function(conn, add) {
   if (!input) {
     throw 'No input found for the connection';
   }
-  var inputShape = this.inputShapes_[input.name];
+  if (!input.outlinePath) {
+    return;
+  }
   if (add) {
-    inputShape.setAttribute('filter', 'url(#blocklyReplacementGlowFilter)');
+    input.outlinePath.setAttribute('filter',
+        'url(#blocklyReplacementGlowFilter)');
     Blockly.utils.addClass(/** @type {!Element} */ (this.svgGroup_),
         'blocklyReplaceable');
   } else {
-    inputShape.removeAttribute('filter');
+    input.outlinePath.removeAttribute('filter');
     Blockly.utils.removeClass(/** @type {!Element} */ (this.svgGroup_),
         'blocklyReplaceable');
   }
@@ -1314,7 +1319,7 @@ Blockly.BlockSvg.prototype.renderDrawRight_ = function(steps,
  * @param {Number} y Y offset of input.
  */
 Blockly.BlockSvg.prototype.renderInputShape_ = function(input, x, y) {
-  var inputShape = this.inputShapes_[input.name];
+  var inputShape = input.outlinePath;
   if (!inputShape) {
     // No input shape for this input - e.g., the block is an insertion marker.
     return;

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -66,9 +66,6 @@ Blockly.BlockSvg = function(workspace, prototypeName, opt_id) {
   /** @type {boolean} */
   this.rendered = false;
 
-  /** @type {Object.<string,Element>} */
-  this.inputShapes_ = {};
-
   /**
    * Whether to move the block to the drag surface when it is dragged.
    * True if it should move, false if it should be translated directly.
@@ -146,9 +143,7 @@ Blockly.BlockSvg.prototype.initSvg = function() {
     // Input shapes are empty holes drawn when a value input is not connected.
     for (var i = 0, input; input = this.inputList[i]; i++) {
       input.init();
-      if (input.type === Blockly.INPUT_VALUE) {
-        this.initInputShape(input);
-      }
+      input.initOutlinePath(this.svgGroup_);
     }
     var icons = this.getIcons();
     for (i = 0; i < icons.length; i++) {
@@ -166,27 +161,6 @@ Blockly.BlockSvg.prototype.initSvg = function() {
   if (!this.getSvgRoot().parentNode) {
     this.workspace.getCanvas().appendChild(this.getSvgRoot());
   }
-};
-
-/**
- * Create and initialize the SVG element for an input shape.
- * May be called more than once for an input.
- * @param {!Blockly.Input} input Value input to add a shape SVG element for.
- */
-Blockly.BlockSvg.prototype.initInputShape = function(input) {
-  if (this.inputShapes_[input.name] || input.connection.getShadowDom()) {
-    // Only create the shape elements once, and don't bother creating them if
-    // there's a shadow block that will always cover the input shape.
-    return;
-  }
-  this.inputShapes_[input.name] = Blockly.utils.createSvgElement(
-    'path',
-    {
-      'class': 'blocklyPath',
-      'style': 'visibility: hidden' // Hide by default - shown when not connected.
-    },
-    this.svgGroup_
-  );
 };
 
 /**

--- a/core/input.js
+++ b/core/input.js
@@ -57,6 +57,13 @@ Blockly.Input = function(type, name, block, connection) {
   this.connection = connection;
   /** @type {!Array.<!Blockly.Field>} */
   this.fieldRow = [];
+
+  /**
+   * The shape that is displayed when this input is rendered but not filled.
+   * @type {SVGElement}
+   * @package
+   */
+  this.outlinePath = null;
 };
 
 /**
@@ -241,6 +248,9 @@ Blockly.Input.prototype.init = function() {
  * Sever all links to this input.
  */
 Blockly.Input.prototype.dispose = function() {
+  if (this.outlinePath) {
+    goog.dom.removeNode(this.outlinePath);
+  }
   for (var i = 0, field; field = this.fieldRow[i]; i++) {
     field.dispose();
   }
@@ -248,4 +258,23 @@ Blockly.Input.prototype.dispose = function() {
     this.connection.dispose();
   }
   this.sourceBlock_ = null;
+};
+
+/**
+ * Create the input shape path element and attach it to the given SVG element.
+ * @param {!SVGElement} svgRoot The parent on which ot append the new element.
+ * @package
+ */
+Blockly.Input.prototype.initOutlinePath = function(svgRoot) {
+  if (this.type == Blockly.INPUT_VALUE) {
+    this.outlinePath = Blockly.utils.createSvgElement(
+      'path',
+      {
+        'class': 'blocklyPath',
+        'style': 'visibility: hidden', // Hide by default - shown when not connected.
+        'd': ''  // IE doesn't like paths without the data definition, set an empty default
+      },
+      svgRoot
+      );
+  }
 };


### PR DESCRIPTION
### Resolves

Fixes https://github.com/LLK/scratch-blocks/issues/1218 and https://github.com/LLK/scratch-blocks/issues/1217

### Proposed Changes

Move "input shapes" into the input class, and rename to "outlinePath".  Check for the existence of the path in `Input.dispose` and remove it from the DOM if necessary.  Update callers.

Always have a path on the input shape, even if it's empty.

### Reason for Changes

Input shapes were owned by the block and not being properly disposed of before.  They also caused problems in IE because the SVG was sometimes malformed.

### Test Coverage

Tested in the vertical playground.