### PR TITLE
Add optional icon to category menu

### DIFF
--- a/blocks_vertical/default_toolbox.js
+++ b/blocks_vertical/default_toolbox.js
@@ -640,7 +640,8 @@ Blockly.Blocks.defaultToolbox = '<xml id="toolbox-categories" style="display: no
   '</category>' +
   '<category name="More" colour="#FF6680" secondaryColour="#FF4D6A" custom="PROCEDURE">' +
   '</category>' +
-  '<category name="Extensions" colour="#FF6680" secondaryColour="#FF4D6A">'+
+  '<category name="Extensions" colour="#FF6680" secondaryColour="#FF4D6A" '+
+    'iconURI="../media/extensions/wedo2-block-icon.svg">'+
     '<block type="extension_pen_down" id="extension_pen_down"></block>'+
     '<block type="extension_music_drum" id="extension_music_drum">'+
       '<value name="NUMBER">'+

--- a/core/css.js
+++ b/core/css.js
@@ -1181,6 +1181,13 @@ Blockly.Css.CONTENT = [
     'margin: 0 auto 0.125rem;',
   '}',
 
+  '.scratchCategoryItemIcon {',
+    'width: 1.25rem;',
+    'height: 1.25rem;',
+    'margin: 0 auto 0.125rem;',
+    'background-size: 100%;',
+  '}',
+
   '.scratchCategoryMenuItem:hover {',
     'color: $colour_toolboxHover !important;',
   '}',

--- a/core/toolbox.js
+++ b/core/toolbox.js
@@ -506,6 +506,7 @@ Blockly.Toolbox.Category = function(parent, parentHtml, domTree) {
   this.name_ = domTree.getAttribute('name');
   this.setColour(domTree);
   this.custom_ = domTree.getAttribute('custom');
+  this.iconURI_ = domTree.getAttribute('iconURI');
   this.contents_ = [];
   if (!this.custom_) {
     this.parseContents_(domTree);
@@ -536,10 +537,16 @@ Blockly.Toolbox.Category.prototype.createDom = function() {
   this.label_ = goog.dom.createDom('div',
     {'class': 'scratchCategoryMenuItemLabel'},
     this.name_);
-  this.bubble_ = goog.dom.createDom('div',
-    {'class': 'scratchCategoryItemBubble'});
-  this.bubble_.style.backgroundColor = this.colour_;
-  this.bubble_.style.borderColor = this.secondaryColour_;
+  if (this.iconURI_) {
+    this.bubble_ = goog.dom.createDom('div',
+        {'class': 'scratchCategoryItemIcon'});
+    this.bubble_.style.backgroundImage = 'url(' + this.iconURI_ + ')';
+  } else {
+    this.bubble_ = goog.dom.createDom('div',
+        {'class': 'scratchCategoryItemBubble'});
+    this.bubble_.style.backgroundColor = this.colour_;
+    this.bubble_.style.borderColor = this.secondaryColour_;
+  }
   this.item_.appendChild(this.bubble_);
   this.item_.appendChild(this.label_);
   this.parentHtml_.appendChild(this.item_);


### PR DESCRIPTION
### Resolves

Part of https://github.com/LLK/scratch-gui/issues/855

### Proposed Changes

Add a new toolbox XML attribute for categories so they can optionally display an icon in place of the colored circle. This works as a path to an SVG (as shown in the default toolbox), or a data URI (which is how we load icons from the VM).

### Reason for Changes

We'll use this for Scratch extensions, so they can display their own icons in the category menu. These will generally match the icons on the blocks themselves.