### PR TITLE
Fix duplicate on drag events

### DIFF
--- a/core/gesture.js
+++ b/core/gesture.js
@@ -834,6 +834,7 @@ Blockly.Gesture.prototype.forceStartBlockDrag = function(fakeEvent, block) {
  */
 Blockly.Gesture.prototype.duplicateOnDrag_ = function() {
   var newBlock = null;
+  Blockly.Events.disable();
   try {
     // Note: targetBlock_ should have no children.  If it has children we would
     // need to update shadow block IDs to avoid problems in the VM.


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_
Fixes https://github.com/LLK/scratch-blocks/issues/1265
### Proposed Changes

_Describe what this Pull Request does_
Looks like there was a typo when the duplicateOnDrag functionality was implemented. There was an "enable" without a corresponding disable, which left events in a bad state.


Tested by checking out the vertical playground and running through repro steps in the linked issue