### PR TITLE
Custom procedure editing: renaming, adding, and deleting inputs and labels

### DIFF
--- a/blocks_vertical/procedures.js
+++ b/blocks_vertical/procedures.js
@@ -96,8 +96,9 @@ Blockly.ScratchBlocks.ProcedureUtils.definitionMutationToDom = function() {
  */
 Blockly.ScratchBlocks.ProcedureUtils.definitionDomToMutation = function(xmlElement) {
   this.procCode_ = xmlElement.getAttribute('proccode');
-  this.argumentIds_ = JSON.parse(xmlElement.getAttribute('argumentids'));
   this.warp_ = xmlElement.getAttribute('warp');
+
+  this.argumentIds_ = JSON.parse(xmlElement.getAttribute('argumentids'));
   this.argumentNames_ = JSON.parse(xmlElement.getAttribute('argumentnames'));
   this.argumentDefaults_ = JSON.parse(
       xmlElement.getAttribute('argumentdefaults'));
@@ -196,9 +197,7 @@ Blockly.ScratchBlocks.ProcedureUtils.createAllInputs_ = function(connectionMap) 
       }
       newLabel = component.substring(2).trim();
 
-      //var inputName = inputPrefix + inputCount;
-      var inputName = '';
-      this.createInput_(inputType, inputName, inputCount, connectionMap);
+      this.createInput_(inputType, inputCount, connectionMap);
       inputCount++;
     } else {
       newLabel = component.trim();
@@ -214,7 +213,8 @@ Blockly.ScratchBlocks.ProcedureUtils.addLabelCaller_ = function(text) {
 
 Blockly.ScratchBlocks.ProcedureUtils.addLabelMutatorRoot_ = function(text) {
   if (text) {
-    this.appendDummyInput().appendField(new Blockly.FieldTextInput(text));
+    this.appendDummyInput(Blockly.utils.genUid()).
+        appendField(new Blockly.FieldTextInput(text));
   }
 };
 
@@ -328,7 +328,6 @@ Blockly.ScratchBlocks.ProcedureUtils.attachArgumentReporter_ = function(
  * params map.
  * This function is used by the procedures_callnoreturn block.
  * @param {string} type One of 'b' (boolean), 's' (string) or 'n' (number).
- * @param {string} name The name to use when adding the input to the block.
  * @param {number} index The index of this input into the argument id array.
  * @param {!Object.<string, Blockly.Block>} connectionMap An object mapping
  *     parameter IDs to the blocks that were connected to those IDs at the
@@ -336,8 +335,8 @@ Blockly.ScratchBlocks.ProcedureUtils.attachArgumentReporter_ = function(
  * @private
  * @this Blockly.Block
  */
-Blockly.ScratchBlocks.ProcedureUtils.createInput_ = function(type, name,
-    index, connectionMap) {
+Blockly.ScratchBlocks.ProcedureUtils.createInput_ = function(type, index,
+    connectionMap) {
   var id = this.argumentIds_[index];
   var oldBlock = null;
   if (connectionMap && (id in connectionMap)) {
@@ -358,7 +357,6 @@ Blockly.ScratchBlocks.ProcedureUtils.createInput_ = function(type, name,
  * This function is used by the procedures_callnoreturn_internal block.
  * TODO (#1213) consider renaming.
  * @param {string} type One of 'b' (boolean), 's' (string) or 'n' (number).
- * @param {string} name The name to use when adding the input to the block.
  * @param {number} index The index of this input into the argument id and name
  *     arrays.
  * @param {!Object.<string, Blockly.Block>} connectionMap An object mapping
@@ -368,7 +366,7 @@ Blockly.ScratchBlocks.ProcedureUtils.createInput_ = function(type, name,
  * @this Blockly.Block
  */
 Blockly.ScratchBlocks.ProcedureUtils.createInputCallerInternal_ = function(type,
-    name, index, connectionMap) {
+    index, connectionMap) {
   var id = this.argumentIds_[index];
   var argumentText = this.argumentNames_[index];
   var oldBlock = null;
@@ -393,7 +391,6 @@ Blockly.ScratchBlocks.ProcedureUtils.createInputCallerInternal_ = function(type,
  * This function is used by the procedures_callnoreturn_internal block.
  * TODO (#1213) consider renaming.
  * @param {string} type One of 'b' (boolean), 's' (string) or 'n' (number).
- * @param {string} name The name to use when adding the input to the block.
  * @param {number} index The index of this input into the argument id and name
  *     arrays.
  * @param {!Object.<string, Blockly.Block>} connectionMap An object mapping
@@ -403,7 +400,7 @@ Blockly.ScratchBlocks.ProcedureUtils.createInputCallerInternal_ = function(type,
  * @this Blockly.Block
  */
 Blockly.ScratchBlocks.ProcedureUtils.createInputMutatorRoot_ = function(type,
-    name, index, connectionMap) {
+    index, connectionMap) {
   var id = this.argumentIds_[index];
   var argumentText = this.argumentNames_[index];
 
@@ -516,33 +513,30 @@ Blockly.ScratchBlocks.ProcedureUtils.updateDisplay_ = function() {
 };
 
 Blockly.ScratchBlocks.ProcedureUtils.updateProcCodeMutatorRoot_ = function() {
-  var procCode = '';
-  var argumentNames = [];
-  var argumentIds = [];
+  this.procCode_ = '';
+  this.argumentNames_ = [];
+  this.argumentIds_ = [];
   for (var i = 0; i < this.inputList.length; i++) {
     if (i != 0) {
-      procCode += ' ';
+      this.procCode_ += ' ';
     }
     var input = this.inputList[i];
     if (input.type == Blockly.DUMMY_INPUT) {
-      procCode += input.fieldRow[0].getValue();
+      this.procCode_ += input.fieldRow[0].getValue();
     } else if (input.type == Blockly.INPUT_VALUE) {
       var target = input.connection.targetBlock();
-      argumentNames.push(target.getFieldValue('TEXT'));
-      argumentIds.push(input.name);
+      this.argumentNames_.push(target.getFieldValue('TEXT'));
+      this.argumentIds_.push(input.name);
       if (target.type == 'boolean_textinput') {
-        procCode += '%b';
+        this.procCode_ += '%b';
       } else {
-        procCode += '%s';
+        this.procCode_ += '%s';
       }
     } else {
       throw new Error(
           'Unexpected input type on a procedure mutator root: ' + input.type);
     }
   }
-  this.procCode_ = procCode;
-  this.argumentNames_ = argumentNames;
-  this.argumentIds_ = argumentIds;
 };
 
 Blockly.ScratchBlocks.ProcedureUtils.addLabelExternal = function() {
@@ -564,30 +558,6 @@ Blockly.ScratchBlocks.ProcedureUtils.addStringNumberExternal = function() {
   this.argumentIds_.push(Blockly.utils.genUid());
   this.argumentDefaults_.push('todo');
   this.updateDisplay_();
-};
-
-Blockly.ScratchBlocks.ProcedureUtils.mutatorRootMutationToDom_ = function() {
-  this.procCode_ = this.getProcCode();
-
-  // Update argument names array.
-  var children = this.getChildren();
-  this.argumentNames_ = [];
-  for (var i = 0; i < children.length; i++) {
-    this.argumentNames_.push(children[i].getFieldValue('TEXT'));
-  }
-
-  this.argumentDefaults_ = ['argument', 'defaults', 'not', 'implemented'];
-  this.warp_ = false;
-
-
-  var container = document.createElement('mutation');
-  container.setAttribute('proccode', this.procCode_);
-  container.setAttribute('argumentids', JSON.stringify(this.argumentIds_));
-  container.setAttribute('argumentnames', JSON.stringify(this.argumentNames_));
-  container.setAttribute('argumentdefaults',
-      JSON.stringify(this.argumentDefaults_));
-  container.setAttribute('warp', this.warp_);
-  return container;
 };
 
 Blockly.Blocks['procedures_defnoreturn'] = {
@@ -808,7 +778,7 @@ Blockly.Blocks['procedures_mutator_root'] = {
     this.paramMap_ = null;
   },
   getProcCode: Blockly.ScratchBlocks.ProcedureUtils.getProcCode,
-  mutationToDom: Blockly.ScratchBlocks.ProcedureUtils.mutatorRootMutationToDom_,
+  mutationToDom: Blockly.ScratchBlocks.ProcedureUtils.definitionMutationToDom,
   domToMutation: Blockly.ScratchBlocks.ProcedureUtils.definitionDomToMutation,
   removeAllInputs_: Blockly.ScratchBlocks.ProcedureUtils.removeAllInputs_,
   disconnectOldBlocks_: Blockly.ScratchBlocks.ProcedureUtils.disconnectOldBlocks_,

--- a/blocks_vertical/procedures.js
+++ b/blocks_vertical/procedures.js
@@ -211,7 +211,7 @@ Blockly.ScratchBlocks.ProcedureUtils.createAllInputs_ = function(connectionMap) 
       if (inputType == 'b') {
         input.setCheck('Boolean');
       }
-      this.populateInput_(inputType, inputCount, connectionMap, id, oldBlock, input);
+      this.populateInput_(inputType, inputCount, connectionMap, oldBlock, input);
       inputCount++;
     } else {
       newLabel = component.trim();
@@ -242,10 +242,23 @@ Blockly.ScratchBlocks.ProcedureUtils.deleteShadows_ = function(connectionMap) {
 };
 // End of shared code.
 
+/**
+ * Add a label with the given text to a procedures_callnoreturn or
+ * procedures_callnoreturn_internal block.
+ * @param {string} text The label text.
+ * @private
+ */
 Blockly.ScratchBlocks.ProcedureUtils.addLabelCaller_ = function(text) {
   this.appendDummyInput().appendField(text);
 };
 
+/**
+ * Add a label editor with the given text to a procedures_declaration_root
+ * block.  Editing the text in the new input updates the text of the
+ * corresponding labels on function calls.
+ * @param {string} text The label text.
+ * @private
+ */
 Blockly.ScratchBlocks.ProcedureUtils.addLabelMutatorRoot_ = function(text) {
   if (text) {
     this.appendDummyInput(Blockly.utils.genUid()).
@@ -314,8 +327,8 @@ Blockly.ScratchBlocks.ProcedureUtils.attachShadow_ = function(input, inputType) 
  * @private
  * @this Blockly.Block
  */
-Blockly.ScratchBlocks.ProcedureUtils.attachArgumentReporter_ = function(
-    input, inputType, displayName) {
+Blockly.ScratchBlocks.ProcedureUtils.attachArgumentReporter_ = function(input,
+    inputType, displayName) {
   if (inputType == 'n' || inputType == 's') {
     var blockType = 'argument_reporter_string_number';
   } else {
@@ -332,21 +345,24 @@ Blockly.ScratchBlocks.ProcedureUtils.attachArgumentReporter_ = function(
 };
 
 /**
- * Create an input and attach the correct block to it.
+ * Populate the given input with the correct child block or values.
  * This function is used by the procedures_callnoreturn block.
  * @param {string} type One of 'b' (boolean), 's' (string) or 'n' (number).
  * @param {number} index The index of this input into the argument id array.
  * @param {!Object.<string, Blockly.Block>} connectionMap An object mapping
  *     parameter IDs to the blocks that were connected to those IDs at the
  *     beginning of the mutation.
+ * @param {Blockly.BlockSvg} oldBlock The block that was previously connected to
+ *     this input, or null.
+ * @param {!Blockly.Input} input The newly created input to populate.
  * @private
  * @this Blockly.Block
  */
 Blockly.ScratchBlocks.ProcedureUtils.populateInputCaller_ = function(type, index,
-    connectionMap, id, oldBlock, input) {
+    connectionMap, oldBlock, input) {
   if (connectionMap && oldBlock) {
     // Reattach the old block.
-    connectionMap[id] = null;
+    connectionMap[input.name] = null;
     oldBlock.outputConnection.connect(input.connection);
     if (type != 'b') {
       input.connection.setShadowDom(this.buildShadowDom_(type));
@@ -357,7 +373,7 @@ Blockly.ScratchBlocks.ProcedureUtils.populateInputCaller_ = function(type, index
 };
 
 /**
- * Create an input and attach the correct block to it.
+ * Populate the given input with the correct child block or values.
  * This function is used by the procedures_callnoreturn_internal block.
  * TODO (#1213) consider renaming.
  * @param {string} type One of 'b' (boolean), 's' (string) or 'n' (number).
@@ -366,11 +382,14 @@ Blockly.ScratchBlocks.ProcedureUtils.populateInputCaller_ = function(type, index
  * @param {!Object.<string, Blockly.Block>} connectionMap An object mapping
  *     parameter IDs to the blocks that were connected to those IDs at the
  *     beginning of the mutation.
+ * @param {Blockly.BlockSvg} oldBlock The block that was previously connected to
+ *     this input, or null.
+ * @param {!Blockly.Input} input The newly created input to populate.
  * @private
  * @this Blockly.Block
  */
 Blockly.ScratchBlocks.ProcedureUtils.populateInputCallerInternal_ = function(type,
-    index, connectionMap, id, oldBlock, input) {
+    index, connectionMap, oldBlock, input) {
   var oldTypeMatches =
     Blockly.ScratchBlocks.ProcedureUtils.checkOldTypeMatches_(oldBlock, type);
   var displayName = this.displayNames_[index];
@@ -379,7 +398,7 @@ Blockly.ScratchBlocks.ProcedureUtils.populateInputCallerInternal_ = function(typ
     // The old block is the same type, and on the same input, but the input name
     // may have changed.
     oldBlock.setFieldValue(displayName, 'VALUE');
-    connectionMap[id] = null;
+    connectionMap[input.name] = null;
     oldBlock.outputConnection.connect(input.connection);
   } else {
     this.attachArgumentReporter_(input, type, displayName);
@@ -387,7 +406,7 @@ Blockly.ScratchBlocks.ProcedureUtils.populateInputCallerInternal_ = function(typ
 };
 
 /**
- * Create an input and attach the correct block to it.
+ * Populate the given input with the correct child block or values.
  * This function is used by the procedures_callnoreturn_internal block.
  * TODO (#1213) consider renaming.
  * @param {string} type One of 'b' (boolean), 's' (string) or 'n' (number).
@@ -396,18 +415,21 @@ Blockly.ScratchBlocks.ProcedureUtils.populateInputCallerInternal_ = function(typ
  * @param {!Object.<string, Blockly.Block>} connectionMap An object mapping
  *     parameter IDs to the blocks that were connected to those IDs at the
  *     beginning of the mutation.
+ * @param {Blockly.BlockSvg} oldBlock The block that was previously connected to
+ *     this input, or null.
+ * @param {!Blockly.Input} input The newly created input to populate.
  * @private
  * @this Blockly.Block
  */
-Blockly.ScratchBlocks.ProcedureUtils.populateInputMutatorRoot_ = function(type,
-    index, connectionMap, id, oldBlock, input) {
+Blockly.ScratchBlocks.ProcedureUtils.populateInputDeclarationRoot_ = function(type,
+    index, connectionMap, oldBlock, input) {
   var oldTypeMatches =
     Blockly.ScratchBlocks.ProcedureUtils.checkOldTypeMatches_(oldBlock, type);
 
   var displayName = this.displayNames_[index];
   if (connectionMap && oldBlock && oldTypeMatches) {
     oldBlock.setFieldValue(displayName, 'TEXT');
-    connectionMap[id] = null;
+    connectionMap[input.name] = null;
     oldBlock.outputConnection.connect(input.connection);
   } else {
     this.attachShadow_(input, type, displayName);
@@ -437,6 +459,8 @@ Blockly.ScratchBlocks.ProcedureUtils.checkOldTypeMatches_ = function(oldBlock,
 
 /**
  * Create a new shadow block and attach it to the given input.
+ * The shadow block has a single text field which is used to set the display
+ * name of the argument.
  * @param {!Blockly.Input} input The value input to attach a block to.
  * @param {string} inputType One of 'b' (boolean), 's' (string) or 'n' (number).
  * @param {string} displayName The display name  of this argument, which is the
@@ -444,8 +468,8 @@ Blockly.ScratchBlocks.ProcedureUtils.checkOldTypeMatches_ = function(oldBlock,
  * @private
  * @this Blockly.Block
  */
-Blockly.ScratchBlocks.ProcedureUtils.attachShadowMutatorRoot_ = function(input,
-    inputType, displayName) {
+Blockly.ScratchBlocks.ProcedureUtils.attachShadowDeclarationRoot_ = function(
+    input, inputType, displayName) {
   if (inputType == 'n' || inputType == 's') {
     var newBlock = this.workspace.newBlock('text');
   } else {
@@ -464,7 +488,7 @@ Blockly.ScratchBlocks.ProcedureUtils.attachShadowMutatorRoot_ = function(input,
  * Update the serializable information on the block based on the existing inputs
  * and their text.
  */
-Blockly.ScratchBlocks.ProcedureUtils.updateProcCodeMutatorRoot_ = function() {
+Blockly.ScratchBlocks.ProcedureUtils.updateProcCodeDeclarationRoot_ = function() {
   this.procCode_ = '';
   this.displayNames_ = [];
   this.argumentIds_ = [];
@@ -509,7 +533,6 @@ Blockly.ScratchBlocks.ProcedureUtils.addBooleanExternal = function() {
   this.displayNames_.push('boolean');
   this.argumentIds_.push(Blockly.utils.genUid());
   this.argumentDefaults_.push('todo');
-  console.log(this.argumentIds_);
   this.updateDisplay_();
 };
 
@@ -690,15 +713,15 @@ Blockly.Blocks['procedures_declaration_root'] = {
   // Exist on all three blocks, but have different implementations.
   mutationToDom: Blockly.ScratchBlocks.ProcedureUtils.definitionMutationToDom,
   domToMutation: Blockly.ScratchBlocks.ProcedureUtils.definitionDomToMutation,
-  populateInput_: Blockly.ScratchBlocks.ProcedureUtils.populateInputMutatorRoot_,
+  populateInput_: Blockly.ScratchBlocks.ProcedureUtils.populateInputDeclarationRoot_,
   addLabel_: Blockly.ScratchBlocks.ProcedureUtils.addLabelMutatorRoot_,
 
   // Shared with procedures_callnoreturn, but with a different implementation.
-  attachShadow_: Blockly.ScratchBlocks.ProcedureUtils.attachShadowMutatorRoot_,
+  attachShadow_: Blockly.ScratchBlocks.ProcedureUtils.attachShadowDeclarationRoot_,
 
   // Only exist on the mutator root.
   addLabelExternal: Blockly.ScratchBlocks.ProcedureUtils.addLabelExternal,
   addBooleanExternal: Blockly.ScratchBlocks.ProcedureUtils.addBooleanExternal,
   addStringNumberExternal: Blockly.ScratchBlocks.ProcedureUtils.addStringNumberExternal,
-  onChangeFn: Blockly.ScratchBlocks.ProcedureUtils.updateProcCodeMutatorRoot_
+  onChangeFn: Blockly.ScratchBlocks.ProcedureUtils.updateProcCodeDeclarationRoot_
 };

--- a/blocks_vertical/procedures.js
+++ b/blocks_vertical/procedures.js
@@ -604,63 +604,6 @@ Blockly.Blocks['procedures_callnoreturn_internal'] = {
   attachArgumentReporter_: Blockly.ScratchBlocks.ProcedureUtils.attachArgumentReporter_
 };
 
-Blockly.Blocks['procedures_param'] = {
-  /**
-   * Block for a parameter.
-   * @this Blockly.Block
-   */
-  init: function() {
-    this.appendDummyInput()
-        .appendField(new Blockly.FieldLabel(), 'paramName');
-
-    this.setPreviousStatement(false);
-    this.setNextStatement(false);
-    this.setOutput(true);
-
-    this.setCategory(Blockly.Categories.more);
-    this.setColour(Blockly.Colours.more.primary,
-      Blockly.Colours.more.secondary,
-      Blockly.Colours.more.tertiary);
-    this._paramName = 'undefined';
-    this._shape = 'r';
-  },
-  /**
-   * Create XML to represent the (non-editable) name and arguments.
-   * @return {!Element} XML storage element.
-   * @this Blockly.Block
-   */
-  mutationToDom: function() {
-    var container = document.createElement('mutation');
-    container.setAttribute('paramname', this._paramName);
-    container.setAttribute('shape', this._shape);
-    return container;
-  },
-  /**
-   * Parse XML to restore the (non-editable) name and parameters.
-   * @param {!Element} xmlElement XML storage element.
-   * @this Blockly.Block
-   */
-  domToMutation: function(xmlElement) {
-    this._paramName = xmlElement.getAttribute('paramname');
-    this._shape = xmlElement.getAttribute('shape');
-    this.updateDisplay_();
-  },
-  updateDisplay_: function() {
-    this.setFieldValue(this._paramName, 'paramName');
-    switch (this._shape) {
-      case 'b':
-        this.setOutputShape(Blockly.OUTPUT_SHAPE_HEXAGONAL);
-        this.setOutput(true, 'Boolean');
-        break;
-      case 's':
-      default:
-        this.setOutputShape(Blockly.OUTPUT_SHAPE_ROUND);
-        this.setOutput(true, 'String');
-        break;
-    }
-  }
-};
-
 Blockly.Blocks['argument_reporter_boolean'] = {
   init: function() {
     this.jsonInit({ "message0": " %1",

--- a/blocks_vertical/procedures.js
+++ b/blocks_vertical/procedures.js
@@ -64,7 +64,7 @@ Blockly.ScratchBlocks.ProcedureUtils.callerDomToMutation = function(xmlElement) 
 /**
  * Create XML to represent the (non-editable) name and arguments of a procedure
  * definition block (procedures_callnoreturn_internal, which is part of a definition,
- * or procedures_mutator_root).
+ * or procedures_declaration_root).
  * @return {!Element} XML storage element.
  * @this Blockly.Block
  */
@@ -82,7 +82,7 @@ Blockly.ScratchBlocks.ProcedureUtils.definitionMutationToDom = function() {
 /**
  * Parse XML to restore the (non-editable) name and parameters of a procedure
  * definition block (procedures_callnoreturn_internal, which is part of a definition,
- * or procedures_mutator_root).
+ * or procedures_declaration_root).
  * @param {!Element} xmlElement XML storage element.
  * @this Blockly.Block
  */
@@ -585,7 +585,7 @@ Blockly.Blocks['procedures_callnoreturn'] = {
   populateInput_: Blockly.ScratchBlocks.ProcedureUtils.populateInputCaller_,
   addLabel_: Blockly.ScratchBlocks.ProcedureUtils.addLabelCaller_,
 
-  // Shared with procedures_mutator_root, but with a different implementation.
+  // Shared with procedures_declaration_root, but with a different implementation.
   attachShadow_: Blockly.ScratchBlocks.ProcedureUtils.attachShadow_,
 
   // Only exists on the external caller.
@@ -682,7 +682,7 @@ Blockly.Blocks['boolean_textinput'] = {
   }
 };
 
-Blockly.Blocks['procedures_mutator_root'] = {
+Blockly.Blocks['procedures_declaration_root'] = {
   /**
    * The root block in the procedure editing workspace.
    * @this Blockly.Block

--- a/blocks_vertical/procedures.js
+++ b/blocks_vertical/procedures.js
@@ -184,7 +184,7 @@ Blockly.ScratchBlocks.ProcedureUtils.createAllInputs_ = function(connectionMap) 
     return c.trim(); // Strip whitespace.
   });
   // Create inputs and shadow blocks as appropriate.
-  var inputPrefix = 'input';
+  //var inputPrefix = 'input';
   var inputCount = 0;
   for (var i = 0, component; component = procComponents[i]; i++) {
     var newLabel;
@@ -196,7 +196,8 @@ Blockly.ScratchBlocks.ProcedureUtils.createAllInputs_ = function(connectionMap) 
       }
       newLabel = component.substring(2).trim();
 
-      var inputName = inputPrefix + inputCount;
+      //var inputName = inputPrefix + inputCount;
+      var inputName = '';
       this.createInput_(inputType, inputName, inputCount, connectionMap);
       inputCount++;
     } else {
@@ -342,7 +343,7 @@ Blockly.ScratchBlocks.ProcedureUtils.createInput_ = function(type, name,
   if (connectionMap && (id in connectionMap)) {
     oldBlock = connectionMap[id];
   }
-  var input = this.appendValueInput(name);
+  var input = this.appendValueInput(id);
   if (connectionMap && oldBlock) {
     this.reattachBlock_(input, type, oldBlock, id, connectionMap);
   } else {
@@ -376,7 +377,7 @@ Blockly.ScratchBlocks.ProcedureUtils.createInputCallerInternal_ = function(type,
   }
   var oldTypeMatches =
     Blockly.ScratchBlocks.ProcedureUtils.checkOldTypeMatches_(oldBlock, type);
-  var input = this.appendValueInput(name);
+  var input = this.appendValueInput(id);
   if (connectionMap && oldBlock && oldTypeMatches) {
     this.reattachBlock_(input, type, oldBlock, id, connectionMap);
     oldBlock.setFieldValue(argumentText, 'VALUE');
@@ -410,7 +411,7 @@ Blockly.ScratchBlocks.ProcedureUtils.createInputMutatorRoot_ = function(type,
   if (connectionMap && (id in connectionMap)) {
     oldBlock = connectionMap[id];
   }
-  var input = this.appendValueInput(name);
+  var input = this.appendValueInput(id);
 
   var oldTypeMatches =
     Blockly.ScratchBlocks.ProcedureUtils.checkOldTypeMatches_(oldBlock, type);
@@ -517,6 +518,7 @@ Blockly.ScratchBlocks.ProcedureUtils.updateDisplay_ = function() {
 Blockly.ScratchBlocks.ProcedureUtils.updateProcCodeMutatorRoot_ = function() {
   var procCode = '';
   var argumentNames = [];
+  var argumentIds = [];
   for (var i = 0; i < this.inputList.length; i++) {
     if (i != 0) {
       procCode += ' ';
@@ -525,8 +527,10 @@ Blockly.ScratchBlocks.ProcedureUtils.updateProcCodeMutatorRoot_ = function() {
     if (input.type == Blockly.DUMMY_INPUT) {
       procCode += input.fieldRow[0].getValue();
     } else if (input.type == Blockly.INPUT_VALUE) {
-      argumentNames.push(input.connection.targetBlock().getFieldValue('TEXT'));
-      if (input.connection.targetBlock().type == 'boolean_textinput') {
+      var target = input.connection.targetBlock();
+      argumentNames.push(target.getFieldValue('TEXT'));
+      argumentIds.push(input.name);
+      if (target.type == 'boolean_textinput') {
         procCode += '%b';
       } else {
         procCode += '%s';
@@ -538,6 +542,7 @@ Blockly.ScratchBlocks.ProcedureUtils.updateProcCodeMutatorRoot_ = function() {
   }
   this.procCode_ = procCode;
   this.argumentNames_ = argumentNames;
+  this.argumentIds_ = argumentIds;
 };
 
 Blockly.ScratchBlocks.ProcedureUtils.addLabelExternal = function() {

--- a/blocks_vertical/procedures.js
+++ b/blocks_vertical/procedures.js
@@ -185,7 +185,6 @@ Blockly.ScratchBlocks.ProcedureUtils.createAllInputs_ = function(connectionMap) 
     return c.trim(); // Strip whitespace.
   });
   // Create inputs and shadow blocks as appropriate.
-  //var inputPrefix = 'input';
   var inputCount = 0;
   for (var i = 0, component; component = procComponents[i]; i++) {
     var newLabel;
@@ -202,8 +201,7 @@ Blockly.ScratchBlocks.ProcedureUtils.createAllInputs_ = function(connectionMap) 
     } else {
       newLabel = component.trim();
     }
-    newLabel.replace(/\\%/, '%');
-    this.addLabel_(newLabel);
+    this.addLabel_(newLabel.replace(/\\%/, '%'));
   }
 };
 
@@ -330,6 +328,9 @@ Blockly.ScratchBlocks.ProcedureUtils.createInput_ = function(type, index,
     // Reattach the old block.
     connectionMap[id] = null;
     oldBlock.outputConnection.connect(input.connection);
+    if (type != 'b') {
+      input.connection.setShadowDom(this.buildShadowDom_(type));
+    }
   } else {
     this.attachShadow_(input, type);
   }
@@ -620,7 +621,6 @@ Blockly.Blocks['procedures_callnoreturn_internal'] = {
   disconnectOldBlocks_: Blockly.ScratchBlocks.ProcedureUtils.disconnectOldBlocks_,
   deleteShadows_: Blockly.ScratchBlocks.ProcedureUtils.deleteShadows_,
   createAllInputs_: Blockly.ScratchBlocks.ProcedureUtils.createAllInputs_,
-  buildShadowDom_: Blockly.ScratchBlocks.ProcedureUtils.buildShadowDom_,
   createInput_: Blockly.ScratchBlocks.ProcedureUtils.createInputCallerInternal_,
   updateDisplay_: Blockly.ScratchBlocks.ProcedureUtils.updateDisplay_,
   reattachBlock_: Blockly.ScratchBlocks.ProcedureUtils.reattachBlock_,
@@ -762,7 +762,6 @@ Blockly.Blocks['procedures_mutator_root'] = {
   disconnectOldBlocks_: Blockly.ScratchBlocks.ProcedureUtils.disconnectOldBlocks_,
   deleteShadows_: Blockly.ScratchBlocks.ProcedureUtils.deleteShadows_,
   createAllInputs_: Blockly.ScratchBlocks.ProcedureUtils.createAllInputs_,
-  buildShadowDom_: Blockly.ScratchBlocks.ProcedureUtils.buildShadowDom_,
   createInput_: Blockly.ScratchBlocks.ProcedureUtils.createInputMutatorRoot_,
   updateDisplay_: Blockly.ScratchBlocks.ProcedureUtils.updateDisplay_,
   attachShadow_: Blockly.ScratchBlocks.ProcedureUtils.attachShadowMutatorRoot_,

--- a/blocks_vertical/procedures.js
+++ b/blocks_vertical/procedures.js
@@ -120,10 +120,8 @@ Blockly.ScratchBlocks.ProcedureUtils.updateDisplay_ = function() {
   var wasRendered = this.rendered;
   this.rendered = false;
 
-  if (this.paramMap_) {
-    var connectionMap = this.disconnectOldBlocks_();
-    this.removeAllInputs_();
-  }
+  var connectionMap = this.disconnectOldBlocks_();
+  this.removeAllInputs_();
 
   this.createAllInputs_(connectionMap);
   this.deleteShadows_(connectionMap);
@@ -147,14 +145,13 @@ Blockly.ScratchBlocks.ProcedureUtils.updateDisplay_ = function() {
 Blockly.ScratchBlocks.ProcedureUtils.disconnectOldBlocks_ = function() {
   // Remove old stuff
   var connectionMap = {};
-  for (var id in this.paramMap_) {
-    var input = this.paramMap_[id];
+  for (var i = 0, input; input = this.inputList[i]; i++) {
     if (input.connection) {
       // Remove the shadow DOM.  Otherwise a shadow block will respawn
       // instantly, and we'd have to remove it when we remove the input.
       input.connection.setShadowDom(null);
       var target = input.connection.targetBlock();
-      connectionMap[id] = target;
+      connectionMap[input.name] = target;
       if (target) {
         input.connection.disconnect();
       }
@@ -188,7 +185,6 @@ Blockly.ScratchBlocks.ProcedureUtils.removeAllInputs_ = function() {
  * @this Blockly.Block
  */
 Blockly.ScratchBlocks.ProcedureUtils.createAllInputs_ = function(connectionMap) {
-  this.paramMap_ = {};
   // Split the proc into components, by %n, %b, and %s (ignoring escaped).
   var procComponents = this.procCode_.split(/(?=[^\\]\%[nbs])/);
   procComponents = procComponents.map(function(c) {
@@ -336,8 +332,7 @@ Blockly.ScratchBlocks.ProcedureUtils.attachArgumentReporter_ = function(
 };
 
 /**
- * Create an input, attach the correct block to it, and insert it into the
- * params map.
+ * Create an input and attach the correct block to it.
  * This function is used by the procedures_callnoreturn block.
  * @param {string} type One of 'b' (boolean), 's' (string) or 'n' (number).
  * @param {number} index The index of this input into the argument id array.
@@ -359,12 +354,10 @@ Blockly.ScratchBlocks.ProcedureUtils.populateInputCaller_ = function(type, index
   } else {
     this.attachShadow_(input, type);
   }
-  this.paramMap_[id] = input;
 };
 
 /**
- * Create an input, attach the correct block to it, and insert it into the
- * params map.
+ * Create an input and attach the correct block to it.
  * This function is used by the procedures_callnoreturn_internal block.
  * TODO (#1213) consider renaming.
  * @param {string} type One of 'b' (boolean), 's' (string) or 'n' (number).
@@ -391,12 +384,10 @@ Blockly.ScratchBlocks.ProcedureUtils.populateInputCallerInternal_ = function(typ
   } else {
     this.attachArgumentReporter_(input, type, displayName);
   }
-  this.paramMap_[id] = input;
 };
 
 /**
- * Create an input, attach the correct block to it, and insert it into the
- * params map.
+ * Create an input and attach the correct block to it.
  * This function is used by the procedures_callnoreturn_internal block.
  * TODO (#1213) consider renaming.
  * @param {string} type One of 'b' (boolean), 's' (string) or 'n' (number).
@@ -421,7 +412,6 @@ Blockly.ScratchBlocks.ProcedureUtils.populateInputMutatorRoot_ = function(type,
   } else {
     this.attachShadow_(input, type, displayName);
   }
-  this.paramMap_[id] = input;
 };
 
 /**
@@ -519,6 +509,7 @@ Blockly.ScratchBlocks.ProcedureUtils.addBooleanExternal = function() {
   this.displayNames_.push('boolean');
   this.argumentIds_.push(Blockly.utils.genUid());
   this.argumentDefaults_.push('todo');
+  console.log(this.argumentIds_);
   this.updateDisplay_();
 };
 
@@ -564,12 +555,8 @@ Blockly.Blocks['procedures_callnoreturn'] = {
       "extensions": ["colours_more", "shape_statement", "procedure_call_contextmenu"]
     });
     this.procCode_ = '';
-    /**
-     * @type {!Object.<string, Blockly.Block>}
-     * An object mapping parameter IDs to the blocks that are connected to those
-     * IDs.
-     */
-    this.paramMap_ = null;
+    this.argumentIds_ = [];
+    this.warp_ = false;
   },
   // Shared.
   getProcCode: Blockly.ScratchBlocks.ProcedureUtils.getProcCode,
@@ -606,15 +593,9 @@ Blockly.Blocks['procedures_callnoreturn_internal'] = {
     /* Data known about the procedure. */
     this.procCode_ = '';
     this.displayNames_ = [];
+    this.argumentIds_ = [];
     this.argumentDefaults_ = [];
     this.warp_ = false;
-
-    /**
-     * @type {!Object.<string, Blockly.Block>}
-     * An object mapping parameter IDs to the blocks that are connected to those
-     * IDs.
-     */
-    this.paramMap_ = null;
   },
   // Shared.
   getProcCode: Blockly.ScratchBlocks.ProcedureUtils.getProcCode,
@@ -694,15 +675,9 @@ Blockly.Blocks['procedures_declaration_root'] = {
     /* Data known about the procedure. */
     this.procCode_ = '';
     this.displayNames_ = [];
+    this.argumentIds_ = [];
     this.argumentDefaults_ = [];
     this.warp_ = false;
-
-    /**
-     * @type {!Object.<string, Blockly.Block>}
-     * An object mapping parameter IDs to the blocks that are connected to those
-     * IDs.
-     */
-    this.paramMap_ = null;
   },
   // Shared.
   getProcCode: Blockly.ScratchBlocks.ProcedureUtils.getProcCode,

--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -491,12 +491,6 @@ Blockly.BlockSvg.TOP_RIGHT_CORNER_DEFINE_HAT =
 Blockly.BlockSvg.DEFINE_BLOCK_PADDING_RIGHT = 2 * Blockly.BlockSvg.GRID_UNIT;
 
 /**
- * The type of all define blocks, which have custom rendering.
- * @cost
- */
-Blockly.BlockSvg.DEFINE_BLOCK_TYPE = 'procedures_defnoreturn';
-
-/**
  * Change the colour of a block.
  */
 Blockly.BlockSvg.prototype.updateColour = function() {
@@ -1159,7 +1153,7 @@ Blockly.BlockSvg.prototype.renderClassify_ = function() {
  */
 Blockly.BlockSvg.prototype.renderDrawTop_ = function(steps, rightEdge) {
   /* eslint-disable indent */
-  if (this.type == Blockly.BlockSvg.DEFINE_BLOCK_TYPE) {
+  if (this.type == Blockly.PROCEDURES_DEFINITION_BLOCK_TYPE) {
     steps.push('m 0, 0');
     steps.push(Blockly.BlockSvg.TOP_LEFT_CORNER_DEFINE_HAT);
   } else {
@@ -1276,7 +1270,7 @@ Blockly.BlockSvg.prototype.renderDrawRight_ = function(steps,
       // Move to the start of the notch.
       cursorX = inputRows.statementEdge + Blockly.BlockSvg.NOTCH_WIDTH;
 
-      if (this.type == Blockly.BlockSvg.DEFINE_BLOCK_TYPE) {
+      if (this.type == Blockly.PROCEDURES_DEFINITION_BLOCK_TYPE) {
         this.renderDefineBlock_(steps, inputRows, input, row);
       } else {
         Blockly.BlockSvg.drawStatementInputFromTopRight_(steps, cursorX,
@@ -1290,7 +1284,7 @@ Blockly.BlockSvg.prototype.renderDrawRight_ = function(steps,
         this.width = Math.max(this.width, inputRows.statementEdge +
           input.connection.targetBlock().getHeightWidth().width);
       }
-      if (this.type != Blockly.BlockSvg.DEFINE_BLOCK_TYPE &&
+      if (this.type != Blockly.PROCEDURES_DEFINITION_BLOCK_TYPE &&
         (y == inputRows.length - 1 ||
           inputRows[y + 1].type == Blockly.NEXT_STATEMENT)) {
         // If the final input is a statement stack, add a small row underneath.

--- a/core/connection.js
+++ b/core/connection.js
@@ -310,8 +310,8 @@ Blockly.Connection.prototype.canConnectWithReason_ = function(target) {
     return Blockly.Connection.REASON_CHECKS_FAILED;
   } else if (blockA.isShadow() && !blockB.isShadow()) {
     return Blockly.Connection.REASON_SHADOW_PARENT;
-  } else if (blockA.type == 'procedures_defnoreturn' &&
-      blockB.type != 'procedures_callnoreturn_internal' &&
+  } else if (blockA.type == Blockly.PROCEDURES_DEFINITION_BLOCK_TYPE &&
+      blockB.type != 'procedures_prototype' &&
       superiorConn == blockA.getInput('custom_block').connection ) {
     // Hack to fix #1127: Fail attempts to connect to the custom_block input
     // on a defnoreturn block, unless the connecting block is a specific type.

--- a/core/constants.js
+++ b/core/constants.js
@@ -326,3 +326,21 @@ Blockly.RENAME_VARIABLE_ID = 'RENAME_VARIABLE_ID';
  * @const {string}
  */
 Blockly.DELETE_VARIABLE_ID = 'DELETE_VARIABLE_ID';
+
+/**
+ * The type of all procedure definition blocks.
+ * @const {string}
+ */
+Blockly.PROCEDURES_DEFINITION_BLOCK_TYPE = 'procedures_definition';
+
+/**
+ * The type of all procedure prototype blocks.
+ * @const {string}
+ */
+Blockly.PROCEDURES_PROTOTYPE_BLOCK_TYPE = 'procedures_prototype';
+
+/**
+ * The type of all procedure call blocks.
+ * @const {string}
+ */
+Blockly.PROCEDURES_CALL_BLOCK_TYPE = 'procedures_call';

--- a/core/procedures.js
+++ b/core/procedures.js
@@ -179,12 +179,12 @@ Blockly.Procedures.rename = function(name) {
  */
 Blockly.Procedures.flyoutCategory = function(workspace) {
   var xmlList = [];
-  if (Blockly.Blocks['procedures_defnoreturn']) {
-    // <block type="procedures_defnoreturn" gap="16">
+  if (Blockly.Blocks[Blockly.PROCEDURES_DEFINITION_BLOCK_TYPE]) {
+    // <block type="procedures_definition" gap="16">
     //     <field name="NAME">do something</field>
     // </block>
     var block = goog.dom.createDom('block');
-    block.setAttribute('type', 'procedures_defnoreturn');
+    block.setAttribute('type', Blockly.PROCEDURES_DEFINITION_BLOCK_TYPE);
     block.setAttribute('gap', 16);
     var nameField = goog.dom.createDom('field', null,
         Blockly.Msg.PROCEDURES_DEFNORETURN_PROCEDURE);
@@ -221,7 +221,7 @@ Blockly.Procedures.flyoutCategory = function(workspace) {
     for (var i = 0; i < procedureList.length; i++) {
       var name = procedureList[i][0];
       var args = procedureList[i][1];
-      // <block type="procedures_callnoreturn" gap="16">
+      // <block type="procedures_call" gap="16">
       //   <mutation name="do something">
       //     <arg name="x"></arg>
       //   </mutation>
@@ -243,7 +243,7 @@ Blockly.Procedures.flyoutCategory = function(workspace) {
 
   var tuple = Blockly.Procedures.allProcedures(workspace);
   populateProcedures(tuple[0], 'procedures_callnoreturn');
-  populateProcedures(tuple[1], 'procedures_callreturn');
+  populateProcedures(tuple[1], 'procedures_call');
   return xmlList;
 };
 
@@ -276,7 +276,7 @@ Blockly.Procedures.getCallers = function(name, ws, definitionRoot,
   var callers = [];
   for (var i = 0; i < allBlocks.length; i++) {
     var block = allBlocks[i];
-    if (block.type == 'procedures_callnoreturn') {
+    if (block.type == Blockly.PROCEDURES_CALL_BLOCK_TYPE ) {
       var procCode = block.getProcCode();
       if (procCode && procCode == name) {
         callers.push(block);
@@ -342,7 +342,7 @@ Blockly.Procedures.getDefinition = function(name, workspace) {
  * @private
  */
 Blockly.Procedures.editProcedureCallback_ = function(block) {
-  if (block.type == 'procedures_defnoreturn') {
+  if (block.type == Blockly.PROCEDURES_DEFINITION_BLOCK_TYPE) {
     var input = block.getInput('custom_block');
     if (!input) {
       alert('Bad input'); // TODO: Decide what to do about this.
@@ -354,7 +354,8 @@ Blockly.Procedures.editProcedureCallback_ = function(block) {
       return;
     }
     var innerBlock = conn.targetBlock();
-    if (!innerBlock || !innerBlock.type == 'procedures_callnoreturn_internal') {
+    if (!innerBlock ||
+        !innerBlock.type == Blockly.PROCEDURES_PROTOTYPE_BLOCK_TYPE) {
       alert('Bad inner block'); // TODO: Decide what to do about this.
       return;
     }

--- a/core/workspace.js
+++ b/core/workspace.js
@@ -357,7 +357,7 @@ Blockly.Workspace.prototype.deleteVariable = function(name) {
   // Check whether this variable is a function parameter before deleting.
   var uses = this.getVariableUses(name);
   for (var i = 0, block; block = uses[i]; i++) {
-    if (block.type == 'procedures_defnoreturn' ||
+    if (block.type == Blockly.PROCEDURES_DEFINITION_BLOCK_TYPE ||
       block.type == 'procedures_defreturn') {
       var procedureName = block.getFieldValue('NAME');
       Blockly.alert(

--- a/tests/custom_procedure_playground.html
+++ b/tests/custom_procedure_playground.html
@@ -67,7 +67,7 @@
   </xml>
 
   <xml id="mutator_blocks" style="display:none">
-    <block type="procedures_mutator_root" x="25" y="25" deletable="false">
+    <block type="procedures_declaration_root" x="25" y="25" deletable="false">
     <mutation proccode="say %s %n times if %b" argumentnames="[&quot;something&quot;,&quot;this many&quot;,&quot;this is true&quot;]" argumentdefaults="[&quot;&quot;,1,false]" warp="false" argumentids="[&quot;a42&quot;, &quot;b23&quot;, &quot;c99&quot;]"/>
     </block>
   </xml>
@@ -127,7 +127,7 @@
   </xml>
 
   <xml id="mutator_blocks_simplest" style="display:none">
-    <block type="procedures_mutator_root" x="25" y="25" deletable="false">
+    <block type="procedures_declaration_root" x="25" y="25" deletable="false">
     <mutation proccode="my first function" argumentnames="[]" argumentdefaults="[]" warp="false" argumentids="[]"/>
     </block>
   </xml>

--- a/tests/custom_procedure_playground.html
+++ b/tests/custom_procedure_playground.html
@@ -47,9 +47,9 @@
     </tr>
     <tr>
       <td>
-        <button id="text_number">Add text/number input</button>
-        <button id="boolean">Add boolean input</button>
-        <button id="label">Add label</button>
+        <button id="text_number" onclick="addTextNumber()">Add text/number input</button>
+        <button id="boolean" onclick="addBoolean()">Add boolean input</button>
+        <button id="label" onclick="addLabel()">Add label</button>
         <button id="cancelButton">cancel</button>
         <button id="okButton" onclick="applyMutation()">ok</button>
       </td>
@@ -109,27 +109,64 @@
   </block>
   </xml>
 
+  <xml id="main_ws_blocks_simplest" style="display:none">
+    <block id="]){{Y!7N9ezN+j@Vr`8p" type="procedures_defnoreturn" x="25" y="25">
+      <statement name="custom_block">
+          <shadow type="procedures_callnoreturn_internal" id="caller_internal">
+              <mutation proccode="my first function" argumentnames="[]" argumentdefaults="[]" warp="false" argumentids="[]"/>
+          </shadow>
+      </statement>
+      <next>
+          <block id="caller_external" type="procedures_callnoreturn">
+            <mutation proccode="my first function" argumentnames="[]" argumentdefaults="[]" warp="false" argumentids="[]"/>
+          </block>
+      </next>
+  </block>
+  </xml>
+
+  <xml id="mutator_blocks_simplest" style="display:none">
+    <block type="procedures_mutator_root" x="25" y="25" deletable="false">
+    <mutation proccode="my first function" argumentnames="[]" argumentdefaults="[]" warp="false" argumentids="[]"/>
+    </block>
+  </xml>
+
 
   <script>
     // Inject primary workspace.
     var primaryWorkspace = Blockly.inject('primaryDiv',
         {media: '../media/'});
 
-    Blockly.Xml.domToWorkspace(document.getElementById('mutator_blocks'),
+    Blockly.Xml.domToWorkspace(document.getElementById('mutator_blocks_simplest'),
         primaryWorkspace);
+
+    var mutationRoot = primaryWorkspace.getTopBlocks()[0];
+
+    primaryWorkspace.addChangeListener(function() {mutationRoot.onChangeFn();});
 
     // Inject secondary workspace.
     var secondaryWorkspace = Blockly.inject('secondaryDiv',
         {media: '../media/'});
 
-    Blockly.Xml.domToWorkspace(document.getElementById('main_ws_blocks'),
+    Blockly.Xml.domToWorkspace(document.getElementById('main_ws_blocks_simplest'),
         secondaryWorkspace);
 
     function applyMutation() {
-      var mutation = primaryWorkspace.getTopBlocks()[0].mutationToDom();
+      var mutation = mutationRoot.mutationToDom();
       console.log(mutation);
       secondaryWorkspace.getBlockById('caller_external').domToMutation(mutation);
       secondaryWorkspace.getBlockById('caller_internal').domToMutation(mutation);
+    }
+
+    function addLabel() {
+      mutationRoot.addLabelExternal();
+    }
+
+    function addBoolean() {
+      mutationRoot.addBooleanExternal();
+    }
+
+    function addTextNumber() {
+      mutationRoot.addStringNumberExternal();
     }
 </script>
 

--- a/tests/custom_procedure_playground.html
+++ b/tests/custom_procedure_playground.html
@@ -67,20 +67,20 @@
   </xml>
 
   <xml id="mutator_blocks" style="display:none">
-    <block type="procedures_declaration_root" x="25" y="25" deletable="false">
+    <block type="procedures_declaration" x="25" y="25" deletable="false">
     <mutation proccode="say %s %n times if %b" argumentnames="[&quot;something&quot;,&quot;this many&quot;,&quot;this is true&quot;]" argumentdefaults="[&quot;&quot;,1,false]" warp="false" argumentids="[&quot;a42&quot;, &quot;b23&quot;, &quot;c99&quot;]"/>
     </block>
   </xml>
 
   <xml id="main_ws_blocks" style="display:none">
-    <block id="]){{Y!7N9ezN+j@Vr`8p" type="procedures_defnoreturn" x="25" y="25">
+    <block id="]){{Y!7N9ezN+j@Vr`8p" type="procedures_definition" x="25" y="25">
       <statement name="custom_block">
-          <shadow type="procedures_callnoreturn_internal" id="caller_internal">
+          <shadow type="procedures_prototype" id="caller_internal">
               <mutation proccode="say %s %n times if %b" argumentnames="[&quot;something&quot;,&quot;this many&quot;,&quot;this is true&quot;]" argumentdefaults="[&quot;&quot;,1,false]" warp="false" argumentids="[&quot;a42&quot;, &quot;b23&quot;, &quot;c99&quot;]"/>
           </shadow>
       </statement>
       <next>
-          <block id="caller_external" type="procedures_callnoreturn">
+          <block id="caller_external" type="procedures_call">
               <mutation proccode="say %s %n times if %b" argumentnames="[&quot;something&quot;,&quot;this many&quot;,&quot;this is true&quot;]" argumentdefaults="[&quot;&quot;,1,false]" warp="false" argumentids="[&quot;a42&quot;, &quot;b23&quot;, &quot;c99&quot;]"/>
               <value name="input0">
                   <shadow id="V0~M:TxRk0Ua%osjGzh," type="text">
@@ -98,28 +98,28 @@
   </xml>
 
   <xml id="main_ws_blocks_simpler" style="display:none">
-    <block id="]){{Y!7N9ezN+j@Vr`8p" type="procedures_defnoreturn" x="25" y="25">
+    <block id="]){{Y!7N9ezN+j@Vr`8p" type="procedures_definition" x="25" y="25">
       <statement name="custom_block">
-          <shadow type="procedures_callnoreturn_internal" id="caller_internal">
+          <shadow type="procedures_prototype" id="caller_internal">
               <mutation proccode="say %s %n times if %b" argumentnames="[&quot;something&quot;,&quot;this many&quot;,&quot;this is true&quot;]" argumentdefaults="[&quot;&quot;,1,false]" warp="false" argumentids="[&quot;a42&quot;, &quot;b23&quot;, &quot;c99&quot;]"/>
           </shadow>
       </statement>
       <next>
-          <block id="caller_external" type="procedures_callnoreturn">
+          <block id="caller_external" type="procedures_call">
           </block>
       </next>
   </block>
   </xml>
 
   <xml id="main_ws_blocks_simplest" style="display:none">
-    <block id="]){{Y!7N9ezN+j@Vr`8p" type="procedures_defnoreturn" x="25" y="25">
+    <block id="]){{Y!7N9ezN+j@Vr`8p" type="procedures_definition" x="25" y="25">
       <statement name="custom_block">
-          <shadow type="procedures_callnoreturn_internal" id="caller_internal">
+          <shadow type="procedures_prototype" id="caller_internal">
               <mutation proccode="my first function" argumentnames="[]" argumentdefaults="[]" warp="false" argumentids="[]"/>
           </shadow>
       </statement>
       <next>
-          <block id="caller_external" type="procedures_callnoreturn">
+          <block id="caller_external" type="procedures_call">
             <mutation proccode="my first function" argumentnames="[]" argumentdefaults="[]" warp="false" argumentids="[]"/>
           </block>
       </next>
@@ -127,7 +127,7 @@
   </xml>
 
   <xml id="mutator_blocks_simplest" style="display:none">
-    <block type="procedures_declaration_root" x="25" y="25" deletable="false">
+    <block type="procedures_declaration" x="25" y="25" deletable="false">
     <mutation proccode="my first function" argumentnames="[]" argumentdefaults="[]" warp="false" argumentids="[]"/>
     </block>
   </xml>

--- a/tests/custom_procedure_playground.html
+++ b/tests/custom_procedure_playground.html
@@ -52,6 +52,8 @@
         <button id="label" onclick="addLabel()">Add label</button>
         <button id="cancelButton">cancel</button>
         <button id="okButton" onclick="applyMutation()">ok</button>
+        <button id="rndButton" onclick="removeRandomInput()">remove random input</button>
+        <button id="addRndButton" onclick="addRandomInput()">add random input</button>
       </td>
       <td></td>
     </tr>
@@ -167,6 +169,32 @@
 
     function addTextNumber() {
       mutationRoot.addStringNumberExternal();
+    }
+
+    function removeRandomInput() {
+      var rnd = Math.floor(Math.random() * mutationRoot.inputList.length);
+      mutationRoot.removeInput(mutationRoot.inputList[rnd].name);
+      mutationRoot.onChangeFn();
+      mutationRoot.updateDisplay_();
+
+      applyMutation();
+    }
+
+    function addRandomInput() {
+      var rnd = Math.floor(Math.random() * 3);
+      switch (rnd) {
+        case 0:
+          addTextNumber();
+          break;
+        case 1:
+          addLabel();
+          break;
+        case 2:
+          addBoolean();
+          break;
+      }
+
+      applyMutation();
     }
 </script>
 

--- a/tests/jsunit/connection_test.js
+++ b/tests/jsunit/connection_test.js
@@ -348,7 +348,7 @@ function test_canConnectWithReason_Procedures_WrongBlockType() {
   var sharedWorkspace = {};
   var one = helper_createConnection(0, 0, Blockly.NEXT_STATEMENT);
   one.sourceBlock_ = helper_makeSourceBlock(sharedWorkspace);
-  one.sourceBlock_.type = 'procedures_defnoreturn';
+  one.sourceBlock_.type = Blockly.PROCEDURES_DEFINITION_BLOCK_TYPE;
   // Make one be the connection on its source block's input.
   one.sourceBlock_.getInput = function() {
     return {
@@ -368,7 +368,7 @@ function test_canConnectWithReason_Procedures_Pass() {
   var sharedWorkspace = {};
   var one = helper_createConnection(0, 0, Blockly.NEXT_STATEMENT);
   one.sourceBlock_ = helper_makeSourceBlock(sharedWorkspace);
-  one.sourceBlock_.type = 'procedures_defnoreturn';
+  one.sourceBlock_.type = Blockly.PROCEDURES_DEFINITION_BLOCK_TYPE;
   // Make one be the connection on its source block's input.
   one.sourceBlock_.getInput = function() {
     return {
@@ -377,7 +377,7 @@ function test_canConnectWithReason_Procedures_Pass() {
   };
   var two = helper_createConnection(0, 0, Blockly.PREVIOUS_STATEMENT);
   two.sourceBlock_ = helper_makeSourceBlock(sharedWorkspace);
-  two.sourceBlock_.type = 'procedures_callnoreturn_internal';
+  two.sourceBlock_.type = Blockly.PROCEDURES_PROTOTYPE_BLOCK_TYPE;
   assertEquals(Blockly.Connection.CAN_CONNECT,
       one.canConnectWithReason_(two));
 }
@@ -386,7 +386,7 @@ function test_canConnectWithReason_Procedures_NextConnection() {
   var sharedWorkspace = {};
   var one = helper_createConnection(0, 0, Blockly.NEXT_STATEMENT);
   one.sourceBlock_ = helper_makeSourceBlock(sharedWorkspace);
-  one.sourceBlock_.type = 'procedures_defnoreturn';
+  one.sourceBlock_.type = Blockly.PROCEDURES_DEFINITION_BLOCK_TYPE;
   // One is the next connection, not an input connection
   one.sourceBlock_.nextConnection = one;
   one.sourceBlock_.getInput = function() {

--- a/tests/jsunit/procedure_test.js
+++ b/tests/jsunit/procedure_test.js
@@ -26,7 +26,7 @@ var workspace;
 //var mockControl_;
 
 function procedureTest_setUp() {
-  Blockly.Blocks['procedures_callnoreturn'] = {
+  Blockly.Blocks[Blockly.PROCEDURES_CALL_BLOCK_TYPE] = {
     init: function() {
       this.procCode_ = '';
       this.setPreviousStatement(true);
@@ -64,7 +64,7 @@ function procedureTest_setUp() {
 }
 
 function procedureTest_tearDown() {
-  delete Blockly.Blocks['procedures_callnoreturn'];
+  delete Blockly.Blocks[Blockly.PROCEDURES_CALL_BLOCK_TYPE];
   delete Blockly.Blocks['foo'];
   delete Blockly.Blocks['loop'];
   //mockControl_.$tearDown();
@@ -74,7 +74,8 @@ function procedureTest_tearDown() {
 function test_findCallers_simple_oneCaller() {
   var xml = '<xml xmlns="http://www.w3.org/1999/xhtml">' +
     '<variables></variables>' +
-    '<block type="procedures_callnoreturn" id="test_1" x="301" y="516">' +
+    '<block type="' + Blockly.PROCEDURES_CALL_BLOCK_TYPE +
+    '" id="test_1" x="301" y="516">' +
     '</block>' +
   '</xml>';
   procedureTest_setUp();
@@ -94,7 +95,8 @@ function test_findCallers_simple_oneCaller() {
 function test_findCallers_noRecursion() {
   var xml = '<xml xmlns="http://www.w3.org/1999/xhtml">' +
     '<variables></variables>' +
-    '<block type="procedures_callnoreturn" id="test_1" x="301" y="516">' +
+    '<block type="' + Blockly.PROCEDURES_CALL_BLOCK_TYPE +
+    '" id="test_1" x="301" y="516">' +
     '</block>' +
   '</xml>';
   procedureTest_setUp();
@@ -117,7 +119,8 @@ function test_findCallers_noRecursion() {
 function test_findCallers_allowRecursion() {
   var xml = '<xml xmlns="http://www.w3.org/1999/xhtml">' +
     '<variables></variables>' +
-    '<block type="procedures_callnoreturn" id="test_1" x="301" y="516">' +
+    '<block type="' + Blockly.PROCEDURES_CALL_BLOCK_TYPE +
+    '" id="test_1" x="301" y="516">' +
     '</block>' +
   '</xml>';
   procedureTest_setUp();
@@ -161,7 +164,8 @@ function test_findCallers_simple_noCallers() {
 function test_findCallers_wrongProcCode() {
   var xml = '<xml xmlns="http://www.w3.org/1999/xhtml">' +
     '<variables></variables>' +
-    '<block type="procedures_callnoreturn" id="test_1" x="301" y="516">' +
+    '<block type="' + Blockly.PROCEDURES_CALL_BLOCK_TYPE +
+    '" id="test_1" x="301" y="516">' +
     '</block>' +
   '</xml>';
   procedureTest_setUp();
@@ -185,7 +189,8 @@ function test_findCallers_onStatementInput() {
       '<statement name="SUBSTACK">' +
         '<block type="foo" id="test_2">' +
           '<next>' +
-            '<block type="procedures_callnoreturn" id="test_3"></block>' +
+            '<block type="' + Blockly.PROCEDURES_CALL_BLOCK_TYPE +
+            '" id="test_3"></block>' +
           '</next></block>' +
       '</statement>' +
     '</block>' +
@@ -209,7 +214,8 @@ function test_findCallers_onStatementInput() {
 function test_findCallers_multipleStacks() {
   var xml = '<xml xmlns="http://www.w3.org/1999/xhtml">' +
     '<block type="foo" id="test_1"></block>' +
-    '<block type="procedures_callnoreturn" id="test_2"></block>'+
+    '<block type="' + Blockly.PROCEDURES_CALL_BLOCK_TYPE +
+    '" id="test_2"></block>'+
     '<block type="foo" id="test_1"></block>' +
   '</xml>';
   procedureTest_setUp();
@@ -230,8 +236,10 @@ function test_findCallers_multipleStacks() {
 
 function test_findCallers_multipleCallers() {
   var xml = '<xml xmlns="http://www.w3.org/1999/xhtml">' +
-    '<block type="procedures_callnoreturn" id="test_1"></block>' +
-    '<block type="procedures_callnoreturn" id="test_2"></block>'+
+    '<block type="' + Blockly.PROCEDURES_CALL_BLOCK_TYPE +
+    '" id="test_1"></block>' +
+    '<block type="' + Blockly.PROCEDURES_CALL_BLOCK_TYPE +
+    '" id="test_2"></block>'+
   '</xml>';
   procedureTest_setUp();
   try {
@@ -256,7 +264,8 @@ function test_deleteProcedure_noCallers() {
   // If there are no callers, the stack should be deleted.
   procedureTest_setUp();
   var xml = '<xml xmlns="http://www.w3.org/1999/xhtml">' +
-    '<block type="procedures_callnoreturn" id="test_1" x="301" y="516"></block>' +
+    '<block type="' + Blockly.PROCEDURES_CALL_BLOCK_TYPE +
+    '" id="test_1" x="301" y="516"></block>' +
     '<block type="foo" id="test_2"></block>' +
     '<block type="foo" id="test_3"></block>' +
     '</block>' +
@@ -286,7 +295,8 @@ function test_deleteProcedure_recursiveCaller() {
       '<statement name="SUBSTACK">' +
         '<block type="foo" id="test_2">' +
           '<next>' +
-            '<block type="procedures_callnoreturn" id="test_3"></block>' +
+            '<block type="' + Blockly.PROCEDURES_CALL_BLOCK_TYPE +
+            '" id="test_3"></block>' +
           '</next></block>' +
       '</statement>' +
     '</block>' +
@@ -311,7 +321,8 @@ function test_deleteProcedure_nonRecursiveCaller() {
 
   procedureTest_setUp();
   var xml = '<xml xmlns="http://www.w3.org/1999/xhtml">' +
-    '<block type="procedures_callnoreturn" id="test_1" x="301" y="516"></block>' +
+    '<block type="' + Blockly.PROCEDURES_CALL_BLOCK_TYPE +
+    '" id="test_1" x="301" y="516"></block>' +
     '<block type="foo" id="test_2"></block>' +
     '<block type="foo" id="test_3"></block>' +
   '</xml>';


### PR DESCRIPTION
### Resolves
Related to #607, https://github.com/LLK/scratch-blocks/issues/1195, https://github.com/LLK/scratch-blocks/issues/1185

### Proposed Changes

Each `argument` on a custom procedure now has an `id` and a `displayName` instead of an `id` and a `name`.
`argument.id` now corresponds to the `name` field on the `Blockly.Input` that stores and renders that argument.
`argument.displayName` is what is seen and edited by the user.

The `paramMap` is now gone, since the mapping is done by `argument.id`.

`procedures_mutator_root` is now called `procedures_declaration_root`.

### Reason for Changes

Continuing to implement custom procedures.

### Test Coverage

Tested in the custom procedure playground.  There are two useful buttons for testing: "add random input" and "remove random input".