### PR TITLE
Broadcast message functionality

### DIFF
--- a/blocks_vertical/default_toolbox.js
+++ b/blocks_vertical/default_toolbox.js
@@ -315,14 +315,8 @@ Blockly.Blocks.defaultToolbox = '<xml id="toolbox-categories" style="display: no
     '<block type="event_whenbroadcastreceived" id="event_whenbroadcastreceived">'+
     '</block>'+
     '<block type="event_broadcast" id="event_broadcast">'+
-      '<value name="BROADCAST_OPTION">'+
-        '<shadow type="event_broadcast_menu"></shadow>'+
-      '</value>'+
     '</block>'+
     '<block type="event_broadcastandwait" id="event_broadcastandwait">'+
-      '<value name="BROADCAST_OPTION">'+
-        '<shadow type="event_broadcast_menu"></shadow>'+
-      '</value>'+
     '</block>'+
   '</category>'+
   '<category name="Control" colour="#FFAB19" secondaryColour="#CF8B17">'+

--- a/blocks_vertical/event.js
+++ b/blocks_vertical/event.js
@@ -80,7 +80,7 @@ Blockly.Blocks['event_whenbroadcastreceived'] = {
           "type": "field_variable",
           "name": "BROADCAST_OPTION",
           "variableTypes": ["broadcast_msg"],
-          "variable": "message1"
+          "variable": Blockly.Msg.DEFAULT_BROADCAST_MESSAGE_NAME
         }
       ],
       "category": Blockly.Categories.event,
@@ -153,7 +153,7 @@ Blockly.Blocks['event_broadcast_menu'] = {
             "type": "field_variable",
             "name": "BROADCAST_OPTION",
             "variableTypes":["broadcast_msg"],
-            "variable":"message1"
+            "variable": Blockly.Msg.DEFAULT_BROADCAST_MESSAGE_NAME
           }
         ],
         "colour": Blockly.Colours.event.secondary,
@@ -178,7 +178,7 @@ Blockly.Blocks['event_broadcast'] = {
           "type": "field_variable",
           "name": "BROADCAST_OPTION",
           "variableTypes": ["broadcast_msg"],
-          "variable": "message1"
+          "variable": Blockly.Msg.DEFAULT_BROADCAST_MESSAGE_NAME
         }
       ],
       "category": Blockly.Categories.event,
@@ -200,7 +200,7 @@ Blockly.Blocks['event_broadcastandwait'] = {
           "type": "field_variable",
           "name": "BROADCAST_OPTION",
           "variableTypes": ["broadcast_msg"],
-          "variable":"message1"
+          "variable": Blockly.Msg.DEFAULT_BROADCAST_MESSAGE_NAME
         }
       ],
       "category": Blockly.Categories.event,

--- a/blocks_vertical/event.js
+++ b/blocks_vertical/event.js
@@ -77,13 +77,10 @@ Blockly.Blocks['event_whenbroadcastreceived'] = {
       "message0": "when I receive %1",
       "args0": [
         {
-          "type": "field_dropdown",
+          "type": "field_variable",
           "name": "BROADCAST_OPTION",
-          "options": [
-            ['message1', 'message1'],
-            ['message2', 'message2'],
-            ['new message', 'new message']
-          ]
+          "variableTypes": ["broadcast_msg"],
+          "variable": "message1"
         }
       ],
       "category": Blockly.Categories.event,
@@ -153,13 +150,10 @@ Blockly.Blocks['event_broadcast_menu'] = {
         "message0": "%1",
         "args0": [
           {
-            "type": "field_dropdown",
+            "type": "field_variable",
             "name": "BROADCAST_OPTION",
-            "options": [
-              ['message1', 'message1'],
-              ['message2', 'message2'],
-              ['new message', 'new message']
-            ]
+            "variableTypes":["broadcast_msg"],
+            "variable":"message1"
           }
         ],
         "colour": Blockly.Colours.event.secondary,
@@ -181,8 +175,10 @@ Blockly.Blocks['event_broadcast'] = {
       "message0": "broadcast %1",
       "args0": [
         {
-          "type": "input_value",
-          "name": "BROADCAST_OPTION"
+          "type": "field_variable",
+          "name": "BROADCAST_OPTION",
+          "variableTypes": ["broadcast_msg"],
+          "variable": "message1"
         }
       ],
       "category": Blockly.Categories.event,
@@ -201,8 +197,10 @@ Blockly.Blocks['event_broadcastandwait'] = {
       "message0": "broadcast %1 and wait",
       "args0": [
         {
-          "type": "input_value",
-          "name": "BROADCAST_OPTION"
+          "type": "field_variable",
+          "name": "BROADCAST_OPTION",
+          "variableTypes": ["broadcast_msg"],
+          "variable":"message1"
         }
       ],
       "category": Blockly.Categories.event,

--- a/blocks_vertical/event.js
+++ b/blocks_vertical/event.js
@@ -79,7 +79,7 @@ Blockly.Blocks['event_whenbroadcastreceived'] = {
         {
           "type": "field_variable",
           "name": "BROADCAST_OPTION",
-          "variableTypes": ["broadcast_msg"],
+          "variableTypes": [Blockly.BROADCAST_MESSAGE_TYPE],
           "variable": Blockly.Msg.DEFAULT_BROADCAST_MESSAGE_NAME
         }
       ],
@@ -152,7 +152,7 @@ Blockly.Blocks['event_broadcast_menu'] = {
           {
             "type": "field_variable",
             "name": "BROADCAST_OPTION",
-            "variableTypes":["broadcast_msg"],
+            "variableTypes":[Blockly.BROADCAST_MESSAGE_TYPE],
             "variable": Blockly.Msg.DEFAULT_BROADCAST_MESSAGE_NAME
           }
         ],
@@ -177,7 +177,7 @@ Blockly.Blocks['event_broadcast'] = {
         {
           "type": "field_variable",
           "name": "BROADCAST_OPTION",
-          "variableTypes": ["broadcast_msg"],
+          "variableTypes": [Blockly.BROADCAST_MESSAGE_TYPE],
           "variable": Blockly.Msg.DEFAULT_BROADCAST_MESSAGE_NAME
         }
       ],
@@ -199,7 +199,7 @@ Blockly.Blocks['event_broadcastandwait'] = {
         {
           "type": "field_variable",
           "name": "BROADCAST_OPTION",
-          "variableTypes": ["broadcast_msg"],
+          "variableTypes": [Blockly.BROADCAST_MESSAGE_TYPE],
           "variable": Blockly.Msg.DEFAULT_BROADCAST_MESSAGE_NAME
         }
       ],

--- a/core/constants.js
+++ b/core/constants.js
@@ -326,3 +326,12 @@ Blockly.RENAME_VARIABLE_ID = 'RENAME_VARIABLE_ID';
  * @const {string}
  */
 Blockly.DELETE_VARIABLE_ID = 'DELETE_VARIABLE_ID';
+
+/**
+ * String for use in the dropdown created in field_variable,
+ * specifically for broadcast messages.
+ * This string indicates that this option in the dropdown is 'New message...'
+ * and if selected, should trigger the prompt to create a new message.
+ * @const {string}
+ */
+Blockly.NEW_MESSAGE_ID = 'NEW_MESSAGE_ID';

--- a/core/constants.js
+++ b/core/constants.js
@@ -334,4 +334,4 @@ Blockly.DELETE_VARIABLE_ID = 'DELETE_VARIABLE_ID';
  * and if selected, should trigger the prompt to create a new message.
  * @const {string}
  */
-Blockly.NEW_MESSAGE_ID = 'NEW_MESSAGE_ID';
+Blockly.NEW_BROADCAST_MESSAGE_ID = 'NEW_BROADCAST_MESSAGE_ID';

--- a/core/constants.js
+++ b/core/constants.js
@@ -337,6 +337,14 @@ Blockly.DELETE_VARIABLE_ID = 'DELETE_VARIABLE_ID';
 Blockly.NEW_BROADCAST_MESSAGE_ID = 'NEW_BROADCAST_MESSAGE_ID';
 
 /**
+ * String representing the variable type of broadcast message blocks.
+ * This string, for use in differentiating between types of variables,
+ * indicates that the current variable is a broadcast message.
+ * @const {string}
+ */
+Blockly.BROADCAST_MESSAGE_TYPE = 'broadcast_msg';
+
+/**
  * The type of all procedure definition blocks.
  * @const {string}
  */

--- a/core/field_variable.js
+++ b/core/field_variable.js
@@ -257,8 +257,11 @@ Blockly.FieldVariable.prototype.onItemSelected = function(menu, menuItem) {
       workspace.deleteVariable(this.getText());
       return;
     } else if (id == Blockly.NEW_MESSAGE_ID) {
-      Blockly.Variables.createVariable(workspace, null, 'broadcast_msg');
-      // TODO update sourceblock's variable name...
+      var thisField = this;
+      var setName = function(newName) {
+        thisField.setValue(newName);
+      };
+      Blockly.Variables.createVariable(workspace, setName, 'broadcast_msg');
       return;
     }
 

--- a/core/field_variable.js
+++ b/core/field_variable.js
@@ -190,7 +190,7 @@ Blockly.FieldVariable.dropdownCreate = function() {
     // doesn't modify the workspace's list.
     for (var i = 0; i < variableTypes.length; i++) {
       var variableType = variableTypes[i];
-      if (variableType === 'broadcast_msg'){
+      if (variableType === Blockly.BROADCAST_MESSAGE_TYPE){
         isBroadcastType = true;
       }
       var variables = workspace.getVariablesOfType(variableType);
@@ -261,7 +261,7 @@ Blockly.FieldVariable.prototype.onItemSelected = function(menu, menuItem) {
       var setName = function(newName) {
         thisField.setValue(newName);
       };
-      Blockly.Variables.createVariable(workspace, setName, 'broadcast_msg');
+      Blockly.Variables.createVariable(workspace, setName, Blockly.BROADCAST_MESSAGE_TYPE);
       return;
     }
 

--- a/core/field_variable.js
+++ b/core/field_variable.js
@@ -216,7 +216,7 @@ Blockly.FieldVariable.dropdownCreate = function() {
     options[i] = [variableModelList[i].name, variableModelList[i].getId()];
   }
   if (isBroadcastType) {
-    options.push([Blockly.Msg.NEW_MESSAGE, Blockly.NEW_MESSAGE_ID]);
+    options.push([Blockly.Msg.NEW_BROADCAST_MESSAGE, Blockly.NEW_BROADCAST_MESSAGE_ID]);
   } else {
     options.push([Blockly.Msg.RENAME_VARIABLE, Blockly.RENAME_VARIABLE_ID]);
     if (Blockly.Msg.DELETE_VARIABLE) {
@@ -256,7 +256,7 @@ Blockly.FieldVariable.prototype.onItemSelected = function(menu, menuItem) {
       // Delete variable.
       workspace.deleteVariable(this.getText());
       return;
-    } else if (id == Blockly.NEW_MESSAGE_ID) {
+    } else if (id == Blockly.NEW_BROADCAST_MESSAGE_ID) {
       var thisField = this;
       var setName = function(newName) {
         thisField.setValue(newName);

--- a/core/field_variable.js
+++ b/core/field_variable.js
@@ -87,7 +87,7 @@ Blockly.FieldVariable.prototype.initModel = function() {
     // If there is exactly one element specified, make the variable
     // being created this specified type. Else, default behavior is to create
     // a scalar variable
-    if (this.getVariableTypes_().length === 1) {
+    if (this.getVariableTypes_().length == 1) {
       this.sourceBlock_.workspace.createVariable(this.getValue(),
         this.getVariableTypes_()[0]);
     } else {
@@ -190,7 +190,7 @@ Blockly.FieldVariable.dropdownCreate = function() {
     // doesn't modify the workspace's list.
     for (var i = 0; i < variableTypes.length; i++) {
       var variableType = variableTypes[i];
-      if (variableType === Blockly.BROADCAST_MESSAGE_TYPE){
+      if (variableType == Blockly.BROADCAST_MESSAGE_TYPE){
         isBroadcastType = true;
       }
       var variables = workspace.getVariablesOfType(variableType);

--- a/core/field_variable.js
+++ b/core/field_variable.js
@@ -84,7 +84,7 @@ Blockly.FieldVariable.prototype.initModel = function() {
     // Check if there was exactly one element specified in the
     // variableTypes list. This is the list that specifies which types of
     // variables to include in the dropdown.
-    // If there is exactly one element specified, make the default variable
+    // If there is exactly one element specified, make the variable
     // being created this specified type. Else, default behavior is to create
     // a scalar variable
     if (this.getVariableTypes_().length === 1) {

--- a/core/variable_map.js
+++ b/core/variable_map.js
@@ -119,6 +119,11 @@ Blockly.VariableMap.prototype.createVariable = function(name, opt_type, opt_id) 
   var variable = this.getVariable(name);
   if (variable) {
     if (opt_type && variable.type != opt_type) {
+      // TODO (#1245)
+      // We want to be able to create new broadcast messages that have the same
+      // name as variables or lists... and vice-versa
+      // also need to make sure that all the places where variables are looked
+      // up by name also do the right thing with their types...
       throw Error('Variable "' + name + '" is already in use and its type is "'
                   + variable.type + '" which conflicts with the passed in ' +
                   'type, "' + opt_type + '".');

--- a/core/variables.js
+++ b/core/variables.js
@@ -182,6 +182,8 @@ Blockly.Variables.createVariable = function(workspace, opt_callback, opt_type) {
     Blockly.Variables.promptName(Blockly.Msg.NEW_VARIABLE_TITLE, defaultName,
       function(text) {
         if (text) {
+          // TODO (#1245) use separate namespaces for lists, variables, and
+          // broadcast messages
           if (workspace.getVariable(text)) {
             Blockly.alert(Blockly.Msg.VARIABLE_ALREADY_EXISTS.replace('%1',
                 text.toLowerCase()),
@@ -240,6 +242,8 @@ Blockly.Variables.renameVariable = function(workspace, variable,
       function(newName) {
         if (newName) {
           var newVariable = workspace.getVariable(newName);
+          // TODO (#1245) use separate namespaces for lists, variables, and
+          // broadcast messages
           if (newVariable && newVariable.type != variable.type) {
             Blockly.alert(Blockly.Msg.VARIABLE_ALREADY_EXISTS_FOR_ANOTHER_TYPE.replace('%1',
                 newName.toLowerCase()).replace('%2', newVariable.type),

--- a/core/variables.js
+++ b/core/variables.js
@@ -173,6 +173,10 @@ Blockly.Variables.generateUniqueName = function(workspace) {
  * @param {string} opt_type Optional type of variable, like 'string' or 'list'.
  */
 Blockly.Variables.createVariable = function(workspace, opt_callback, opt_type) {
+  // (karishma) TODO (#1244) Modal message should change depending on what type
+  // (opt_type above) of variable we are creating. If opt_type is not provided,
+  // we should default to the original 'NEW_VARIABLE_TITLE' message for
+  // scalar variables.
   // This function needs to be named so it can be called recursively.
   var promptAndCheckWithAlert = function(defaultName) {
     Blockly.Variables.promptName(Blockly.Msg.NEW_VARIABLE_TITLE, defaultName,
@@ -227,6 +231,8 @@ Blockly.Variables.createVariable = function(workspace, opt_callback, opt_type) {
  */
 Blockly.Variables.renameVariable = function(workspace, variable,
   opt_callback) {
+  // (karishma) TODO (#1244) Modal message should change depending on what type
+  // of variable is getting renamed.
   // This function needs to be named so it can be called recursively.
   var promptAndCheckWithAlert = function(defaultName) {
     Blockly.Variables.promptName(

--- a/core/xml.js
+++ b/core/xml.js
@@ -116,6 +116,21 @@ Blockly.Xml.blockToDom = function(block, opt_noId) {
         if (variable) {
           container.setAttribute('id', variable.getId());
           container.setAttribute('variabletype', variable.type);
+        } else {
+          // Above works well for untyped variables, but we need to correctly
+          // set the type for blocks that exist by default in the toolbox
+          // (e.g. broadcast messages)
+          // TODO figure out if we ever need to do something where there's
+          // more than one element in variableTypes field
+
+          // must check that field is an instance of FieldVariable because
+          // FieldVariableGetter doesn't have getVariableTypes_ function
+          if (field instanceof Blockly.FieldVariable) {
+            var variableTypes = field.getVariableTypes_();
+            if (variableTypes.length === 1) {
+              container.setAttribute('variabletype', variableTypes[0]);
+            }
+          }
         }
       }
       element.appendChild(container);

--- a/core/xml.js
+++ b/core/xml.js
@@ -112,6 +112,7 @@ Blockly.Xml.blockToDom = function(block, opt_noId) {
       container.setAttribute('name', field.name);
       if (field instanceof Blockly.FieldVariable || field instanceof
         Blockly.FieldVariableGetter) {
+        // TODO (#1253) Lookup variable by id instead of name
         var variable = block.workspace.getVariable(field.getValue());
         if (variable) {
           container.setAttribute('id', variable.getId());

--- a/core/xml.js
+++ b/core/xml.js
@@ -127,7 +127,7 @@ Blockly.Xml.blockToDom = function(block, opt_noId) {
           // FieldVariableGetter doesn't have getVariableTypes_ function
           if (field instanceof Blockly.FieldVariable) {
             var variableTypes = field.getVariableTypes_();
-            if (variableTypes.length === 1) {
+            if (variableTypes.length == 1) {
               container.setAttribute('variabletype', variableTypes[0]);
             }
           }

--- a/core/xml.js
+++ b/core/xml.js
@@ -120,7 +120,7 @@ Blockly.Xml.blockToDom = function(block, opt_noId) {
           // Above works well for untyped variables, but we need to correctly
           // set the type for blocks that exist by default in the toolbox
           // (e.g. broadcast messages)
-          // TODO figure out if we ever need to do something where there's
+          // TODO figure out if we need to do something different when there's
           // more than one element in variableTypes field
 
           // must check that field is an instance of FieldVariable because

--- a/msg/messages.js
+++ b/msg/messages.js
@@ -148,6 +148,10 @@ Blockly.Msg.CANNOT_DELETE_VARIABLE_PROCEDURE = 'Can\'t delete the variable "%1" 
 /// dropdown choice - Delete the currently selected variable.
 Blockly.Msg.DELETE_VARIABLE = 'Delete the "%1" variable';
 
+// Broadcast Message creation
+/// dropdown choice - Create a new message.
+Blockly.Msg.NEW_MESSAGE = 'New message...';
+
 // Colour Blocks.
 /// url - Information about colour.
 Blockly.Msg.COLOUR_PICKER_HELPURL = 'https://en.wikipedia.org/wiki/Color';

--- a/msg/messages.js
+++ b/msg/messages.js
@@ -143,6 +143,9 @@ Blockly.Msg.NEW_LIST = 'Create list...';
 // Broadcast Message creation
 /// dropdown choice - Create a new message.
 Blockly.Msg.NEW_BROADCAST_MESSAGE = 'New message...';
+/// default broadcast message name
+/// (default option in broadcast message dropdown menus)
+Blockly.Msg.DEFAULT_BROADCAST_MESSAGE_NAME = 'message1';
 
 // Variable deletion.
 /// confirm -  Ask the user to confirm their deletion of multiple uses of a variable.

--- a/msg/messages.js
+++ b/msg/messages.js
@@ -140,6 +140,10 @@ Blockly.Msg.PROCEDURE_ALREADY_EXISTS = 'A procedure named "%1" already exists.';
 /// button text - Text on the button used to launch the list creation dialogue.
 Blockly.Msg.NEW_LIST = 'Create list...';
 
+// Broadcast Message creation
+/// dropdown choice - Create a new message.
+Blockly.Msg.NEW_BROADCAST_MESSAGE = 'New message...';
+
 // Variable deletion.
 /// confirm -  Ask the user to confirm their deletion of multiple uses of a variable.
 Blockly.Msg.DELETE_VARIABLE_CONFIRMATION = 'Delete %1 uses of the "%2" variable?';
@@ -147,10 +151,6 @@ Blockly.Msg.DELETE_VARIABLE_CONFIRMATION = 'Delete %1 uses of the "%2" variable?
 Blockly.Msg.CANNOT_DELETE_VARIABLE_PROCEDURE = 'Can\'t delete the variable "%1" because it\'s part of the definition of the function "%2"';
 /// dropdown choice - Delete the currently selected variable.
 Blockly.Msg.DELETE_VARIABLE = 'Delete the "%1" variable';
-
-// Broadcast Message creation
-/// dropdown choice - Create a new message.
-Blockly.Msg.NEW_MESSAGE = 'New message...';
 
 // Colour Blocks.
 /// url - Information about colour.


### PR DESCRIPTION
### Resolves

Resolves parts of #749 ("Broadcast Menu new broadcast doesn't do anything" and "Broadcast menu doesn't show broadcasts except the preset ones")

### Proposed Changes

This pull request adds the following pieces of functionality:
- All of the broadcast message related blocks are now populated with two options, "message1" which is a preset message the user can broadcast, and "New message..." which, like "Rename Variable"/"Delete Variable" for lists and variables will bring up a modal prompting the user to create a new message.
- Messages are treated as typed variables with the string "broadcast_msg" differentiating this type of variable from lists and scalar variables
- The default option of "message1" gets added to the variable model with the correct type (specified above) when the block gets added to the workspace.
- When the new message option is selected and the user is able to successfully create a new message, that message gets added to the variable model and the field on the block that was used to create the new message gets updated with the new message name.
- When a new message is created, all broadcast message drop-downs get updated with the new message name as a menu option.

### Reason for Changes

Broadcast messages were previously non-functional.

### Test Coverage

The changes have been tested with the existing unit tests.
@rachel-fenichel If you think there are any specific tests that need to be changed or added, please let me know.

### Additional Comments

There are a few outstanding tasks/issues remaining. These are outlined below:

- Modify the messages in the modals that pop up when creating or renaming lists and broadcast messages (issue #1244)
- Allow messages, lists, and variables to share common names (issue #1245). Resolving this issue might also require changing how variables are looked up, because I believe there are certain places where variables are looked up by name (type information would not get properly checked here).
- A next step (not covered in this PR) is to allow the drop-down field for the 'broadcast' and 'broadcast and wait' blocks to be input fields (allowing dropping other blocks into that slot).
- A question that came up is: we are currently are specifying broadcast messages as variables by specifying that their field dropdown is specifically a FieldVariable. We also specify that the drop downs should only contain variables of the types specified in the variableTypes list. E.g. broadcast message block drop downs should only contain names of broadcast messages (and not scalar variables or lists). Often, we are using this variableTypes list to discern what type the actual variable we're trying to create (by means of the 'New message...' option in the dropdown) is. See proposed changes to FieldVariable.initModel and FieldVariable.dropdownCreate, for examples. What should happen if variableTypes has more than one type in it? Perhaps we need a different way of specifying in the json representation of the block what the type of the variable is (similar to how we define a default message name for the broadcast message dropdowns, via 'variable: "message1"'

