### PR TITLE
Bail on dropdown editor if no options instead of exploding

### DIFF
--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -152,6 +152,9 @@ Blockly.FieldDropdown.prototype.init = function() {
  * @private
  */
 Blockly.FieldDropdown.prototype.showEditor_ = function() {
+  var options = this.getOptions();
+  if (options.length == 0) return;
+
   this.dropDownOpen_ = true;
   // If there is an existing drop-down someone else owns, hide it immediately and clear it.
   Blockly.DropDownDiv.hideWithoutAnimation();
@@ -173,7 +176,6 @@ Blockly.FieldDropdown.prototype.showEditor_ = function() {
 
   var menu = new goog.ui.Menu();
   menu.setRightToLeft(this.sourceBlock_.RTL);
-  var options = this.getOptions();
   for (var i = 0; i < options.length; i++) {
     var content = options[i][0]; // Human-readable text or image.
     var value = options[i][1];   // Language-neutral value.


### PR DESCRIPTION
Previously, trying to open a menu with no options does this https://github.com/LLK/scratch-gui/issues/1047

Now it just doesn't open anything. Not the best behavior, but it doesn't explode 💁‍♂️

This is not the long-term intended behavior anyway, since a variable will be available at some point. So this is just a backstop to prevent errors.