### PR TITLE
Changing color of list blocks 

### DIFF
--- a/blocks_vertical/data.js
+++ b/blocks_vertical/data.js
@@ -166,7 +166,7 @@ Blockly.Blocks['data_listcontents'] = {
         }
       ],
       "category": Blockly.Categories.data,
-      "extensions": ["colours_data", "output_string"],
+      "extensions": ["colours_data_lists", "output_string"],
       "checkboxInFlyout": true
     });
   }
@@ -248,7 +248,7 @@ Blockly.Blocks['data_addtolist'] = {
         }
       ],
       "category": Blockly.Categories.data,
-      "extensions": ["colours_data", "shape_statement"]
+      "extensions": ["colours_data_lists", "shape_statement"]
     });
   }
 };
@@ -273,7 +273,7 @@ Blockly.Blocks['data_deleteoflist'] = {
         }
       ],
       "category": Blockly.Categories.data,
-      "extensions": ["colours_data", "shape_statement"]
+      "extensions": ["colours_data_lists", "shape_statement"]
     });
   }
 };
@@ -302,7 +302,7 @@ Blockly.Blocks['data_insertatlist'] = {
         }
       ],
       "category": Blockly.Categories.data,
-      "extensions": ["colours_data", "shape_statement"]
+      "extensions": ["colours_data_lists", "shape_statement"]
     });
   }
 };
@@ -331,7 +331,7 @@ Blockly.Blocks['data_replaceitemoflist'] = {
         }
       ],
       "category": Blockly.Categories.data,
-      "extensions": ["colours_data", "shape_statement"]
+      "extensions": ["colours_data_lists", "shape_statement"]
     });
   }
 };
@@ -357,7 +357,7 @@ Blockly.Blocks['data_itemoflist'] = {
       ],
       "output": null,
       "category": Blockly.Categories.data,
-      "extensions": ["colours_data"],
+      "extensions": ["colours_data_lists"],
       "outputShape": Blockly.OUTPUT_SHAPE_ROUND
     });
   }
@@ -379,7 +379,7 @@ Blockly.Blocks['data_lengthoflist'] = {
         }
       ],
       "category": Blockly.Categories.data,
-      "extensions": ["colours_data", "output_number"]
+      "extensions": ["colours_data_lists", "output_number"]
     });
   }
 };
@@ -404,7 +404,7 @@ Blockly.Blocks['data_listcontainsitem'] = {
         }
       ],
       "category": Blockly.Categories.data,
-      "extensions": ["colours_data", "output_boolean"]
+      "extensions": ["colours_data_lists", "output_boolean"]
     });
   }
 };
@@ -425,7 +425,7 @@ Blockly.Blocks['data_showlist'] = {
         }
       ],
       "category": Blockly.Categories.data,
-      "extensions": ["colours_data", "shape_statement"]
+      "extensions": ["colours_data_lists", "shape_statement"]
     });
   }
 };
@@ -446,7 +446,7 @@ Blockly.Blocks['data_hidelist'] = {
         }
       ],
       "category": Blockly.Categories.data,
-      "extensions": ["colours_data", "shape_statement"]
+      "extensions": ["colours_data_lists", "shape_statement"]
     });
   }
 };

--- a/blocks_vertical/vertical_extensions.js
+++ b/blocks_vertical/vertical_extensions.js
@@ -217,8 +217,8 @@ Blockly.ScratchBlocks.VerticalExtensions.PROCEDURE_CALL_CONTEXTMENU = {
  */
 Blockly.ScratchBlocks.VerticalExtensions.registerAll = function() {
   var categoryNames =
-      ['control', 'data', 'sounds', 'motion', 'looks', 'event', 'sensing',
-      'pen', 'operators', 'more'];
+      ['control', 'data', 'data_lists', 'sounds', 'motion', 'looks', 'event',
+      'sensing', 'pen', 'operators', 'more'];
   // Register functions for all category colours.
   for (var i = 0; i < categoryNames.length; i++) {
     name = categoryNames[i];

--- a/core/colours.js
+++ b/core/colours.js
@@ -70,6 +70,13 @@ Blockly.Colours = {
     "secondary": "#FF8000",
     "tertiary": "#DB6E00"
   },
+  // This is not a new category, but rather for differentiation
+  // between lists and scalar variables.
+  "data_lists": {
+    "primary": "#FF661A",
+    "secondary": "#FF5500",
+    "tertiary": "#E64D00"
+  },
   "more": {
     "primary": "#FF6680",
     "secondary": "#FF4D6A",


### PR DESCRIPTION
Changing color of list blocks to differentiate from variable blocks.

### Resolves

Resolves #1257 

### Proposed Changes

Change the color of list blocks to differentiate from scalar variables according to color chart in #600 and discussion in #1257.

### Reason for Changes

Lists and variables will be able to share names, so color is a visible way of differentiating between the blocks that would otherwise look the same (e.g. variable getter).

### Test Coverage

Existing tests pass.
