### PR TITLE
Add the definitions for show/hide variable blocks, hide in toolbox.

### DIFF
--- a/blocks_vertical/data.js
+++ b/blocks_vertical/data.js
@@ -100,54 +100,53 @@ Blockly.Blocks['data_changevariableby'] = {
   }
 };
 
-// @todo reinstate when there are implementations for these
-// Blockly.Blocks['data_showvariable'] = {
-//   /**
-//    * Block to show a variable
-//    * @this Blockly.Block
-//    */
-//   init: function() {
-//     this.jsonInit({
-//       "message0": "show variable %1",
-//       "args0": [
-//         {
-//           "type": "input_value",
-//           "name": "VARIABLE"
-//         }
-//       ],
-//       "previousStatement": null,
-//       "nextStatement": null,
-//       "category": Blockly.Categories.data,
-//       "colour": Blockly.Colours.data.primary,
-//       "colourSecondary": Blockly.Colours.data.secondary,
-//       "colourTertiary": Blockly.Colours.data.tertiary
-//     });
-//   }
-// };
-//
-// Blockly.Blocks['data_hidevariable'] = {
-//   /**
-//    * Block to hide a variable
-//    * @this Blockly.Block
-//    */
-//   init: function() {
-//     this.jsonInit({
-//       "message0": "hide variable %1",
-//       "args0": [
-//         {
-//           "type": "input_value",
-//           "name": "VARIABLE"
-//         }
-//       ],
-//       "previousStatement": null,
-//       "nextStatement": null,
-//       "category": Blockly.Categories.data,
-//       "colour": Blockly.Colours.data.primary,
-//       "colourSecondary": Blockly.Colours.data.secondary,
-//       "colourTertiary": Blockly.Colours.data.tertiary
-//     });
-//   }
-// };
+Blockly.Blocks['data_showvariable'] = {
+  /**
+   * Block to show a variable
+   * @this Blockly.Block
+   */
+  init: function() {
+    this.jsonInit({
+      "message0": "show variable %1",
+      "args0": [
+        {
+          "type": "field_variable",
+          "name": "VARIABLE"
+        }
+      ],
+      "previousStatement": null,
+      "nextStatement": null,
+      "category": Blockly.Categories.data,
+      "colour": Blockly.Colours.data.primary,
+      "colourSecondary": Blockly.Colours.data.secondary,
+      "colourTertiary": Blockly.Colours.data.tertiary
+    });
+  }
+};
+
+Blockly.Blocks['data_hidevariable'] = {
+  /**
+   * Block to hide a variable
+   * @this Blockly.Block
+   */
+  init: function() {
+    this.jsonInit({
+      "message0": "hide variable %1",
+      "args0": [
+        {
+          "type": "field_variable",
+          "name": "VARIABLE"
+        }
+      ],
+      "previousStatement": null,
+      "nextStatement": null,
+      "category": Blockly.Categories.data,
+      "colour": Blockly.Colours.data.primary,
+      "colourSecondary": Blockly.Colours.data.secondary,
+      "colourTertiary": Blockly.Colours.data.tertiary
+    });
+  }
+};
 
 Blockly.Blocks['data_listcontents'] = {
   /**
@@ -549,4 +548,3 @@ Blockly.Constants.Data.DELETE_OPTION_CALLBACK_FACTORY = function(block) {
     workspace.deleteVariable(name);
   };
 };
-

--- a/core/data_category.js
+++ b/core/data_category.js
@@ -57,7 +57,7 @@ Blockly.DataCategory = function(workspace) {
 
     Blockly.DataCategory.addSetVariableTo(xmlList, firstVariable);
     Blockly.DataCategory.addChangeVariableBy(xmlList, firstVariable);
-    // TODO uncomment these when their implementations are finished.
+    // TODO (#1276): uncomment these when their implementations are finished.
     // Blockly.DataCategory.addShowVariable(xmlList, firstVariable);
     // Blockly.DataCategory.addHideVariable(xmlList, firstVariable);
   }
@@ -81,7 +81,7 @@ Blockly.DataCategory = function(workspace) {
     Blockly.DataCategory.addItemOfList(xmlList, firstVariable);
     Blockly.DataCategory.addLengthOfList(xmlList, firstVariable);
     Blockly.DataCategory.addListContainsItem(xmlList, firstVariable);
-    // TODO uncomment these when their implementations are finished.
+    // TODO (#1276): uncomment these when their implementations are finished.
     // Blockly.DataCategory.addShowList(xmlList, firstVariable);
     // Blockly.DataCategory.addHideList(xmlList, firstVariable);
   }

--- a/core/data_category.js
+++ b/core/data_category.js
@@ -57,8 +57,9 @@ Blockly.DataCategory = function(workspace) {
 
     Blockly.DataCategory.addSetVariableTo(xmlList, firstVariable);
     Blockly.DataCategory.addChangeVariableBy(xmlList, firstVariable);
-    Blockly.DataCategory.addShowVariable(xmlList, firstVariable);
-    Blockly.DataCategory.addHideVariable(xmlList, firstVariable);
+    // TODO uncomment these when their implementations are finished.
+    // Blockly.DataCategory.addShowVariable(xmlList, firstVariable);
+    // Blockly.DataCategory.addHideVariable(xmlList, firstVariable);
   }
 
   // Now add list variables to the flyout
@@ -80,8 +81,9 @@ Blockly.DataCategory = function(workspace) {
     Blockly.DataCategory.addItemOfList(xmlList, firstVariable);
     Blockly.DataCategory.addLengthOfList(xmlList, firstVariable);
     Blockly.DataCategory.addListContainsItem(xmlList, firstVariable);
-    Blockly.DataCategory.addShowList(xmlList, firstVariable);
-    Blockly.DataCategory.addHideList(xmlList, firstVariable);
+    // TODO uncomment these when their implementations are finished.
+    // Blockly.DataCategory.addShowList(xmlList, firstVariable);
+    // Blockly.DataCategory.addHideList(xmlList, firstVariable);
   }
 
   return xmlList;


### PR DESCRIPTION
By commenting out the definitions, instead of the toolbox addition, we
are breaking imported projects that use these blocks.

### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-vm/issues/834

### Proposed Changes

_Describe what this Pull Request does_

Adds the block definitions for `data_show|hidevariable` and comment out the code which adds those blocks to the "Data" category. Also comment out the related list blocks, since those are not ready also. 

I also changed the show/hide definition slightly to use a field instead of an input, a change we made a long time ago to the other variable blocks. That change just brings these blocks up-to-date.

