### PR TITLE
Empty/whitespace message names no longer cause type error.

### DIFF
--- a/core/field_variable.js
+++ b/core/field_variable.js
@@ -263,7 +263,9 @@ Blockly.FieldVariable.prototype.onItemSelected = function(menu, menuItem) {
     } else if (id == Blockly.NEW_BROADCAST_MESSAGE_ID) {
       var thisField = this;
       var setName = function(newName) {
-        thisField.setValue(newName);
+        if (newName) {
+          thisField.setValue(newName);
+        }
       };
       Blockly.Variables.createVariable(workspace, setName, Blockly.BROADCAST_MESSAGE_VARIABLE_TYPE);
       return;


### PR DESCRIPTION
### Resolves

Resolves #1298.

### Proposed Changes

Fixes the bug that was causing a type error when trying to create a new message without a name or with whitespace as a name.

This change only resolves the bug, but does not yet allow creating a message with whitespace as a a name (as can be done in SB2). This functionality will require fixing the block dropdown menu rendering issues discussed in #1304.

### Reason for Changes

Bug #1298 

### Test Coverage

Existing tests pass.
