### PR TITLE
Fix expanding field_textinput width for label editors

### DIFF
--- a/core/field.js
+++ b/core/field.js
@@ -696,9 +696,9 @@ Blockly.Field.prototype.setTooltip = function(/*newTip*/) {
  * Select the element to bind the click handler to. When this element is
  * clicked on an editable field, the editor will open.
  *
- * <p>If the block has multiple fields, this is just the group containing the
- * field. If the block has only one field, we handle clicks over the whole
- * block.
+ * If the block has only one field and no output connection, we handle clicks
+ * over the whole block. Otherwise, handle clicks over the the group containing
+ * the field.
  *
  * @return {!Element} Element to bind click handler to.
  * @private
@@ -709,8 +709,7 @@ Blockly.Field.prototype.getClickTarget_ = function() {
   for (var i = 0, input; input = this.sourceBlock_.inputList[i]; i++) {
     nFields += input.fieldRow.length;
   }
-
-  if (nFields <= 1) {
+  if (nFields <= 1 && this.sourceBlock_.outputConnection) {
     return this.sourceBlock_.getSvgRoot();
   } else {
     return this.getSvgRoot();

--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -419,6 +419,13 @@ Blockly.FieldTextInput.prototype.resizeEditor_ = function() {
   var scale = this.sourceBlock_.workspace.scale;
   var div = Blockly.WidgetDiv.DIV;
 
+  var initialWidth;
+  if (this.sourceBlock_.isShadow()) {
+    initialWidth = this.sourceBlock_.getHeightWidth().width * scale;
+  } else {
+    initialWidth = this.size_.width * scale;
+  }
+
   var width;
   if (Blockly.BlockSvg.FIELD_TEXTINPUT_EXPAND_PAST_TRUNCATION) {
     // Resize the box based on the measured width of the text, pre-truncation
@@ -434,7 +441,7 @@ Blockly.FieldTextInput.prototype.resizeEditor_ = function() {
     width = textWidth;
   } else {
     // Set width to (truncated) block size.
-    width = this.sourceBlock_.getHeightWidth().width * scale;
+    width = initialWidth;
   }
   // The width must be at least FIELD_WIDTH and at most FIELD_WIDTH_MAX_EDIT
   width = Math.max(width, Blockly.BlockSvg.FIELD_WIDTH_MIN_EDIT * scale);
@@ -447,10 +454,7 @@ Blockly.FieldTextInput.prototype.resizeEditor_ = function() {
   // Use margin-left to animate repositioning of the box (value is unscaled).
   // This is the difference between the default position and the positioning
   // after growing the box.
-  var fieldWidth = this.sourceBlock_.getHeightWidth().width;
-  var initialWidth = fieldWidth * scale;
-  var finalWidth = width;
-  div.style.marginLeft = -0.5 * (finalWidth - initialWidth) + 'px';
+  div.style.marginLeft = -0.5 * (width - initialWidth) + 'px';
 
   // Add 0.5px to account for slight difference between SVG and CSS border
   var borderRadius = this.getBorderRadius() + 0.5;
@@ -522,9 +526,14 @@ Blockly.FieldTextInput.prototype.widgetDispose_ = function() {
     div.style.boxShadow = '';
     // Resize to actual size of final source block.
     if (thisField.sourceBlock_) {
-      var size = thisField.sourceBlock_.getHeightWidth();
-      div.style.width = (size.width + 1) + 'px';
-      div.style.height = (size.height + 1) + 'px';
+      if (thisField.sourceBlock_.isShadow()) {
+        var size = thisField.sourceBlock_.getHeightWidth();
+        div.style.width = (size.width + 1) + 'px';
+        div.style.height = (size.height + 1) + 'px';
+      } else {
+        div.style.width = (thisField.size_.width + 1) + 'px';
+        div.style.height = (Blockly.BlockSvg.FIELD_HEIGHT_MAX_EDIT + 1) + 'px';
+      }
     }
     div.style.marginLeft = 0;
   };


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Towards https://github.com/LLK/scratch-blocks/issues/1231

Fix the mega expansion of `field_textinput` when not in a shadow block (i.e. for label editors). 

original
![vertical-inputs--original](https://user-images.githubusercontent.com/654102/32958038-479c491a-cb8b-11e7-992a-f69c06f1e555.gif)

Fixed
![vertical-inputs--fixed](https://user-images.githubusercontent.com/654102/32958036-478c8f2a-cb8b-11e7-994e-1adfbba5b168.gif)

Also confirmed that the "expand past truncation" fields also still work, used in the horizontal playground (note there is a bug about which value is being displayed there, but that is not relevant)

develop
![horizontal-inputs--original](https://user-images.githubusercontent.com/654102/32958076-63585734-cb8b-11e7-8198-46341c0e5549.gif)

this (should be identical) 
![horizontal-inputs--changed](https://user-images.githubusercontent.com/654102/32958075-63478012-cb8b-11e7-8f65-7061a2bee588.gif)
