### PR TITLE
Cancel workspace gestures on toolbox mousedown.

### DIFF
--- a/core/toolbox.js
+++ b/core/toolbox.js
@@ -117,6 +117,8 @@ Blockly.Toolbox.prototype.init = function() {
   // Clicking on toolbox closes popups.
   Blockly.bindEventWithChecks_(this.HtmlDiv, 'mousedown', this,
       function(e) {
+        // Cancel any gestures in progress.
+        this.workspace_.cancelCurrentGesture();
         if (Blockly.utils.isRightButton(e) || e.target == this.HtmlDiv) {
           // Close flyout.
           Blockly.hideChaff(false);


### PR DESCRIPTION
Fixes the problem where dragging a duplicated block onto the category
menu didn't properly delete it.

### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-blocks/issues/1089

### Proposed Changes

_Describe what this Pull Request does_

Cancel any gestures that are in-progress when mousedown-ing on the toolbox. This allows blocks to be correctly disposed of.

### Reason for Changes

_Explain why these changes should be made_

The toolbox was greedily cancelling the touch identifier on mousedown, breaking the sequence of identifiers that duplicated blocks use. 

### Test Coverage

_Please show how you have added tests to cover your changes_

Tested in the vertical playground.

----

@rachel-fenichel I think it ended up not being necassary to check for a gesture and act differently depending on whether one was received, because this mousedown handler should always cancel any in-progress gestures. I'm still pretty fuzzy on this code, though, so let me know.