### PR TITLE
Try to fix travis errors from platform update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ addons:
 cache:
   directories:
   - node_modules
-
+group: deprecated-2017Q4
 before_install:
 # Symlink closure library
 - ln -s $(npm root)/google-closure-library ../closure-library


### PR DESCRIPTION
New images were released for travis, and the build on develop is no longer completing. Trying the recommendation from https://blog.travis-ci.com/2017-12-12-new-trusty-images-q4-launch of trying the old image to isolate the problem / fix the build