### PR TITLE
Change argument default values and automatically focus on new inputs

### DIFF
--- a/blocks_vertical/procedures.js
+++ b/blocks_vertical/procedures.js
@@ -532,6 +532,7 @@ Blockly.ScratchBlocks.ProcedureUtils.updateDeclarationProcCode_ = function() {
 
 /**
  * Focus on the final input of the block
+ * @private
  */
 Blockly.ScratchBlocks.ProcedureUtils.focusLastInput_ = function() {
   if (this.inputList.length > 0) {

--- a/blocks_vertical/procedures.js
+++ b/blocks_vertical/procedures.js
@@ -531,7 +531,7 @@ Blockly.ScratchBlocks.ProcedureUtils.updateDeclarationProcCode_ = function() {
 };
 
 /**
- * Focus on the final input of the block
+ * Focus on the last argument editor or label editor on the block.
  * @private
  */
 Blockly.ScratchBlocks.ProcedureUtils.focusLastInput_ = function() {

--- a/blocks_vertical/procedures.js
+++ b/blocks_vertical/procedures.js
@@ -279,11 +279,11 @@ Blockly.ScratchBlocks.ProcedureUtils.buildShadowDom_ = function(type) {
   if (type == 'n') {
     var shadowType = 'math_number';
     var fieldName = 'NUM';
-    var fieldValue = '10';
+    var fieldValue = '1';
   } else {
     var shadowType = 'text';
     var fieldName = 'TEXT';
-    var fieldValue = 'hello world';
+    var fieldValue = '';
   }
   shadowDom.setAttribute('type', shadowType);
   var fieldDom = goog.dom.createDom('field', null, fieldValue);
@@ -306,9 +306,9 @@ Blockly.ScratchBlocks.ProcedureUtils.attachShadow_ = function(input,
     var blockType = argumentType == 'n' ? 'math_number' : 'text';
     var newBlock = this.workspace.newBlock(blockType);
     if (argumentType == 'n') {
-      newBlock.setFieldValue('99', 'NUM');
+      newBlock.setFieldValue('1', 'NUM');
     } else {
-      newBlock.setFieldValue('hello world', 'TEXT');
+      newBlock.setFieldValue('', 'TEXT');
     }
     newBlock.setShadow(true);
     if (!this.isInsertionMarker()) {
@@ -531,12 +531,30 @@ Blockly.ScratchBlocks.ProcedureUtils.updateDeclarationProcCode_ = function() {
 };
 
 /**
+ * Focus on the final input of the block
+ */
+Blockly.ScratchBlocks.ProcedureUtils.focusLastInput_ = function() {
+  if (this.inputList.length > 0) {
+    var newInput = this.inputList[this.inputList.length - 1];
+    if (newInput.type == Blockly.DUMMY_INPUT) {
+      newInput.fieldRow[0].showEditor_();
+    } else if (newInput.type == Blockly.INPUT_VALUE) {
+      // Inspect the argument editor.
+      var target = newInput.connection.targetBlock();
+      target.getField('TEXT').showEditor_();
+    }
+  }
+};
+
+/**
  * Externally-visible function to add a label to the procedure declaration.
  * @public
  */
 Blockly.ScratchBlocks.ProcedureUtils.addLabelExternal = function() {
+  Blockly.WidgetDiv.hide(true);
   this.procCode_ = this.procCode_ + ' label text';
   this.updateDisplay_();
+  this.focusLastInput_();
 };
 
 /**
@@ -545,11 +563,13 @@ Blockly.ScratchBlocks.ProcedureUtils.addLabelExternal = function() {
  * @public
  */
 Blockly.ScratchBlocks.ProcedureUtils.addBooleanExternal = function() {
+  Blockly.WidgetDiv.hide(true);
   this.procCode_ = this.procCode_ + ' %b';
   this.displayNames_.push('boolean');
   this.argumentIds_.push(Blockly.utils.genUid());
   this.argumentDefaults_.push('todo');
   this.updateDisplay_();
+  this.focusLastInput_();
 };
 
 /**
@@ -558,11 +578,13 @@ Blockly.ScratchBlocks.ProcedureUtils.addBooleanExternal = function() {
  * @public
  */
 Blockly.ScratchBlocks.ProcedureUtils.addStringNumberExternal = function() {
+  Blockly.WidgetDiv.hide(true);
   this.procCode_ = this.procCode_ + ' %s';
   this.displayNames_.push('string or number');
   this.argumentIds_.push(Blockly.utils.genUid());
   this.argumentDefaults_.push('todo');
   this.updateDisplay_();
+  this.focusLastInput_();
 };
 
 Blockly.Blocks['procedures_definition'] = {
@@ -684,6 +706,7 @@ Blockly.Blocks['procedures_declaration'] = {
 
   // Only exist on procedures_declaration.
   createArgumentEditor_: Blockly.ScratchBlocks.ProcedureUtils.createArgumentEditor_,
+  focusLastInput_: Blockly.ScratchBlocks.ProcedureUtils.focusLastInput_,
   addLabelExternal: Blockly.ScratchBlocks.ProcedureUtils.addLabelExternal,
   addBooleanExternal: Blockly.ScratchBlocks.ProcedureUtils.addBooleanExternal,
   addStringNumberExternal: Blockly.ScratchBlocks.ProcedureUtils.addStringNumberExternal,
@@ -755,4 +778,3 @@ Blockly.Blocks['argument_editor_string_number'] = {
     });
   }
 };
-

--- a/blocks_vertical/procedures.js
+++ b/blocks_vertical/procedures.js
@@ -534,7 +534,7 @@ Blockly.ScratchBlocks.ProcedureUtils.updateDeclarationProcCode_ = function() {
  * Focus on the last argument editor or label editor on the block.
  * @private
  */
-Blockly.ScratchBlocks.ProcedureUtils.focusLastInput_ = function() {
+Blockly.ScratchBlocks.ProcedureUtils.focusLastEditor_ = function() {
   if (this.inputList.length > 0) {
     var newInput = this.inputList[this.inputList.length - 1];
     if (newInput.type == Blockly.DUMMY_INPUT) {
@@ -555,7 +555,7 @@ Blockly.ScratchBlocks.ProcedureUtils.addLabelExternal = function() {
   Blockly.WidgetDiv.hide(true);
   this.procCode_ = this.procCode_ + ' label text';
   this.updateDisplay_();
-  this.focusLastInput_();
+  this.focusLastEditor_();
 };
 
 /**
@@ -570,7 +570,7 @@ Blockly.ScratchBlocks.ProcedureUtils.addBooleanExternal = function() {
   this.argumentIds_.push(Blockly.utils.genUid());
   this.argumentDefaults_.push('todo');
   this.updateDisplay_();
-  this.focusLastInput_();
+  this.focusLastEditor_();
 };
 
 /**
@@ -585,7 +585,7 @@ Blockly.ScratchBlocks.ProcedureUtils.addStringNumberExternal = function() {
   this.argumentIds_.push(Blockly.utils.genUid());
   this.argumentDefaults_.push('todo');
   this.updateDisplay_();
-  this.focusLastInput_();
+  this.focusLastEditor_();
 };
 
 Blockly.Blocks['procedures_definition'] = {
@@ -707,7 +707,7 @@ Blockly.Blocks['procedures_declaration'] = {
 
   // Only exist on procedures_declaration.
   createArgumentEditor_: Blockly.ScratchBlocks.ProcedureUtils.createArgumentEditor_,
-  focusLastInput_: Blockly.ScratchBlocks.ProcedureUtils.focusLastInput_,
+  focusLastEditor_: Blockly.ScratchBlocks.ProcedureUtils.focusLastEditor_,
   addLabelExternal: Blockly.ScratchBlocks.ProcedureUtils.addLabelExternal,
   addBooleanExternal: Blockly.ScratchBlocks.ProcedureUtils.addBooleanExternal,
   addStringNumberExternal: Blockly.ScratchBlocks.ProcedureUtils.addStringNumberExternal,


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_
Resolves https://github.com/LLK/scratch-blocks/issues/1233

Use the scratch-2 default values for custom procedure inputs, and change the behavior of adding new inputs to focus on the newly created input.


![custom-procedure-defaults](https://user-images.githubusercontent.com/654102/33286542-aaf70ebe-d383-11e7-98a6-e21952a474b7.gif)
