### PR TITLE
Render label with secondary color background and white text

### DIFF
--- a/core/css.js
+++ b/core/css.js
@@ -452,6 +452,10 @@ Blockly.Css.CONTENT = [
     'fill: $colour_text;',
   '}',
 
+  '.blocklyEditableText>.blocklyEditableLabel {',
+    'fill: #fff;',
+  '}',
+
   '.blocklyDropdownText {',
     'fill: #fff !important;',
   '}',

--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -96,16 +96,22 @@ Blockly.FieldTextInput.prototype.init = function() {
     return;
   }
 
+  var notInShadow = !this.sourceBlock_.isShadow();
+
+  if (notInShadow) {
+    this.className_ += ' blocklyEditableLabel';
+  }
+
   Blockly.FieldTextInput.superClass_.init.call(this);
+
   // If not in a shadow block, draw a box.
-  if (!this.sourceBlock_.isShadow()) {
+  if (notInShadow) {
     this.box_ = Blockly.utils.createSvgElement('rect', {
       'x': 0,
       'y': 0,
       'width': this.size_.width,
       'height': this.size_.height,
-      'fill': Blockly.Colours.textField,
-      'fill-opacity': 0.3
+      'fill': this.sourceBlock_.getColourTertiary()
     });
     this.fieldGroup_.insertBefore(this.box_, this.textElement_);
   }


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Towards https://github.com/LLK/scratch-blocks/issues/1231

### Proposed Changes

_Describe what this Pull Request does_

Render the unfocused state of the textinput field with the secondary color background and white text. The focused state still has a white box and border, that is not included in this.
Old
![screen shot 2017-11-21 at 10 41 52 am](https://user-images.githubusercontent.com/654102/33081675-d87c955a-cea8-11e7-9cf4-564d185050f2.png)
New
![image](https://user-images.githubusercontent.com/654102/33081667-d2bb87f2-cea8-11e7-961c-f08c966f72fe.png) 