### PR TITLE
Extension icon separator line

### DIFF
--- a/blocks_vertical/default_toolbox.js
+++ b/blocks_vertical/default_toolbox.js
@@ -642,7 +642,13 @@ Blockly.Blocks.defaultToolbox = '<xml id="toolbox-categories" style="display: no
   '</category>' +
   '<category name="Extensions" colour="#FF6680" secondaryColour="#FF4D6A">'+
     '<block type="extension_pen_down" id="extension_pen_down"></block>'+
-    '<block type="extension_music_drum" id="extension_music_drum"></block>'+
+    '<block type="extension_music_drum" id="extension_music_drum">'+
+      '<value name="NUMBER">'+
+        '<shadow type="math_number">'+
+          '<field name="NUM">1</field>'+
+        '</shadow>'+
+      '</value>'+
+      '</block>'+
     '<block type="extension_wedo_motor" id="extension_wedo_motor"></block>'+
     '<block type="extension_wedo_hat" id="extension_wedo_hat"></block>'+
     '<block type="extension_wedo_boolean" id="extension_wedo_boolean"></block>'+

--- a/blocks_vertical/extensions.js
+++ b/blocks_vertical/extensions.js
@@ -55,13 +55,17 @@ Blockly.Blocks['extension_music_drum'] = {
    */
   init: function() {
     this.jsonInit({
-      "message0": "%1 play a drum",
+      "message0": "%1 play drum %2",
       "args0": [
         {
           "type": "field_image",
           "src": Blockly.mainWorkspace.options.pathToMedia + "extensions/music-block-icon.svg",
           "width": 40,
           "height": 40
+        },
+        {
+          "type": "input_value",
+          "name": "NUMBER"
         }
       ],
       "category": Blockly.Categories.more,

--- a/blocks_vertical/extensions.js
+++ b/blocks_vertical/extensions.js
@@ -27,20 +27,22 @@ goog.require('Blockly.Colours');
 goog.require('Blockly.constants');
 goog.require('Blockly.ScratchBlocks.VerticalExtensions');
 
-
 Blockly.Blocks['extension_pen_down'] = {
   /**
    * @this Blockly.Block
    */
   init: function() {
     this.jsonInit({
-      "message0": "%1 pen down",
+      "message0": "%1 %2 pen down",
       "args0": [
         {
           "type": "field_image",
           "src": Blockly.mainWorkspace.options.pathToMedia + "extensions/pen-block-icon.svg",
           "width": 40,
           "height": 40
+        },
+        {
+          "type": "field_vertical_separator"
         }
       ],
       "category": Blockly.Categories.more,
@@ -55,13 +57,16 @@ Blockly.Blocks['extension_music_drum'] = {
    */
   init: function() {
     this.jsonInit({
-      "message0": "%1 play drum %2",
+      "message0": "%1 %2 play drum %3",
       "args0": [
         {
           "type": "field_image",
           "src": Blockly.mainWorkspace.options.pathToMedia + "extensions/music-block-icon.svg",
           "width": 40,
           "height": 40
+        },
+        {
+          "type": "field_vertical_separator"
         },
         {
           "type": "input_value",
@@ -80,13 +85,16 @@ Blockly.Blocks['extension_wedo_motor'] = {
    */
   init: function() {
     this.jsonInit({
-      "message0": "%1 turn a motor %2",
+      "message0": "%1 %2 turn a motor %3",
       "args0": [
         {
           "type": "field_image",
           "src": Blockly.mainWorkspace.options.pathToMedia + "extensions/wedo2-block-icon.svg",
           "width": 40,
           "height": 40
+        },
+        {
+          "type": "field_vertical_separator"
         },
         {
           "type": "field_image",
@@ -107,13 +115,16 @@ Blockly.Blocks['extension_wedo_hat'] = {
    */
   init: function() {
     this.jsonInit({
-      "message0": "%1 when I am wearing a hat",
+      "message0": "%1 %2 when I am wearing a hat",
       "args0": [
         {
           "type": "field_image",
           "src": Blockly.mainWorkspace.options.pathToMedia + "extensions/wedo2-block-icon.svg",
           "width": 40,
           "height": 40
+        },
+        {
+          "type": "field_vertical_separator"
         }
       ],
       "category": Blockly.Categories.more,
@@ -128,13 +139,16 @@ Blockly.Blocks['extension_wedo_boolean'] = {
    */
   init: function() {
     this.jsonInit({
-      "message0": "%1 O RLY?",
+      "message0": "%1 %2 O RLY?",
       "args0": [
         {
           "type": "field_image",
           "src": Blockly.mainWorkspace.options.pathToMedia + "extensions/wedo2-block-icon.svg",
           "width": 40,
           "height": 40
+        },
+        {
+          "type": "field_vertical_separator"
         }
       ],
       "category": Blockly.Categories.more,
@@ -149,13 +163,16 @@ Blockly.Blocks['extension_wedo_tilt_reporter'] = {
    */
   init: function() {
     this.jsonInit({
-      "message0": "%1 tilt angle %2",
+      "message0": "%1 %2 tilt angle %3",
       "args0": [
         {
           "type": "field_image",
           "src": Blockly.mainWorkspace.options.pathToMedia + "extensions/wedo2-block-icon.svg",
           "width": 40,
           "height": 40
+        },
+        {
+          "type": "field_vertical_separator"
         },
         {
           "type": "input_value",
@@ -199,13 +216,16 @@ Blockly.Blocks['extension_music_reporter'] = {
    */
   init: function() {
     this.jsonInit({
-      "message0": "%1 hey now, you're an all-star",
+      "message0": "%1 %2 hey now, you're an all-star",
       "args0": [
         {
           "type": "field_image",
           "src": Blockly.mainWorkspace.options.pathToMedia + "extensions/music-block-icon.svg",
           "width": 40,
           "height": 40
+        },
+        {
+          "type": "field_vertical_separator"
         }
       ],
       "category": Blockly.Categories.more,

--- a/core/block.js
+++ b/core/block.js
@@ -1389,6 +1389,9 @@ Blockly.Block.prototype.interpolate_ = function(message, args, lastDummyAlign) {
             case 'field_variable_getter':
               field = Blockly.Block.newFieldVariableGetterFromJson_(element);
               break;
+            case 'field_vertical_separator':
+              field = new Blockly.FieldVerticalSeparator();
+              break;
             case 'field_date':
               if (Blockly.FieldDate) {
                 field = new Blockly.FieldDate(element['date']);

--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -748,7 +748,8 @@ Blockly.BlockSvg.prototype.renderFields_ =
         'x2': cursorX,
         'y2': cursorY + lineBottomHeight
       }, field.sourceBlock_.svgGroup_);
-      cursorX += 2 * Blockly.BlockSvg.GRID_UNIT;
+      cursorX += this.RTL ?
+        -2 * Blockly.BlockSvg.GRID_UNIT : 2 * Blockly.BlockSvg.GRID_UNIT;
     }
 
     // Fields are invisible on insertion marker.

--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -759,7 +759,7 @@ Blockly.BlockSvg.prototype.addIconSeparatorLine_ = function(field, cursorX,
   var lineTopHeight = Blockly.BlockSvg.ICON_SEPARATOR_HEIGHT / 2;
   var lineBottomHeight = lineTopHeight;
   // If this is a hat block, shorten the bottom of the line by one grid unit.
-  if (!this.previousConnection) {
+  if (!this.previousConnection && this.nextConnection) {
     lineBottomHeight -= Blockly.BlockSvg.GRID_UNIT;
   }
   Blockly.utils.createSvgElement('line', {

--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -722,6 +722,28 @@ Blockly.BlockSvg.prototype.renderFields_ =
     root.setAttribute('transform',
       'translate(' + translateX + ', ' + translateY + ') ' + scale
     );
+
+    // If the first field is an image, as in extension blocks, and this field is the first field,
+    // add a vertical separator line next to the icon.
+    if ((this.inputList[0].fieldRow[0] instanceof Blockly.FieldImage) &&
+      (field === this.inputList[0].fieldRow[0])) {
+      var lineTopHeight = 5 * Blockly.BlockSvg.GRID_UNIT;
+      var lineBottomHeight = lineTopHeight;
+      // If this is a hat block, shorten the bottom of the line by one grid unit.
+      if (!this.previousConnection) {
+        lineBottomHeight -= Blockly.BlockSvg.GRID_UNIT;
+      }
+      Blockly.utils.createSvgElement('line', {
+        'stroke': this.getColourSecondary(),
+        'stroke-linecap': 'round',
+        'x1': cursorX,
+        'y1': cursorY - lineTopHeight,
+        'x2': cursorX,
+        'y2': cursorY + lineBottomHeight
+      }, field.sourceBlock_.svgGroup_);
+      cursorX += 2 * Blockly.BlockSvg.GRID_UNIT;
+    }
+
     // Fields are invisible on insertion marker.
     if (this.isInsertionMarker()) {
       root.setAttribute('display', 'none');

--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -730,26 +730,13 @@ Blockly.BlockSvg.prototype.renderFields_ =
       'translate(' + translateX + ', ' + translateY + ') ' + scale
     );
 
-    // If the first field is an image, as in extension blocks, and this field is the first field,
-    // add a vertical separator line next to the icon.
+    // If the first field is an image, as in extension blocks, and this field
+    // is the first field, add a vertical separator line next to the icon.
     if ((this.inputList[0].fieldRow[0] instanceof Blockly.FieldImage) &&
-      (field === this.inputList[0].fieldRow[0])) {
-      var lineTopHeight = Blockly.BlockSvg.ICON_SEPARATOR_HEIGHT / 2;
-      var lineBottomHeight = lineTopHeight;
-      // If this is a hat block, shorten the bottom of the line by one grid unit.
-      if (!this.previousConnection) {
-        lineBottomHeight -= Blockly.BlockSvg.GRID_UNIT;
-      }
-      Blockly.utils.createSvgElement('line', {
-        'stroke': this.getColourSecondary(),
-        'stroke-linecap': 'round',
-        'x1': cursorX,
-        'y1': cursorY - lineTopHeight,
-        'x2': cursorX,
-        'y2': cursorY + lineBottomHeight
-      }, field.sourceBlock_.svgGroup_);
+        (field === this.inputList[0].fieldRow[0])) {
+      this.addIconSeparatorLine_(field, cursorX, cursorY);
       cursorX += this.RTL ?
-        -2 * Blockly.BlockSvg.GRID_UNIT : 2 * Blockly.BlockSvg.GRID_UNIT;
+        -Blockly.BlockSvg.SEP_SPACE_X : Blockly.BlockSvg.SEP_SPACE_X;
     }
 
     // Fields are invisible on insertion marker.
@@ -759,6 +746,31 @@ Blockly.BlockSvg.prototype.renderFields_ =
   }
   return this.RTL ? -cursorX : cursorX;
 }; /* eslint-enable indent */
+
+/**
+ * Add a vertical separator line SVG after the current field.
+ * @param {Blockly.Field} field - the field after which to place the line.
+ * @param {number} cursorX - the current x position for rendering.
+ * @param {number} cursorY - the current y position for rendering.
+ * @private
+ */
+Blockly.BlockSvg.prototype.addIconSeparatorLine_ = function(field, cursorX,
+    cursorY) {
+  var lineTopHeight = Blockly.BlockSvg.ICON_SEPARATOR_HEIGHT / 2;
+  var lineBottomHeight = lineTopHeight;
+  // If this is a hat block, shorten the bottom of the line by one grid unit.
+  if (!this.previousConnection) {
+    lineBottomHeight -= Blockly.BlockSvg.GRID_UNIT;
+  }
+  Blockly.utils.createSvgElement('line', {
+    'stroke': this.getColourSecondary(),
+    'stroke-linecap': 'round',
+    'x1': cursorX,
+    'y1': cursorY - lineTopHeight,
+    'x2': cursorX,
+    'y2': cursorY + lineBottomHeight
+  }, field.sourceBlock_.svgGroup_);
+};
 
 /**
  * Computes the height and widths for each row and field.

--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -703,6 +703,16 @@ Blockly.BlockSvg.prototype.renderFields_ =
       yOffset += Blockly.BlockSvg.GRID_UNIT;
     }
 
+    // If this is an extension hat block, adjust the height of the vertical
+    // separator without adjusting the field height. The effect is to move
+    // the bottom end of the line up one grid unit.
+    if (this.isScratchExtension &&
+        !this.previousConnection && this.nextConnection &&
+        field instanceof Blockly.FieldVerticalSeparator) {
+      field.setLineHeight(Blockly.BlockSvg.ICON_SEPARATOR_HEIGHT -
+          Blockly.BlockSvg.GRID_UNIT);
+    }
+
     var translateX, translateY;
     var scale = '';
     if (this.RTL) {

--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -642,8 +642,8 @@ Blockly.BlockSvg.prototype.render = function(opt_bubble) {
   // reporter block, add a horizontal offset.
   if ((this.inputList[0].fieldRow[0] instanceof Blockly.FieldImage) &&
     this.outputConnection) {
-    cursorX += Blockly.BlockSvg.GRID_UNIT;
-  }
+    cursorX += this.RTL ?
+      -Blockly.BlockSvg.GRID_UNIT : Blockly.BlockSvg.GRID_UNIT;  }
 
   var inputRows = this.renderCompute_(cursorX);
   this.renderDraw_(cursorX, inputRows);

--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -730,15 +730,6 @@ Blockly.BlockSvg.prototype.renderFields_ =
       'translate(' + translateX + ', ' + translateY + ') ' + scale
     );
 
-    // If this an extension block, and this is the first field, and it is an
-    // image, add a vertical separator line next to the image.
-    if (this.isScratchExtension && (field === this.inputList[0].fieldRow[0]) &&
-        (field instanceof Blockly.FieldImage)) {
-      this.addIconSeparatorLine_(field, cursorX, cursorY);
-      cursorX += this.RTL ?
-        -Blockly.BlockSvg.SEP_SPACE_X : Blockly.BlockSvg.SEP_SPACE_X;
-    }
-
     // Fields are invisible on insertion marker.
     if (this.isInsertionMarker()) {
       root.setAttribute('display', 'none');
@@ -746,31 +737,6 @@ Blockly.BlockSvg.prototype.renderFields_ =
   }
   return this.RTL ? -cursorX : cursorX;
 }; /* eslint-enable indent */
-
-/**
- * Add a vertical separator line SVG after the current field.
- * @param {Blockly.Field} field - the field after which to place the line.
- * @param {number} cursorX - the current x position for rendering.
- * @param {number} cursorY - the current y position for rendering.
- * @private
- */
-Blockly.BlockSvg.prototype.addIconSeparatorLine_ = function(field, cursorX,
-    cursorY) {
-  var lineTopHeight = Blockly.BlockSvg.ICON_SEPARATOR_HEIGHT / 2;
-  var lineBottomHeight = lineTopHeight;
-  // If this is a hat block, shorten the bottom of the line by one grid unit.
-  if (!this.previousConnection && this.nextConnection) {
-    lineBottomHeight -= Blockly.BlockSvg.GRID_UNIT;
-  }
-  Blockly.utils.createSvgElement('line', {
-    'stroke': this.getColourSecondary(),
-    'stroke-linecap': 'round',
-    'x1': cursorX,
-    'y1': cursorY - lineTopHeight,
-    'x2': cursorX,
-    'y2': cursorY + lineBottomHeight
-  }, field.sourceBlock_.svgGroup_);
-};
 
 /**
  * Computes the height and widths for each row and field.

--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -141,6 +141,13 @@ Blockly.BlockSvg.STATEMENT_INPUT_INNER_SPACE = 2 * Blockly.BlockSvg.GRID_UNIT;
 Blockly.BlockSvg.START_HAT_HEIGHT = 16;
 
 /**
+ * Height of the vertical separator line for icons that appear at the left edge
+ * of a block, such as extension icons.
+ * @const
+ */
+Blockly.BlockSvg.ICON_SEPARATOR_HEIGHT = 10 * Blockly.BlockSvg.GRID_UNIT;
+
+/**
  * Path of the top hat's curve.
  * @const
  */
@@ -727,7 +734,7 @@ Blockly.BlockSvg.prototype.renderFields_ =
     // add a vertical separator line next to the icon.
     if ((this.inputList[0].fieldRow[0] instanceof Blockly.FieldImage) &&
       (field === this.inputList[0].fieldRow[0])) {
-      var lineTopHeight = 5 * Blockly.BlockSvg.GRID_UNIT;
+      var lineTopHeight = Blockly.BlockSvg.ICON_SEPARATOR_HEIGHT / 2;
       var lineBottomHeight = lineTopHeight;
       // If this is a hat block, shorten the bottom of the line by one grid unit.
       if (!this.previousConnection) {

--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -730,10 +730,10 @@ Blockly.BlockSvg.prototype.renderFields_ =
       'translate(' + translateX + ', ' + translateY + ') ' + scale
     );
 
-    // If the first field is an image, as in extension blocks, and this field
-    // is the first field, add a vertical separator line next to the icon.
-    if ((this.inputList[0].fieldRow[0] instanceof Blockly.FieldImage) &&
-        (field === this.inputList[0].fieldRow[0])) {
+    // If this an extension block, and this is the first field, and it is an
+    // image, add a vertical separator line next to the image.
+    if (this.isScratchExtension && (field === this.inputList[0].fieldRow[0]) &&
+        (field instanceof Blockly.FieldImage)) {
       this.addIconSeparatorLine_(field, cursorX, cursorY);
       cursorX += this.RTL ?
         -Blockly.BlockSvg.SEP_SPACE_X : Blockly.BlockSvg.SEP_SPACE_X;

--- a/core/blockly.js
+++ b/core/blockly.js
@@ -49,6 +49,7 @@ goog.require('Blockly.FieldTextDropdown');
 goog.require('Blockly.FieldNumber');
 goog.require('Blockly.FieldNumberDropdown');
 goog.require('Blockly.FieldVariable');
+goog.require('Blockly.FieldVerticalSeparator');
 goog.require('Blockly.Generator');
 goog.require('Blockly.Msg');
 goog.require('Blockly.Procedures');

--- a/core/field_vertical_separator.js
+++ b/core/field_vertical_separator.js
@@ -1,0 +1,137 @@
+/**
+ * @license
+ * Visual Blocks Editor
+ *
+ * Copyright 2012 Google Inc.
+ * https://developers.google.com/blockly/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Vertical separator field. Draws a vertical line.
+ * @author ericr@media.mit.edu (Eric Rosenbaum)
+ */
+'use strict';
+
+goog.provide('Blockly.FieldVerticalSeparator');
+goog.require('Blockly.Field');
+goog.require('goog.dom');
+goog.require('goog.math.Size');
+
+/**
+ * Class for a vertical separator line.
+ * @extends {Blockly.Field}
+ * @constructor
+ */
+Blockly.FieldVerticalSeparator = function() {
+  this.sourceBlock_ = null;
+  this.width_ = 1;
+  this.height_ = Blockly.BlockSvg.ICON_SEPARATOR_HEIGHT;
+  this.size_ = new goog.math.Size(this.width_, this.height_);
+};
+goog.inherits(Blockly.FieldVerticalSeparator, Blockly.Field);
+
+/**
+ * Editable fields are saved by the XML renderer, non-editable fields are not.
+ */
+Blockly.FieldVerticalSeparator.prototype.EDITABLE = false;
+
+/**
+ * Install this field on a block.
+ */
+Blockly.FieldVerticalSeparator.prototype.init = function() {
+  if (this.fieldGroup_) {
+    // Image has already been initialized once.
+    return;
+  }
+  // Build the DOM.
+  /** @type {SVGElement} */
+  this.fieldGroup_ = Blockly.utils.createSvgElement('g', {}, null);
+  if (!this.visible_) {
+    this.fieldGroup_.style.display = 'none';
+  }
+  /** @type {SVGElement} */
+  this.lineElement_ = Blockly.utils.createSvgElement('line', {
+    'stroke': this.sourceBlock_.getColourSecondary(),
+    'stroke-linecap': 'round',
+    'x1': 0,
+    'y1': 0,
+    'x2': 0,
+    'y2': this.height_
+  }, this.fieldGroup_);
+
+  this.sourceBlock_.getSvgRoot().appendChild(this.fieldGroup_);
+};
+
+/**
+ * Set the height of the line element, without adjusting the field's height.
+ * This allows the line's height to be changed without causing it to be
+ * centered with the new height (needed for correct rendering of hat blocks).
+ * @param {number} newHeight the new height for the line.
+ */
+Blockly.FieldVerticalSeparator.prototype.setLineHeight = function(newHeight) {
+    this.lineElement_.setAttribute('y2', newHeight);
+};
+
+/**
+ * Dispose of all DOM objects belonging to this text.
+ */
+Blockly.FieldVerticalSeparator.prototype.dispose = function() {
+  goog.dom.removeNode(this.fieldGroup_);
+  this.fieldGroup_ = null;
+  this.lineElement_ = null;
+};
+
+/**
+ * Get the source URL of this field.
+ * @return {string} null.
+ * @override
+ */
+Blockly.FieldVerticalSeparator.prototype.getValue = function() {
+  return null;
+};
+
+/**
+ * Set the value of this field.
+ * @param {?string} src New value.
+ * @override
+ */
+Blockly.FieldVerticalSeparator.prototype.setValue = function(src) {
+  return;
+};
+
+/**
+ * Set the text of this field.
+ * @param {?string} alt New text.
+ * @override
+ */
+Blockly.FieldVerticalSeparator.prototype.setText = function(alt) {
+  return;
+};
+
+/**
+ * Separator lines are fixed width, no need to render.
+ * @private
+ */
+Blockly.FieldVerticalSeparator.prototype.render_ = function() {
+  // NOP
+};
+
+/**
+ * Separator lines are fixed width, no need to update.
+ * @private
+ */
+Blockly.FieldVerticalSeparator.prototype.updateWidth = function() {
+ // NOP
+};

--- a/core/field_vertical_separator.js
+++ b/core/field_vertical_separator.js
@@ -2,7 +2,7 @@
  * @license
  * Visual Blocks Editor
  *
- * Copyright 2012 Google Inc.
+ * Copyright 2017 Massachusetts Institute of Technology
  * https://developers.google.com/blockly/
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,9 +25,11 @@
 'use strict';
 
 goog.provide('Blockly.FieldVerticalSeparator');
+
 goog.require('Blockly.Field');
 goog.require('goog.dom');
 goog.require('goog.math.Size');
+
 
 /**
  * Class for a vertical separator line.
@@ -79,9 +81,10 @@ Blockly.FieldVerticalSeparator.prototype.init = function() {
  * This allows the line's height to be changed without causing it to be
  * centered with the new height (needed for correct rendering of hat blocks).
  * @param {number} newHeight the new height for the line.
+ * @package
  */
 Blockly.FieldVerticalSeparator.prototype.setLineHeight = function(newHeight) {
-    this.lineElement_.setAttribute('y2', newHeight);
+  this.lineElement_.setAttribute('y2', newHeight);
 };
 
 /**
@@ -94,7 +97,7 @@ Blockly.FieldVerticalSeparator.prototype.dispose = function() {
 };
 
 /**
- * Get the source URL of this field.
+ * Get the value of this field. A no-op in this case.
  * @return {string} null.
  * @override
  */
@@ -103,20 +106,24 @@ Blockly.FieldVerticalSeparator.prototype.getValue = function() {
 };
 
 /**
- * Set the value of this field.
+ * Set the value of this field. A no-op in this case.
  * @param {?string} src New value.
  * @override
  */
-Blockly.FieldVerticalSeparator.prototype.setValue = function(src) {
+Blockly.FieldVerticalSeparator.prototype.setValue = function(
+    /* eslint-disable no-unused-vars */ src
+    /* eslint-enable no-unused-vars */) {
   return;
 };
 
 /**
- * Set the text of this field.
+ * Set the text of this field. A no-op in this case.
  * @param {?string} alt New text.
  * @override
  */
-Blockly.FieldVerticalSeparator.prototype.setText = function(alt) {
+Blockly.FieldVerticalSeparator.prototype.setText = function(
+    /* eslint-disable no-unused-vars */ alt
+    /* eslint-enable no-unused-vars */) {
   return;
 };
 


### PR DESCRIPTION
### Resolves

Resolves https://github.com/LLK/scratch-blocks/issues/1285

Should come after https://github.com/LLK/scratch-blocks/pull/1284

### Proposed Changes

See changes [here](https://github.com/ericrosenbaum/scratch-blocks/compare/ericrosenbaum:feature/extension-block-icon-rendering...feature/extension-icon-separator)

To match the spec in #1207, add a vertical line after the extension icon on extension blocks.