### PR TITLE
Fix block duplication errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,9 @@ language: node_js
 node_js:
 - "4"
 - "stable"
-sudo: false
+sudo: required
+addons:
+  chrome: stable
 cache:
   directories:
   - node_modules

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -626,7 +626,7 @@ Blockly.BlockSvg.prototype.createTabList_ = function() {
  * @private
  */
 Blockly.BlockSvg.prototype.onMouseDown_ = function(e) {
-  var gesture = this.workspace.getGesture(e);
+  var gesture = this.workspace && this.workspace.getGesture(e);
   if (gesture) {
     gesture.handleBlockStart(e, this);
   }


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_
Fixes https://github.com/LLK/scratch-gui/issues/758
Fixes https://github.com/LLK/scratch-blocks/issues/1271

### Proposed Changes

_Describe what this Pull Request does_

First fix is a tiny one, just making sure to check for a workspace before trying to get gestures from it. That fixes #1271 

Second one makes the `duplicateAndDrag` code work more like the `paste` code by wrapping the block creation in disable/enable events and manually emitting the new block event after a series of actions has been performed. 

This fixes the problem where the "create" event was being emitted before the "    changeObscuredShadowIds" utility has the chance to run. It also makes the undo stack nicer by not putting the block placed at 0,0.

### Reason for Changes

_Explain why these changes should be made_

Fix some pretty terrible exceptions that occur when the VM gets out of sync with blocks in terms of which blocks exist.

### Test Coverage

_Please show how you have added tests to cover your changes_

Tested in the vertical playground and in the VM playground for both of the linked issues/repro cases.