### PR TITLE
Allow Whitespace Messages

### DIFF
--- a/core/css.js
+++ b/core/css.js
@@ -947,6 +947,7 @@ Blockly.Css.CONTENT = [
     'font-weight: bold;',
     'list-style: none;',
     'margin: 0;',
+    'min-height: 24px;',
      /* 28px on the left for icon or checkbox; 7em on the right for shortcut. */
     'padding: 4px 7em 4px 28px;',
     'white-space: nowrap;',

--- a/core/variables.js
+++ b/core/variables.js
@@ -307,7 +307,7 @@ Blockly.Variables.promptName = function(promptText, defaultText, callback, opt_t
  * @return {string} The validated and possibly transformed name of the variable.
  */
 Blockly.Variables.validateName_ = function(name, opt_type) {
-  if (!opt_type || !opt_type == Blockly.BROADCAST_MESSAGE_VARIABLE_TYPE) {
+  if (!opt_type || opt_type != Blockly.BROADCAST_MESSAGE_VARIABLE_TYPE) {
     name = name.replace(/[\s\xa0]+/g, ' ').replace(/^ | $/g, '');
     if (name == Blockly.Msg.RENAME_VARIABLE ||
         name == Blockly.Msg.NEW_VARIABLE) {

--- a/core/variables.js
+++ b/core/variables.js
@@ -185,7 +185,7 @@ Blockly.Variables.createVariable = function(workspace, opt_callback, opt_type) {
   }
   // This function needs to be named so it can be called recursively.
   var promptAndCheckWithAlert = function(defaultName) {
-    Blockly.Variables.promptName(newMsg, defaultName, opt_type,
+    Blockly.Variables.promptName(newMsg, defaultName,
       function(text) {
         if (text) {
           // TODO (#1245) use separate namespaces for lists, variables, and
@@ -223,7 +223,7 @@ Blockly.Variables.createVariable = function(workspace, opt_callback, opt_type) {
             opt_callback(null);
           }
         }
-      });
+      }, opt_type);
   };
   promptAndCheckWithAlert('');
 };
@@ -244,7 +244,7 @@ Blockly.Variables.renameVariable = function(workspace, variable,
   // This function needs to be named so it can be called recursively.
   var promptAndCheckWithAlert = function(defaultName) {
     Blockly.Variables.promptName(
-      Blockly.Msg.RENAME_VARIABLE_TITLE.replace('%1', variable.name), defaultName, null,
+      Blockly.Msg.RENAME_VARIABLE_TITLE.replace('%1', variable.name), defaultName,
       function(newName) {
         if (newName) {
           var newVariable = workspace.getVariable(newName);
@@ -276,7 +276,7 @@ Blockly.Variables.renameVariable = function(workspace, variable,
             opt_callback(null);
           }
         }
-      });
+      }, null);
   };
   promptAndCheckWithAlert('');
 };
@@ -285,11 +285,11 @@ Blockly.Variables.renameVariable = function(workspace, variable,
  * Prompt the user for a new variable name.
  * @param {string} promptText The string of the prompt.
  * @param {string} defaultText The default value to show in the prompt's field.
- * @param {string} opt_type Optional type of variable, like 'string' or 'list'.
  * @param {function(?string)} callback A callback. It will be passed the new
  *     variable name, or null if the user picked something illegal.
+ * @param {string} opt_type Optional type of variable, like 'string' or 'list'.
  */
-Blockly.Variables.promptName = function(promptText, defaultText, opt_type, callback) {
+Blockly.Variables.promptName = function(promptText, defaultText, callback, opt_type) {
   Blockly.prompt(promptText, defaultText, function(newVar) {
     // Merge runs of whitespace.  Strip leading and trailing whitespace.
     // Beyond this, all names are legal.
@@ -300,6 +300,12 @@ Blockly.Variables.promptName = function(promptText, defaultText, opt_type, callb
   });
 };
 
+/**
+ * Validate the variable name provided by the user.
+ * @param {string} name The user-provided name of the variable.
+ * @param {string} opt_type Optional type of variable, like 'string' or 'list'.
+ * @return {string} The validated and possibly transformed name of the variable.
+ */
 Blockly.Variables.validateName_ = function(name, opt_type) {
   if (!opt_type || !opt_type == Blockly.BROADCAST_MESSAGE_VARIABLE_TYPE) {
     name = name.replace(/[\s\xa0]+/g, ' ').replace(/^ | $/g, '');

--- a/core/variables.js
+++ b/core/variables.js
@@ -185,7 +185,7 @@ Blockly.Variables.createVariable = function(workspace, opt_callback, opt_type) {
   }
   // This function needs to be named so it can be called recursively.
   var promptAndCheckWithAlert = function(defaultName) {
-    Blockly.Variables.promptName(newMsg, defaultName,
+    Blockly.Variables.promptName(newMsg, defaultName, opt_type,
       function(text) {
         if (text) {
           // TODO (#1245) use separate namespaces for lists, variables, and
@@ -244,7 +244,7 @@ Blockly.Variables.renameVariable = function(workspace, variable,
   // This function needs to be named so it can be called recursively.
   var promptAndCheckWithAlert = function(defaultName) {
     Blockly.Variables.promptName(
-      Blockly.Msg.RENAME_VARIABLE_TITLE.replace('%1', variable.name), defaultName,
+      Blockly.Msg.RENAME_VARIABLE_TITLE.replace('%1', variable.name), defaultName, null,
       function(newName) {
         if (newName) {
           var newVariable = workspace.getVariable(newName);
@@ -285,23 +285,31 @@ Blockly.Variables.renameVariable = function(workspace, variable,
  * Prompt the user for a new variable name.
  * @param {string} promptText The string of the prompt.
  * @param {string} defaultText The default value to show in the prompt's field.
+ * @param {string} opt_type Optional type of variable, like 'string' or 'list'.
  * @param {function(?string)} callback A callback. It will be passed the new
  *     variable name, or null if the user picked something illegal.
  */
-Blockly.Variables.promptName = function(promptText, defaultText, callback) {
+Blockly.Variables.promptName = function(promptText, defaultText, opt_type, callback) {
   Blockly.prompt(promptText, defaultText, function(newVar) {
     // Merge runs of whitespace.  Strip leading and trailing whitespace.
     // Beyond this, all names are legal.
     if (newVar) {
-      newVar = newVar.replace(/[\s\xa0]+/g, ' ').replace(/^ | $/g, '');
-      if (newVar == Blockly.Msg.RENAME_VARIABLE ||
-          newVar == Blockly.Msg.NEW_VARIABLE) {
-        // Ok, not ALL names are legal...
-        newVar = null;
-      }
+      newVar = Blockly.Variables.validateName_(newVar, opt_type);
     }
     callback(newVar);
   });
+};
+
+Blockly.Variables.validateName_ = function(name, opt_type) {
+  if (!opt_type || !opt_type == Blockly.BROADCAST_MESSAGE_VARIABLE_TYPE) {
+    name = name.replace(/[\s\xa0]+/g, ' ').replace(/^ | $/g, '');
+    if (name == Blockly.Msg.RENAME_VARIABLE ||
+        name == Blockly.Msg.NEW_VARIABLE) {
+      // Ok, not ALL names are legal...
+      name = null;
+    }
+  }
+  return name;
 };
 
 /**


### PR DESCRIPTION
This is another example of a change where there is a separate validator for the names of broadcast messages vs. other variables...

### Resolves

Completes #1298, by allowing whitespace message names.

### Proposed Changes

This pull request allows users to create new broadcast messages with arbitrary white space in the name (either solely whitespace as the message name, or arbitrary whitespace interspersed between other text). Broadcast messages no longer follow the same whitespace stripping rules as other variables.

Importing projects with whitespace messages also no longer have dropdown rendering issues as discussed in #1304.

### Reason for Changes

Compatibility with Scratch 2.0.

### Test Coverage

Existing tests pass.