### PR TITLE
Broadcast Inputs and Implicit Message Deletion

### DIFF
--- a/blocks_vertical/default_toolbox.js
+++ b/blocks_vertical/default_toolbox.js
@@ -315,8 +315,14 @@ Blockly.Blocks.defaultToolbox = '<xml id="toolbox-categories" style="display: no
     '<block type="event_whenbroadcastreceived" id="event_whenbroadcastreceived">'+
     '</block>'+
     '<block type="event_broadcast" id="event_broadcast">'+
+      '<value name="BROADCAST_INPUT">'+
+        '<shadow type="event_broadcast_menu"></shadow>'+
+      '</value>'+
     '</block>'+
     '<block type="event_broadcastandwait" id="event_broadcastandwait">'+
+      '<value name="BROADCAST_INPUT">'+
+        '<shadow type="event_broadcast_menu"></shadow>'+
+      '</value>'+
     '</block>'+
   '</category>'+
   '<category name="Control" colour="#FFAB19" secondaryColour="#CF8B17">'+

--- a/blocks_vertical/event.js
+++ b/blocks_vertical/event.js
@@ -175,10 +175,8 @@ Blockly.Blocks['event_broadcast'] = {
       "message0": "broadcast %1",
       "args0": [
         {
-          "type": "field_variable",
-          "name": "BROADCAST_OPTION",
-          "variableTypes": [Blockly.BROADCAST_MESSAGE_VARIABLE_TYPE],
-          "variable": Blockly.Msg.DEFAULT_BROADCAST_MESSAGE_NAME
+          "type": "input_value",
+          "name": "BROADCAST_INPUT"
         }
       ],
       "category": Blockly.Categories.event,
@@ -197,10 +195,8 @@ Blockly.Blocks['event_broadcastandwait'] = {
       "message0": "broadcast %1 and wait",
       "args0": [
         {
-          "type": "field_variable",
-          "name": "BROADCAST_OPTION",
-          "variableTypes": [Blockly.BROADCAST_MESSAGE_VARIABLE_TYPE],
-          "variable": Blockly.Msg.DEFAULT_BROADCAST_MESSAGE_NAME
+          "type":"input_value",
+          "name":"BROADCAST_INPUT"
         }
       ],
       "category": Blockly.Categories.event,

--- a/core/field_variable.js
+++ b/core/field_variable.js
@@ -51,6 +51,8 @@ Blockly.FieldVariable = function(varname, opt_validator, opt_variableTypes) {
   this.setValue(varname || '');
   this.addArgType('variable');
   this.variableTypes = opt_variableTypes;
+  this.variableType = (opt_variableTypes && opt_variableTypes.length == 1) ?
+    opt_variableTypes[0] : '';
 };
 goog.inherits(Blockly.FieldVariable, Blockly.FieldDropdown);
 
@@ -84,14 +86,14 @@ Blockly.FieldVariable.prototype.initModel = function() {
     // Check if there was exactly one element specified in the
     // variableTypes list. This is the list that specifies which types of
     // variables to include in the dropdown.
-    // If there is exactly one element specified, make the variable
-    // being created this specified type. Else, default behavior is to create
-    // a scalar variable
-    if (this.getVariableTypes_().length == 1) {
-      this.sourceBlock_.workspace.createVariable(this.getValue(),
-        this.getVariableTypes_()[0]);
-    } else {
-      this.sourceBlock_.workspace.createVariable(this.getValue());
+    this.sourceBlock_.workspace.createVariable(this.getValue(), this.variableType);
+  } else {
+    // Using shorter name for this constant
+    var broadcastMsgType = Blockly.BROADCAST_MESSAGE_VARIABLE_TYPE;
+    var broadcastVars = this.sourceBlock_.workspace.getVariablesOfType(broadcastMsgType);
+    if (this.variableType == broadcastMsgType && broadcastVars.length != 0) {
+      broadcastVars.sort(Blockly.VariableModel.compareByName);
+      this.setValue(broadcastVars[0].name);
     }
   }
 };

--- a/core/field_variable.js
+++ b/core/field_variable.js
@@ -205,9 +205,13 @@ Blockly.FieldVariable.dropdownCreate = function() {
     }
   }
   // Ensure that the currently selected variable is an option.
-  // TODO (#1270): Remove isBroadcastType check here when flyout variables fixed.
-  if (createSelectedVariable && workspace && !isBroadcastType) {
-    var newVar = workspace.createVariable(name);
+  if (createSelectedVariable && workspace) {
+    var newVar = null;
+    if (isBroadcastType && workspace.isFlyout) {
+      newVar = workspace.targetWorkspace.createVariable(name, Blockly.BROADCAST_MESSAGE_VARIABLE_TYPE);
+    } else {
+      newVar = workspace.createVariable(name);
+    }
     variableModelList.push(newVar);
   }
   variableModelList.sort(Blockly.VariableModel.compareByName);
@@ -217,10 +221,7 @@ Blockly.FieldVariable.dropdownCreate = function() {
     options[i] = [variableModelList[i].name, variableModelList[i].getId()];
   }
   if (isBroadcastType) {
-    // TODO (#1270): Re-enable create broadcast message dropdown in flyout when fixed.
-    if (!workspace.isFlyout) {
-      options.push([Blockly.Msg.NEW_BROADCAST_MESSAGE, Blockly.NEW_BROADCAST_MESSAGE_ID]);
-    }
+    options.push([Blockly.Msg.NEW_BROADCAST_MESSAGE, Blockly.NEW_BROADCAST_MESSAGE_ID]);
   } else {
     options.push([Blockly.Msg.RENAME_VARIABLE, Blockly.RENAME_VARIABLE_ID]);
     if (Blockly.Msg.DELETE_VARIABLE) {
@@ -267,7 +268,8 @@ Blockly.FieldVariable.prototype.onItemSelected = function(menu, menuItem) {
           thisField.setValue(newName);
         }
       };
-      Blockly.Variables.createVariable(workspace, setName, Blockly.BROADCAST_MESSAGE_VARIABLE_TYPE);
+      var broadcastMsgWkspc = workspace.isFlyout ? workspace.targetWorkspace : workspace;
+      Blockly.Variables.createVariable(broadcastMsgWkspc, setName, Blockly.BROADCAST_MESSAGE_VARIABLE_TYPE);
       return;
     }
 

--- a/core/field_variable.js
+++ b/core/field_variable.js
@@ -184,7 +184,6 @@ Blockly.FieldVariable.dropdownCreate = function() {
   if (this.sourceBlock_) {
     workspace = this.sourceBlock_.workspace;
   }
-  var isBroadcastType = false;
   if (workspace) {
     var variableTypes = this.getVariableTypes_();
     var variableModelList = [];
@@ -192,9 +191,6 @@ Blockly.FieldVariable.dropdownCreate = function() {
     // doesn't modify the workspace's list.
     for (var i = 0; i < variableTypes.length; i++) {
       var variableType = variableTypes[i];
-      if (variableType == Blockly.BROADCAST_MESSAGE_VARIABLE_TYPE){
-        isBroadcastType = true;
-      }
       var variables = workspace.getVariablesOfType(variableType);
       variableModelList = variableModelList.concat(variables);
     }
@@ -206,6 +202,7 @@ Blockly.FieldVariable.dropdownCreate = function() {
       }
     }
   }
+  var isBroadcastType = this.variableType == Blockly.BROADCAST_MESSAGE_VARIABLE_TYPE;
   // Ensure that the currently selected variable is an option.
   if (createSelectedVariable && workspace) {
     var newVar = null;

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1083,7 +1083,7 @@ Blockly.WorkspaceSvg.prototype.createVariable = function(name, opt_type, opt_id)
     opt_type, opt_id);
   // For performance reasons, only refresh the the toolbox for new variables.
   // Variables that already exist should already be there.
-  if (!variableInMap) {
+  if (!variableInMap && !(opt_type == Blockly.BROADCAST_MESSAGE_VARIABLE_TYPE)) {
     this.refreshToolboxSelection_();
   }
   return newVar;

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1083,7 +1083,7 @@ Blockly.WorkspaceSvg.prototype.createVariable = function(name, opt_type, opt_id)
     opt_type, opt_id);
   // For performance reasons, only refresh the the toolbox for new variables.
   // Variables that already exist should already be there.
-  if (!variableInMap && !(opt_type == Blockly.BROADCAST_MESSAGE_VARIABLE_TYPE)) {
+  if (!variableInMap && (opt_type != Blockly.BROADCAST_MESSAGE_VARIABLE_TYPE)) {
     this.refreshToolboxSelection_();
   }
   return newVar;

--- a/core/xml.js
+++ b/core/xml.js
@@ -729,9 +729,6 @@ Blockly.Xml.domToBlockHeadless_ = function(xmlBlock, workspace) {
       goog.asserts.assert(child.isShadow(),
                           'Shadow block not allowed non-shadow child.');
     }
-    // Ensure this block doesn't have any variable inputs.
-    goog.asserts.assert(block.getVars().length == 0,
-        'Shadow blocks cannot have variable fields.');
     block.setShadow(true);
   }
   return block;


### PR DESCRIPTION
### Resolves

Resolves #1268 
Resolves #1270 
Resolves #1290 
Resolves #1304 

### Proposed Changes

Broadcast blocks (namely `broadcast` and `broadcast and wait`) now have pluggable inputs.
New messages can once again be created from the flyout (resolving the issue in #1270). 
New messages created from a block in the flyout are created as variables in the flyout's target workspace, thus appearing in all broadcast block dropdown menus.

A message is created when either: 
1) the broadcast block dropdown menu is clicked for the first time OR
2) any broadcast block with the message selected in its dropdown field is dragged out of the flyout and created on the workspace **(this is not new functionality)** OR
3) the message is explicitly created using the `New message` option in any of the broadcast block dropdowns.

A message is deleted using the implicit deletion behavior from SB2. Most of this functionality is implemented in scratch-vm. A message is deleted (disappears from dropdowns) if all blocks referencing that message are removed from the VM. This deletion behavior updates every time the workspace is updated (e.g. switching sprites or switching between the blocks tab and the costumes/sounds tabs). When the workspace is updated, the broadcast blocks in the flyout update their fields according to SB2 behavior -- the broadcast message that comes first in sorted order will appear selected in the field of each of the broadcast blocks in the flyout. The sorting behavior is the same as that used to sort the options in the dropdown menu (alphanumeric sorting by message name).

The assertion that shadows cannot have variables is no longer true, so the assertion statement has been removed.

#### Diversions from SB2
SB2 projects that have empty string message names will be converted to a fresh name `message#`.
In SB2, plugging in an input, e.g. `((1) + (1))`, into a `broadcast [foo]` or `broadcast [foo] and wait` block, and then taking that input back out will result in removing the old message name `foo` and replacing it with the empty string. In the proposed changes, `foo` will remain in the message dropdowns, as well as in the shadow behind the plugged in input. 

The reason for these divergences are to avoid the potential for buggy behavior when introducing this round-about way of creating empty string message names when they are otherwise disallowed from explicit creation.

If we decide that we would like to maintain this SB2 behavior, that change can be made.

### Reason for Changes

To maintain compatibility with Scratch 2.0 which allows blocks to be plugged into the broadcast block inputs, and has the implicit deletion behavior.

### Test Coverage

Existing tests pass.

### Additional Notes

This PR depends on corresponding PRs in scratch-vm and scratch-gui:
[LLK/scratch-gui#1033](https://github.com/LLK/scratch-gui/pull/1033)
[LLK/scratch-vm#860](https://github.com/LLK/scratch-vm/pull/860)

These three PRs can be tested together [here](https://llk.github.io/scratch-gui/broadcast-input/).