### PR TITLE
Disable the new message option for flyout broadcast dropdowns.

### DIFF
--- a/core/field_variable.js
+++ b/core/field_variable.js
@@ -205,7 +205,8 @@ Blockly.FieldVariable.dropdownCreate = function() {
     }
   }
   // Ensure that the currently selected variable is an option.
-  if (createSelectedVariable && workspace) {
+  // TODO (#1270): Remove isBroadcastType check here when flyout variables fixed.
+  if (createSelectedVariable && workspace && !isBroadcastType) {
     var newVar = workspace.createVariable(name);
     variableModelList.push(newVar);
   }
@@ -216,7 +217,10 @@ Blockly.FieldVariable.dropdownCreate = function() {
     options[i] = [variableModelList[i].name, variableModelList[i].getId()];
   }
   if (isBroadcastType) {
-    options.push([Blockly.Msg.NEW_BROADCAST_MESSAGE, Blockly.NEW_BROADCAST_MESSAGE_ID]);
+    // TODO (#1270): Re-enable create broadcast message dropdown in flyout when fixed.
+    if (!workspace.isFlyout) {
+      options.push([Blockly.Msg.NEW_BROADCAST_MESSAGE, Blockly.NEW_BROADCAST_MESSAGE_ID]);
+    }
   } else {
     options.push([Blockly.Msg.RENAME_VARIABLE, Blockly.RENAME_VARIABLE_ID]);
     if (Blockly.Msg.DELETE_VARIABLE) {


### PR DESCRIPTION
The fix for this bug involves a pretty extensive refactor of
field_variable that rachel is working on. In order to support continued
workshop testing, we need to prevent these bugs by disabling this
feature temporarily.

### Resolves

_What Github issue does this resolve (please include link)?_

Does not fix, but is designed to stop this bug from ruining workshop testing: https://github.com/LLK/scratch-blocks/issues/1270

### Proposed Changes

_Describe what this Pull Request does_

Stops the "new message" option from appearing when in the flyout, and stops the dropdown creation from automatically creating a new variable when opened, again if it is in the flyout.

Real fixes for those issues are incoming from work @rachel-fenichel is doing on blockly. But we wanted to make sure to stop this from causing issues until then.
