### PR TITLE
Remove 'Go To Definition' option from context menu

### DIFF
--- a/blocks_vertical/vertical_extensions.js
+++ b/blocks_vertical/vertical_extensions.js
@@ -202,13 +202,13 @@ Blockly.ScratchBlocks.VerticalExtensions.PROCEDURE_DEF_CONTEXTMENU = {
  */
 Blockly.ScratchBlocks.VerticalExtensions.PROCEDURE_CALL_CONTEXTMENU = {
   /**
-   * Add the "edit" and "go to definition" options to the context menu.
+   * Add the "edit" option to the context menu.
+   * @todo Add "go to definition" option once implemented.
    * @param {!Array.<!Object>} menuOptions List of menu options to edit.
    * @this Blockly.Block
    */
   customContextMenu: function(menuOptions) {
     menuOptions.push(Blockly.Procedures.makeEditOption(this));
-    menuOptions.push(Blockly.Procedures.makeShowDefinitionOption(this));
   }
 };
 


### PR DESCRIPTION
### Resolves

GH-1299

### Proposed Changes

- Removes "Go to Definition" item from context menu

### Reason for Changes

- Removes option for feature that is not yet implemented