### PR TITLE
Add data-lists to Blockly.Categories

### DIFF
--- a/blocks_vertical/data.js
+++ b/blocks_vertical/data.js
@@ -164,7 +164,7 @@ Blockly.Blocks['data_listcontents'] = {
           "variableTypes": ["list"]
         }
       ],
-      "category": Blockly.Categories.data,
+      "category": Blockly.Categories.dataLists,
       "extensions": ["colours_data_lists", "output_string"],
       "checkboxInFlyout": true
     });
@@ -246,7 +246,7 @@ Blockly.Blocks['data_addtolist'] = {
           "variableTypes": ["list"]
         }
       ],
-      "category": Blockly.Categories.data,
+      "category": Blockly.Categories.dataLists,
       "extensions": ["colours_data_lists", "shape_statement"]
     });
   }
@@ -271,7 +271,7 @@ Blockly.Blocks['data_deleteoflist'] = {
           "variableTypes": ["list"]
         }
       ],
-      "category": Blockly.Categories.data,
+      "category": Blockly.Categories.dataLists,
       "extensions": ["colours_data_lists", "shape_statement"]
     });
   }
@@ -300,7 +300,7 @@ Blockly.Blocks['data_insertatlist'] = {
           "variableTypes": ["list"]
         }
       ],
-      "category": Blockly.Categories.data,
+      "category": Blockly.Categories.dataLists,
       "extensions": ["colours_data_lists", "shape_statement"]
     });
   }
@@ -329,7 +329,7 @@ Blockly.Blocks['data_replaceitemoflist'] = {
           "name": "ITEM"
         }
       ],
-      "category": Blockly.Categories.data,
+      "category": Blockly.Categories.dataLists,
       "extensions": ["colours_data_lists", "shape_statement"]
     });
   }
@@ -355,7 +355,7 @@ Blockly.Blocks['data_itemoflist'] = {
         }
       ],
       "output": null,
-      "category": Blockly.Categories.data,
+      "category": Blockly.Categories.dataLists,
       "extensions": ["colours_data_lists"],
       "outputShape": Blockly.OUTPUT_SHAPE_ROUND
     });
@@ -377,7 +377,7 @@ Blockly.Blocks['data_lengthoflist'] = {
           "variableTypes": ["list"]
         }
       ],
-      "category": Blockly.Categories.data,
+      "category": Blockly.Categories.dataLists,
       "extensions": ["colours_data_lists", "output_number"]
     });
   }
@@ -402,7 +402,7 @@ Blockly.Blocks['data_listcontainsitem'] = {
           "name": "ITEM"
         }
       ],
-      "category": Blockly.Categories.data,
+      "category": Blockly.Categories.dataLists,
       "extensions": ["colours_data_lists", "output_boolean"]
     });
   }
@@ -423,7 +423,7 @@ Blockly.Blocks['data_showlist'] = {
           "variableTypes": ["list"]
         }
       ],
-      "category": Blockly.Categories.data,
+      "category": Blockly.Categories.dataLists,
       "extensions": ["colours_data_lists", "shape_statement"]
     });
   }
@@ -444,7 +444,7 @@ Blockly.Blocks['data_hidelist'] = {
           "variableTypes": ["list"]
         }
       ],
-      "category": Blockly.Categories.data,
+      "category": Blockly.Categories.dataLists,
       "extensions": ["colours_data_lists", "shape_statement"]
     });
   }

--- a/core/constants.js
+++ b/core/constants.js
@@ -268,6 +268,7 @@ Blockly.Categories = {
   "sound": "sounds",
   "pen": "pen",
   "data": "data",
+  "dataLists": "data-lists",
   "event": "events",
   "control": "control",
   "sensing": "sensing",


### PR DESCRIPTION
### Resolves

There's not a standalone issue for this but the discussion is in https://github.com/LLK/scratch-blocks/pull/1267#issuecomment-347996948

### Proposed Changes

Now that list blocks are a different color from scalar variable blocks, add an entry for them in `Blockly.Categories` and update the vertical blocks accordingly. This makes it so that the svg `<g>` tag that represents the block will have the attribute `data-category="data-lists"`

Note that I named the property `Blockly.Categories.dataLists` -- if you guys have anything against camelcase I have no problem changing that.

### Reason for Changes

To make scratch-blocks fully styleable with CSS! Before this change, all blocks in the data category could be styled but there was no way to focus in on list blocks.

### Test Coverage

Right now there are no tests for all the stylability data-attributes, but maybe that's something to consider! I tried my best to get the test runner working but I'm still having some difficulties -- anyway, `vertical_playground.html` seems to work fine and all blocks in the data category are showing the expected `data-category`
