### PR TITLE
Return early from field init if the field has already been initialized.

### DIFF
--- a/core/field_colour.js
+++ b/core/field_colour.js
@@ -70,6 +70,10 @@ Blockly.FieldColour.prototype.columns_ = 0;
  * @param {!Blockly.Block} block The block containing this field.
  */
 Blockly.FieldColour.prototype.init = function(block) {
+  if (this.fieldGroup_) {
+    // Colour field has already been initialized once.
+    return;
+  }
   Blockly.FieldColour.superClass_.init.call(this, block);
   this.setValue(this.getValue());
 };

--- a/core/field_colour_slider.js
+++ b/core/field_colour_slider.js
@@ -71,6 +71,10 @@ Blockly.FieldColourSlider.EYEDROPPER_PATH = 'eyedropper.svg';
  * @param {!Blockly.Block} block The block containing this field.
  */
 Blockly.FieldColourSlider.prototype.init = function(block) {
+  if (this.fieldGroup_) {
+    // Colour slider has already been initialized once.
+    return;
+  }
   Blockly.FieldColourSlider.superClass_.init.call(this, block);
   this.setValue(this.getValue());
 };

--- a/core/field_iconmenu.js
+++ b/core/field_iconmenu.js
@@ -69,6 +69,10 @@ Blockly.FieldIconMenu.savedPrimary_ = null;
  * @param {Block} block The owning block.
  */
 Blockly.FieldIconMenu.prototype.init = function(block) {
+  if (this.fieldGroup_) {
+    // Icon menu has already been initialized once.
+    return;
+  }
   // Render the arrow icon
   // Fixed sizes in px. Saved for creating the flip transform of the menu renders above the button.
   var arrowSize = 12;

--- a/core/field_textdropdown.js
+++ b/core/field_textdropdown.js
@@ -59,6 +59,10 @@ goog.inherits(Blockly.FieldTextDropdown, Blockly.FieldTextInput);
  * Install this text drop-down field on a block.
  */
 Blockly.FieldTextDropdown.prototype.init = function() {
+  if (this.fieldGroup_) {
+    // Text input + dropdown has already been initialized once.
+    return;
+  }
   Blockly.FieldTextDropdown.superClass_.init.call(this);
   // Add dropdown arrow: "option ▾" (LTR) or "▾ אופציה" (RTL)
   // Positioned on render, after text size is calculated.

--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -91,6 +91,10 @@ Blockly.FieldTextInput.prototype.spellcheck_ = true;
  * Install this text field on a block.
  */
 Blockly.FieldTextInput.prototype.init = function() {
+  if (this.fieldGroup_) {
+    // Field has already been initialized once.
+    return;
+  }
 
   Blockly.FieldTextInput.superClass_.init.call(this);
   // If not in a shadow block, draw a box.


### PR DESCRIPTION
### Resolves

None
### Proposed Changes

Most fields check whether they're already been initialized on a block before creating SVG elements.  These fields didn't, so if init was called twice there would be two instances of each SVG element.  One would be a memory leak, since we would lose the pointer to it.

### Reason for Changes

The previous behaviour was leaky and created duplicates of some elements.

### Test Coverage

Checked that I can open the playground and scroll through all blocks in the toolbox.