### PR TITLE
Micromanage events for new procedure blocks because they are shadows

### DIFF
--- a/blocks_vertical/procedures.js
+++ b/blocks_vertical/procedures.js
@@ -304,16 +304,24 @@ Blockly.ScratchBlocks.ProcedureUtils.attachShadow_ = function(input,
     argumentType) {
   if (argumentType == 'n' || argumentType == 's') {
     var blockType = argumentType == 'n' ? 'math_number' : 'text';
-    var newBlock = this.workspace.newBlock(blockType);
-    if (argumentType == 'n') {
-      newBlock.setFieldValue('1', 'NUM');
-    } else {
-      newBlock.setFieldValue('', 'TEXT');
+    Blockly.Events.disable();
+    try {
+      var newBlock = this.workspace.newBlock(blockType);
+      if (argumentType == 'n') {
+        newBlock.setFieldValue('1', 'NUM');
+      } else {
+        newBlock.setFieldValue('', 'TEXT');
+      }
+      newBlock.setShadow(true);
+      if (!this.isInsertionMarker()) {
+        newBlock.initSvg();
+        newBlock.render(false);
+      }
+    } finally {
+      Blockly.Events.enable();
     }
-    newBlock.setShadow(true);
-    if (!this.isInsertionMarker()) {
-      newBlock.initSvg();
-      newBlock.render(false);
+    if (Blockly.Events.isEnabled()) {
+      Blockly.Events.fire(new Blockly.Events.BlockCreate(newBlock));
     }
     newBlock.outputConnection.connect(input.connection);
   }
@@ -336,12 +344,20 @@ Blockly.ScratchBlocks.ProcedureUtils.createArgumentReporter_ = function(
   } else {
     var blockType = 'argument_reporter_boolean';
   }
-  var newBlock = this.workspace.newBlock(blockType);
-  newBlock.setShadow(true);
-  newBlock.setFieldValue(displayName, 'VALUE');
-  if (!this.isInsertionMarker()) {
-    newBlock.initSvg();
-    newBlock.render(false);
+  Blockly.Events.disable();
+  try {
+    var newBlock = this.workspace.newBlock(blockType);
+    newBlock.setShadow(true);
+    newBlock.setFieldValue(displayName, 'VALUE');
+    if (!this.isInsertionMarker()) {
+      newBlock.initSvg();
+      newBlock.render(false);
+    }
+  } finally {
+    Blockly.Events.enable();
+  }
+  if (Blockly.Events.isEnabled()) {
+    Blockly.Events.fire(new Blockly.Events.BlockCreate(newBlock));
   }
   return newBlock;
 };
@@ -484,16 +500,24 @@ Blockly.ScratchBlocks.ProcedureUtils.checkOldTypeMatches_ = function(oldBlock,
  */
 Blockly.ScratchBlocks.ProcedureUtils.createArgumentEditor_ = function(
     argumentType, displayName) {
-  if (argumentType == 'n' || argumentType == 's') {
-    var newBlock = this.workspace.newBlock('argument_editor_string_number');
-  } else {
-    var newBlock = this.workspace.newBlock('argument_editor_boolean');
+  Blockly.Events.disable();
+  try {
+    if (argumentType == 'n' || argumentType == 's') {
+      var newBlock = this.workspace.newBlock('argument_editor_string_number');
+    } else {
+      var newBlock = this.workspace.newBlock('argument_editor_boolean');
+    }
+    newBlock.setFieldValue(displayName, 'TEXT');
+    newBlock.setShadow(true);
+    if (!this.isInsertionMarker()) {
+      newBlock.initSvg();
+      newBlock.render(false);
+    }
+  } finally {
+    Blockly.Events.enable();
   }
-  newBlock.setFieldValue(displayName, 'TEXT');
-  newBlock.setShadow(true);
-  if (!this.isInsertionMarker()) {
-    newBlock.initSvg();
-    newBlock.render(false);
+  if (Blockly.Events.isEnabled()) {
+    Blockly.Events.fire(new Blockly.Events.BlockCreate(newBlock));
   }
   return newBlock;
 };


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-blocks/issues/1291 using the suggestion from @rachel-fenichel 

### Proposed Changes

_Describe what this Pull Request does_

Wrap all uses of `workspace.newBlock` in a "try disable events => (create block) =>  finally enable events => emit new block" sequence. This allows us to emit correct events for procedure operations. 

### Reason for Changes

_Explain why these changes should be made_

As rachel mentioned, 
> The create event that's fired in new block is really optimistic. Anywhere that we go through domToBlock events are disabled until all of the blocks are created, to sidestep problems like this. We can do the same here:

I made a few minor tweaks to your recommended code @rachel-fenichel, adding try/finally (you mentioned that as a necessity when disabling/enabling events in the past) and also implemented the fix for all three places in the code we were using newBlock then setting it to a shadow. 

### Test Coverage

_Please show how you have added tests to cover your changes_

Went through the repro in the linked issues, the events are emitted with the xml listing the new blocks as shadows. I also built into the GUI and went through the repro steps from the original bug report (https://github.com/LLK/scratch-gui/issues/1005) and confirmed that it fixes that issue as well