### PR TITLE
Sort the More category by procedure procCodes

### DIFF
--- a/core/procedures.js
+++ b/core/procedures.js
@@ -93,6 +93,31 @@ Blockly.Procedures.allProcedureMutations = function(root) {
 };
 
 /**
+ * Sorts an array of procedure definition mutations alphabetically.
+ * (Does not mutate the given array.)
+ * @param {!Array.<Element>} mutations Array of mutation xml elements.
+ * @return {!Array.<Element>} Sorted array of mutation xml elements.
+ */
+Blockly.Procedures.sortProcedureMutations = function(mutations) {
+  var newMutations = mutations.slice();
+
+  newMutations.sort(function(a, b) {
+    var procCodeA = a.getAttribute('proccode');
+    var procCodeB = b.getAttribute('proccode');
+
+    if (procCodeA < procCodeB) {
+      return -1;
+    } else if (procCodeA > procCodeB) {
+      return 1;
+    } else {
+      return 0;
+    }
+  });
+
+  return newMutations;
+};
+
+/**
  * Comparison function for case-insensitive sorting of the first element of
  * a tuple.
  * @param {!Array} ta First tuple.
@@ -203,6 +228,7 @@ Blockly.Procedures.flyoutCategory = function(workspace) {
 
   // Create call blocks for each procedure defined in the workspace
   var mutations = Blockly.Procedures.allProcedureMutations(workspace);
+  mutations = Blockly.Procedures.sortProcedureMutations(mutations);
   for (var i = 0; i < mutations.length; i++) {
     var mutation = mutations[i];
     // <block type="procedures_call">

--- a/core/procedures.js
+++ b/core/procedures.js
@@ -97,8 +97,9 @@ Blockly.Procedures.allProcedureMutations = function(root) {
  * (Does not mutate the given array.)
  * @param {!Array.<Element>} mutations Array of mutation xml elements.
  * @return {!Array.<Element>} Sorted array of mutation xml elements.
+ * @Private
  */
-Blockly.Procedures.sortProcedureMutations = function(mutations) {
+Blockly.Procedures.sortProcedureMutations_ = function(mutations) {
   var newMutations = mutations.slice();
 
   newMutations.sort(function(a, b) {
@@ -228,7 +229,7 @@ Blockly.Procedures.flyoutCategory = function(workspace) {
 
   // Create call blocks for each procedure defined in the workspace
   var mutations = Blockly.Procedures.allProcedureMutations(workspace);
-  mutations = Blockly.Procedures.sortProcedureMutations(mutations);
+  mutations = Blockly.Procedures.sortProcedureMutations_(mutations);
   for (var i = 0; i < mutations.length; i++) {
     var mutation = mutations[i];
     // <block type="procedures_call">

--- a/core/procedures.js
+++ b/core/procedures.js
@@ -97,7 +97,7 @@ Blockly.Procedures.allProcedureMutations = function(root) {
  * (Does not mutate the given array.)
  * @param {!Array.<Element>} mutations Array of mutation xml elements.
  * @return {!Array.<Element>} Sorted array of mutation xml elements.
- * @Private
+ * @private
  */
 Blockly.Procedures.sortProcedureMutations_ = function(mutations) {
   var newMutations = mutations.slice();


### PR DESCRIPTION
### Resolves

Resolves #1250.

### Proposed Changes

Sorts procedure definitions in the More category by their name, so that the category acts like a dictionary.

### Reason for Changes

Convenience - finding a particular custom block is much easier when they are predictably, intuitively sorted. Also, to resolve 'help wanted' issue #1250.

### Test Coverage

No new tests added. Could be worth adding tests to see if this function sorts correctly - but I was having trouble getting the unit test setup to work, so I couldn't/can't do that myself.
