### PR TITLE
Add logic for edit/create custom procedures, wire up the playground

### DIFF
--- a/core/procedures.js
+++ b/core/procedures.js
@@ -360,7 +360,7 @@ Blockly.Procedures.newProcedureMutation = function() {
  * @private
  */
 Blockly.Procedures.createProcedureDefCallback_ = function(workspace) {
-  Blockly.Procedures.externalProcedureDefCallback_(
+  Blockly.Procedures.externalProcedureDefCallback(
     Blockly.Procedures.newProcedureMutation(),
     Blockly.Procedures.createProcedureCallbackFactory_(workspace)
   );
@@ -426,7 +426,7 @@ Blockly.Procedures.editProcedureCallback_ = function(block) {
       block.getProcCode(), block.workspace);
   }
   // Block now refers to the procedure prototype block, it is safe to proceed.
-  Blockly.Procedures.externalProcedureDefCallback_(
+  Blockly.Procedures.externalProcedureDefCallback(
     block.mutationToDom(),
     Blockly.Procedures.editProcedureCallbackFactory_(block)
   );
@@ -449,10 +449,10 @@ Blockly.Procedures.editProcedureCallbackFactory_ = function(block) {
 
 /**
  * Callback to create a new procedure custom command block.
- * @private
+ * @public
  */
-Blockly.Procedures.externalProcedureDefCallback_ = function(/** mutator, callback */) {
-  alert('External procedure editor must be override Blockly.Procedures.externalProcedureDefCallback_');
+Blockly.Procedures.externalProcedureDefCallback = function(/** mutator, callback */) {
+  alert('External procedure editor must be override Blockly.Procedures.externalProcedureDefCallback');
 };
 
 /**

--- a/core/procedures.js
+++ b/core/procedures.js
@@ -308,7 +308,7 @@ Blockly.Procedures.mutateCallersAndPrototype = function(name, ws, mutation) {
 
 /**
  * Find the definition block for the named procedure.
- * @param {string} procCode The identifier of the procedure to delete.
+ * @param {string} procCode The identifier of the procedure.
  * @param {!Blockly.Workspace} workspace The workspace to search.
  * @return {Blockly.Block} The procedure definition block, or null not found.
  */
@@ -328,7 +328,7 @@ Blockly.Procedures.getDefineBlock = function(procCode, workspace) {
 
 /**
  * Find the prototype block for the named procedure.
- * @param {string} procCode The identifier of the procedure to delete.
+ * @param {string} procCode The identifier of the procedure.
  * @param {!Blockly.Workspace} workspace The workspace to search.
  * @return {Blockly.Block} The procedure prototype block, or null not found.
  */

--- a/core/procedures.js
+++ b/core/procedures.js
@@ -77,6 +77,7 @@ Blockly.Procedures.allProcedures = function(root) {
  * Find all user-created procedure definition mutations in a workspace.
  * @param {!Blockly.Workspace} root Root workspace.
  * @return {!Array.<Element>} Array of mutation xml elements.
+ * @package
  */
 Blockly.Procedures.allProcedureMutations = function(root) {
   var blocks = root.getAllBlocks();
@@ -280,6 +281,7 @@ Blockly.Procedures.getCallers = function(name, ws, definitionRoot,
  * @param {string} name Name of procedure (procCode in scratch-blocks).
  * @param {!Blockly.Workspace} ws The workspace to find callers in.
  * @param {!Element} mutation New mutation for the callers.
+ * @package
  */
 Blockly.Procedures.mutateCallersAndPrototype = function(name, ws, mutation) {
   var defineBlock = Blockly.Procedures.getDefineBlock(name, ws);
@@ -311,6 +313,7 @@ Blockly.Procedures.mutateCallersAndPrototype = function(name, ws, mutation) {
  * @param {string} procCode The identifier of the procedure.
  * @param {!Blockly.Workspace} workspace The workspace to search.
  * @return {Blockly.Block} The procedure definition block, or null not found.
+ * @package
  */
 Blockly.Procedures.getDefineBlock = function(procCode, workspace) {
   // Assume that a procedure definition is a top block.
@@ -331,6 +334,7 @@ Blockly.Procedures.getDefineBlock = function(procCode, workspace) {
  * @param {string} procCode The identifier of the procedure.
  * @param {!Blockly.Workspace} workspace The workspace to search.
  * @return {Blockly.Block} The procedure prototype block, or null not found.
+ * @package
  */
 Blockly.Procedures.getPrototypeBlock = function(procCode, workspace) {
   var defineBlock = Blockly.Procedures.getDefineBlock(procCode, workspace);
@@ -343,6 +347,7 @@ Blockly.Procedures.getPrototypeBlock = function(procCode, workspace) {
 /**
  * Create a mutation for a brand new custom procedure.
  * @return {Element} The mutation for a new custom procedure
+ * @package
  */
 Blockly.Procedures.newProcedureMutation = function() {
   var mutationText = '<xml>' +

--- a/core/procedures.js
+++ b/core/procedures.js
@@ -345,13 +345,16 @@ Blockly.Procedures.getPrototypeBlock = function(procCode, workspace) {
  * @return {Element} The mutation for a new custom procedure
  */
 Blockly.Procedures.newProcedureMutation = function() {
-  var mutation = goog.dom.createDom('mutation');
-  mutation.setAttribute('proccode', 'block name');
-  mutation.setAttribute('argumentids', JSON.stringify([]));
-  mutation.setAttribute('argumentnames', JSON.stringify([]));
-  mutation.setAttribute('argumentdefaults', JSON.stringify([]));
-  mutation.setAttribute('warp', false);
-  return mutation;
+  var mutationText = '<xml>' +
+      '<mutation' +
+      ' proccode="block name"' +
+      ' argumentids="[]"' +
+      ' argumentnames="[]"' +
+      ' argumentdefaults="[]"' +
+      ' warp="false">' +
+      '</mutation>' +
+      '</xml>';
+  return Blockly.Xml.textToDom(mutationText).firstChild;
 };
 
 /**

--- a/core/procedures.js
+++ b/core/procedures.js
@@ -82,7 +82,7 @@ Blockly.Procedures.allProcedureMutations = function(root) {
   var blocks = root.getAllBlocks();
   var mutations = [];
   for (var i = 0; i < blocks.length; i++) {
-    if (blocks[i].type == 'procedures_prototype') {
+    if (blocks[i].type == Blockly.PROCEDURES_PROTOTYPE_BLOCK_TYPE) {
       var mutation = blocks[i].mutationToDom();
       if (mutation) {
         mutations.push(mutation);

--- a/core/procedures.js
+++ b/core/procedures.js
@@ -369,8 +369,8 @@ Blockly.Procedures.newProcedureMutation = function() {
  */
 Blockly.Procedures.createProcedureDefCallback_ = function(workspace) {
   Blockly.Procedures.externalProcedureDefCallback(
-    Blockly.Procedures.newProcedureMutation(),
-    Blockly.Procedures.createProcedureCallbackFactory_(workspace)
+      Blockly.Procedures.newProcedureMutation(),
+      Blockly.Procedures.createProcedureCallbackFactory_(workspace)
   );
 };
 
@@ -431,12 +431,12 @@ Blockly.Procedures.editProcedureCallback_ = function(block) {
   } else if (block.type == Blockly.PROCEDURES_CALL_BLOCK_TYPE) {
     // This is a call block, find the prototype corresponding to the procCode
     block = Blockly.Procedures.getPrototypeBlock(
-      block.getProcCode(), block.workspace);
+        block.getProcCode(), block.workspace);
   }
   // Block now refers to the procedure prototype block, it is safe to proceed.
   Blockly.Procedures.externalProcedureDefCallback(
-    block.mutationToDom(),
-    Blockly.Procedures.editProcedureCallbackFactory_(block)
+      block.mutationToDom(),
+      Blockly.Procedures.editProcedureCallbackFactory_(block)
   );
 };
 
@@ -450,7 +450,7 @@ Blockly.Procedures.editProcedureCallbackFactory_ = function(block) {
   return function(mutation) {
     if (mutation) {
       Blockly.Procedures.mutateCallersAndPrototype(block.getProcCode(),
-        block.workspace, mutation);
+          block.workspace, mutation);
     }
   };
 };

--- a/tests/custom_procedure_playground.html
+++ b/tests/custom_procedure_playground.html
@@ -153,7 +153,7 @@
     Blockly.Xml.clearWorkspaceAndLoadFromXml(document.getElementById('main_ws_blocks_simplest'),
         definitionWorkspace);
 
-    Blockly.Procedures.externalProcedureDefCallback_ = function (mutation, cb) {
+    Blockly.Procedures.externalProcedureDefCallback = function (mutation, cb) {
       editorActions.style.visibility = 'visible';
       callback = cb;
       declarationWorkspace.clear();

--- a/tests/custom_procedure_playground.html
+++ b/tests/custom_procedure_playground.html
@@ -32,39 +32,28 @@
   </style>
 </head>
 <body>
-
-  <p>This page has two workspaces.  The workspace on the left (primaryWorkspace) will be the custom procedure editing workspace, which will hold a single non-deletable block.  The workspace on the right will hold the resulting procedure definition and call blocks.</p>
-
-
   <table width="100%">
     <tr>
       <td>
-        <div id="primaryDiv" style="height: 480px; width: 600px;"></div>
+        <div id="secondaryDiv" style="height: 480px; width: 600px;"></div>
       </td>
       <td>
-        <div id="secondaryDiv" style="height: 480px; width: 600px;"></div>
+        <div id="primaryDiv" style="height: 480px; width: 600px;"></div>
       </td>
     </tr>
     <tr>
-      <td>
+      <td></td>
+      <td id="editor-actions">
         <button id="text_number" onclick="addTextNumber()">Add text/number input</button>
         <button id="boolean" onclick="addBoolean()">Add boolean input</button>
         <button id="label" onclick="addLabel()">Add label</button>
-        <button id="cancelButton">cancel</button>
+        <button id="cancelButton" onclick="cancel()">cancel</button>
         <button id="okButton" onclick="applyMutation()">ok</button>
         <button id="rndButton" onclick="removeRandomInput()">remove random input</button>
         <button id="addRndButton" onclick="addRandomInput()">add random input</button>
       </td>
-      <td></td>
     </tr>
   </table>
-
-  <xml id="toolbox" style="display: none">
-    <block type="pen_clear"></block>
-    <block type="pen_stamp"></block>
-    <block type="pen_pendown"></block>
-    <block type="pen_penup"></block>
-  </xml>
 
   <xml id="mutator_blocks" style="display:none">
     <block type="procedures_declaration" x="25" y="25" deletable="false">
@@ -132,31 +121,55 @@
     </block>
   </xml>
 
+  <xml id="toolbox" style="display:none">
+    <category name="More" colour="#FF6680" secondaryColour="#FF4D6A" custom="PROCEDURE">
+    </category>
+  </xml>
 
   <script>
-    // Inject primary workspace.
-    var primaryWorkspace = Blockly.inject('primaryDiv',
+    var editorActions = document.getElementById('editor-actions');
+    editorActions.style.visibility = 'hidden';
+
+    var callback = null;
+    var mutationRoot = null;
+
+    var declarationWorkspace = Blockly.inject('primaryDiv',
         {media: '../media/'});
 
-    Blockly.Xml.domToWorkspace(document.getElementById('mutator_blocks_simplest'),
-        primaryWorkspace);
+    declarationWorkspace.addChangeListener(function() {
+      if (mutationRoot) {
+        mutationRoot.onChangeFn();
+      }
+    });
 
-    var mutationRoot = primaryWorkspace.getTopBlocks()[0];
+    var definitionWorkspace = Blockly.inject('secondaryDiv', {
+      media: '../media/',
+      toolbox: document.getElementById('toolbox'),
+      zoom: {
+        startScale: 0.75
+      }
+    });
 
-    primaryWorkspace.addChangeListener(function() {mutationRoot.onChangeFn();});
+    Blockly.Xml.clearWorkspaceAndLoadFromXml(document.getElementById('main_ws_blocks_simplest'),
+        definitionWorkspace);
 
-    // Inject secondary workspace.
-    var secondaryWorkspace = Blockly.inject('secondaryDiv',
-        {media: '../media/'});
-
-    Blockly.Xml.domToWorkspace(document.getElementById('main_ws_blocks_simplest'),
-        secondaryWorkspace);
+    Blockly.Procedures.externalProcedureDefCallback_ = function (mutation, cb) {
+      editorActions.style.visibility = 'visible';
+      callback = cb;
+      declarationWorkspace.clear();
+      mutationRoot = declarationWorkspace.newBlock('procedures_declaration');
+      mutationRoot.domToMutation(mutation);
+      mutationRoot.initSvg();
+      mutationRoot.render(false);
+    }
 
     function applyMutation() {
-      var mutation = mutationRoot.mutationToDom();
-      console.log(mutation);
-      secondaryWorkspace.getBlockById('caller_external').domToMutation(mutation);
-      secondaryWorkspace.getBlockById('caller_internal').domToMutation(mutation);
+      callback(mutationRoot.mutationToDom());
+      callback = null;
+      mutationRoot = null;
+      declarationWorkspace.clear();
+      definitionWorkspace.refreshToolboxSelection_()
+      editorActions.style.visibility = 'hidden';
     }
 
     function addLabel() {
@@ -176,8 +189,6 @@
       mutationRoot.removeInput(mutationRoot.inputList[rnd].name);
       mutationRoot.onChangeFn();
       mutationRoot.updateDisplay_();
-
-      applyMutation();
     }
 
     function addRandomInput() {
@@ -193,8 +204,14 @@
           addBoolean();
           break;
       }
+    }
 
-      applyMutation();
+    function cancel() {
+      callback = null;
+      mutationRoot = null;
+      declarationWorkspace.clear();
+      definitionWorkspace.refreshToolboxSelection_()
+      editorActions.style.visibility = 'hidden';
     }
 </script>
 


### PR DESCRIPTION
[work in progress, wanted to get it up so people could start taking a look]

This PR implements the `editProcedureCallback_` and `createProcedureCallback_` by wiring them to a common `externalProcedureDefCallback_`. This new function is just a stub, intended to be overwritten externally. An example implementation is then added to the custom procedure playground. 

![new-custom-procedure-playground](https://user-images.githubusercontent.com/654102/33146447-327c0650-cf92-11e7-972a-b73eea4ec750.gif)

I'd like to use this as a starting point for talking about how communication should work. Right now the external function gets the mutator from the procedure block of a given procedure, and a callback to call with an updated version of that mutator. 