### PR TITLE
Tweak text input rendering when not on a shadow block

### DIFF
--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -96,14 +96,12 @@ Blockly.FieldTextInput.prototype.init = function() {
   // If not in a shadow block, draw a box.
   if (!this.sourceBlock_.isShadow()) {
     this.box_ = Blockly.utils.createSvgElement('rect', {
-      'rx': Blockly.BlockSvg.CORNER_RADIUS,
-      'ry': Blockly.BlockSvg.CORNER_RADIUS,
       'x': 0,
       'y': 0,
       'width': this.size_.width,
       'height': this.size_.height,
       'fill': Blockly.Colours.textField,
-      'stroke': this.sourceBlock_.getColourTertiary()
+      'fill-opacity': 0.3
     });
     this.fieldGroup_.insertBefore(this.box_, this.textElement_);
   }
@@ -186,7 +184,7 @@ Blockly.FieldTextInput.prototype.setRestrictor = function(restrictor) {
  * @private
  */
 Blockly.FieldTextInput.prototype.showEditor_ = function(
-  opt_quietInput, opt_readOnly, opt_withArrow, opt_arrowCallback) {
+    opt_quietInput, opt_readOnly, opt_withArrow, opt_arrowCallback) {
   this.workspace_ = this.sourceBlock_.workspace;
   var quietInput = opt_quietInput || false;
   var readOnly = opt_readOnly || false;


### PR DESCRIPTION
### Resolves

Part of https://github.com/LLK/scratch-blocks/issues/1231

### Proposed Changes

Get rid of rounded corners and white background when the text input field is not on a shadow block.

Doesn't do anything about the placement of the editor.

### Reason for Changes

Label editor rendering for custom procedures.

### Test Coverage

New: 
![image](https://user-images.githubusercontent.com/13686399/32921797-e102758c-cae3-11e7-927a-581ed9bbad65.png)

Old: 
![image](https://user-images.githubusercontent.com/13686399/32921803-e98bd324-cae3-11e7-9bd0-27562dd2ed91.png)

