### PR TITLE
Variable modal messages

### DIFF
--- a/blocks_vertical/event.js
+++ b/blocks_vertical/event.js
@@ -79,7 +79,7 @@ Blockly.Blocks['event_whenbroadcastreceived'] = {
         {
           "type": "field_variable",
           "name": "BROADCAST_OPTION",
-          "variableTypes": [Blockly.BROADCAST_MESSAGE_TYPE],
+          "variableTypes": [Blockly.BROADCAST_MESSAGE_VARIABLE_TYPE],
           "variable": Blockly.Msg.DEFAULT_BROADCAST_MESSAGE_NAME
         }
       ],
@@ -152,7 +152,7 @@ Blockly.Blocks['event_broadcast_menu'] = {
           {
             "type": "field_variable",
             "name": "BROADCAST_OPTION",
-            "variableTypes":[Blockly.BROADCAST_MESSAGE_TYPE],
+            "variableTypes":[Blockly.BROADCAST_MESSAGE_VARIABLE_TYPE],
             "variable": Blockly.Msg.DEFAULT_BROADCAST_MESSAGE_NAME
           }
         ],
@@ -177,7 +177,7 @@ Blockly.Blocks['event_broadcast'] = {
         {
           "type": "field_variable",
           "name": "BROADCAST_OPTION",
-          "variableTypes": [Blockly.BROADCAST_MESSAGE_TYPE],
+          "variableTypes": [Blockly.BROADCAST_MESSAGE_VARIABLE_TYPE],
           "variable": Blockly.Msg.DEFAULT_BROADCAST_MESSAGE_NAME
         }
       ],
@@ -199,7 +199,7 @@ Blockly.Blocks['event_broadcastandwait'] = {
         {
           "type": "field_variable",
           "name": "BROADCAST_OPTION",
-          "variableTypes": [Blockly.BROADCAST_MESSAGE_TYPE],
+          "variableTypes": [Blockly.BROADCAST_MESSAGE_VARIABLE_TYPE],
           "variable": Blockly.Msg.DEFAULT_BROADCAST_MESSAGE_NAME
         }
       ],

--- a/core/constants.js
+++ b/core/constants.js
@@ -342,7 +342,15 @@ Blockly.NEW_BROADCAST_MESSAGE_ID = 'NEW_BROADCAST_MESSAGE_ID';
  * indicates that the current variable is a broadcast message.
  * @const {string}
  */
-Blockly.BROADCAST_MESSAGE_TYPE = 'broadcast_msg';
+Blockly.BROADCAST_MESSAGE_VARIABLE_TYPE = 'broadcast_msg';
+
+/**
+ * String representing the variable type of list blocks.
+ * This string, for use in differentiating between types of variables,
+ * indicates that the current variable is a list.
+ * @const {string}
+ */
+Blockly.LIST_VARIABLE_TYPE = 'list';
 
 /**
  * The type of all procedure definition blocks.

--- a/core/data_category.js
+++ b/core/data_category.js
@@ -63,7 +63,7 @@ Blockly.DataCategory = function(workspace) {
 
   // Now add list variables to the flyout
   Blockly.DataCategory.addCreateButton(xmlList, workspace, 'LIST');
-  variableModelList = workspace.getVariablesOfType('list');
+  variableModelList = workspace.getVariablesOfType(Blockly.LIST_VARIABLE_TYPE);
   variableModelList.sort(Blockly.VariableModel.compareByName);
   for (var i = 0; i < variableModelList.length; i++) {
     Blockly.DataCategory.addDataList(xmlList, variableModelList[i]);
@@ -359,7 +359,7 @@ Blockly.DataCategory.addCreateButton = function(xmlList, workspace, type) {
     callbackKey = 'CREATE_LIST';
     callback = function(button) {
       Blockly.Variables.createVariable(button.getTargetWorkspace(), null,
-        'list');};
+        Blockly.LIST_VARIABLE_TYPE);};
   }
   button.setAttribute('text', msg);
   button.setAttribute('callbackKey', callbackKey);

--- a/core/field_variable.js
+++ b/core/field_variable.js
@@ -190,7 +190,7 @@ Blockly.FieldVariable.dropdownCreate = function() {
     // doesn't modify the workspace's list.
     for (var i = 0; i < variableTypes.length; i++) {
       var variableType = variableTypes[i];
-      if (variableType == Blockly.BROADCAST_MESSAGE_TYPE){
+      if (variableType == Blockly.BROADCAST_MESSAGE_VARIABLE_TYPE){
         isBroadcastType = true;
       }
       var variables = workspace.getVariablesOfType(variableType);
@@ -261,7 +261,7 @@ Blockly.FieldVariable.prototype.onItemSelected = function(menu, menuItem) {
       var setName = function(newName) {
         thisField.setValue(newName);
       };
-      Blockly.Variables.createVariable(workspace, setName, Blockly.BROADCAST_MESSAGE_TYPE);
+      Blockly.Variables.createVariable(workspace, setName, Blockly.BROADCAST_MESSAGE_VARIABLE_TYPE);
       return;
     }
 

--- a/core/variables.js
+++ b/core/variables.js
@@ -176,9 +176,9 @@ Blockly.Variables.createVariable = function(workspace, opt_callback, opt_type) {
   // Decide on a modal message based on the opt_type. If opt_type was not
   // provided, default to the original message for scalar variables.
   var newMsg = '';
-  if (opt_type === 'list') {
+  if (opt_type === Blockly.LIST_VARIABLE_TYPE) {
     newMsg = Blockly.Msg.NEW_LIST_TITLE;
-  } else if (opt_type === 'broadcast_msg') {
+  } else if (opt_type === Blockly.BROADCAST_MESSAGE_VARIABLE_TYPE) {
     newMsg = Blockly.Msg.NEW_BROADCAST_MESSAGE_TITLE;
   } else {
     newMsg = Blockly.Msg.NEW_VARIABLE_TITLE;

--- a/core/variables.js
+++ b/core/variables.js
@@ -173,13 +173,19 @@ Blockly.Variables.generateUniqueName = function(workspace) {
  * @param {string} opt_type Optional type of variable, like 'string' or 'list'.
  */
 Blockly.Variables.createVariable = function(workspace, opt_callback, opt_type) {
-  // (karishma) TODO (#1244) Modal message should change depending on what type
-  // (opt_type above) of variable we are creating. If opt_type is not provided,
-  // we should default to the original 'NEW_VARIABLE_TITLE' message for
-  // scalar variables.
+  // Decide on a modal message based on the opt_type. If opt_type was not
+  // provided, default to the original message for scalar variables.
+  var newMsg = '';
+  if (opt_type === 'list') {
+    newMsg = Blockly.Msg.NEW_LIST_TITLE;
+  } else if (opt_type === 'broadcast_msg') {
+    newMsg = Blockly.Msg.NEW_BROADCAST_MESSAGE_TITLE;
+  } else {
+    newMsg = Blockly.Msg.NEW_VARIABLE_TITLE;
+  }
   // This function needs to be named so it can be called recursively.
   var promptAndCheckWithAlert = function(defaultName) {
-    Blockly.Variables.promptName(Blockly.Msg.NEW_VARIABLE_TITLE, defaultName,
+    Blockly.Variables.promptName(newMsg, defaultName,
       function(text) {
         if (text) {
           // TODO (#1245) use separate namespaces for lists, variables, and

--- a/msg/messages.js
+++ b/msg/messages.js
@@ -143,10 +143,14 @@ Blockly.Msg.NEW_PROCEDURE = 'Make a Block...';
 // List creation
 /// button text - Text on the button used to launch the list creation dialogue.
 Blockly.Msg.NEW_LIST = 'Create list...';
+/// prompt - Prompts the user to enter the name for a new list
+Blockly.Msg.NEW_LIST_TITLE = 'New list name:';
 
 // Broadcast Message creation
 /// dropdown choice - Create a new message.
 Blockly.Msg.NEW_BROADCAST_MESSAGE = 'New message...';
+/// prompt - Prompts the user to enter the name for a new broadcast message
+Blockly.Msg.NEW_BROADCAST_MESSAGE_TITLE = 'New message name:';
 /// default broadcast message name
 /// (default option in broadcast message dropdown menus)
 Blockly.Msg.DEFAULT_BROADCAST_MESSAGE_NAME = 'message1';


### PR DESCRIPTION
### Resolves

Resolves #1244.

### Proposed Changes

Changes message in the modal that appears when creating a variable, list, or broadcast message to reflect the thing that is being created (instead of 'New variable name' for all of them).

Minor refactoring of code that used hard coded 'list' to refer to the list variable type. This existing code (and new changes) both use new `Blockly.LIST_VARIABLE_TYPE` constant.

Changed name of `Blockly.BROADCAST_MESSAGE_TYPE` to `Blockly.BROADCAST_MESSAGE_VARIABLE_TYPE` to match new, more specific naming convention for variable type constants (e.g. `LIST_VARIABLE_TYPE`).

### Reason for Changes

Current behavior was that creating a new message or list would bring up a modal that asks the user to enter a 'New variable name'.

### Test Coverage

Existing tests pass.
