### PR TITLE
Reduce connecting snap radius

### DIFF
--- a/core/constants.js
+++ b/core/constants.js
@@ -48,7 +48,7 @@ Blockly.SNAP_RADIUS = 48;
  * Maximum misalignment between connections for them to snap together,
  * when a connection is already highlighted.
  */
-Blockly.CONNECTING_SNAP_RADIUS = 96;
+Blockly.CONNECTING_SNAP_RADIUS = 68;
 
 /**
  * How much to prefer staying connected to the current connection over moving to


### PR DESCRIPTION
### Resolves

Resolves https://github.com/LLK/scratch-blocks/issues/854

### Proposed Changes

Reduce the distance threshold for blocks to snap together or disconnect. 

### Reason for Changes

Previously, the threshold was higher, so you had to drag a block down off the bottom of a stack for a distance almost twice the height of the block in order to disconnect it (otherwise it would re-attach when you release). Now, you have to drag less far to disconnect a block from a stack. This parameter can't be too low, or else the blocks will jump around while you drag to insert in the middle of a stack (as noted by @rachel-fenichel), so @carljbowman and I played around with it until we found an acceptable compromise. 
