### PR TITLE
Add warp getters/setters for custom procedures

### DIFF
--- a/blocks_vertical/procedures.js
+++ b/blocks_vertical/procedures.js
@@ -44,7 +44,7 @@ Blockly.ScratchBlocks.ProcedureUtils.callerMutationToDom = function() {
   var container = document.createElement('mutation');
   container.setAttribute('proccode', this.procCode_);
   container.setAttribute('argumentids', JSON.stringify(this.argumentIds_));
-  container.setAttribute('warp', this.warp_);
+  container.setAttribute('warp', JSON.stringify(this.warp_));
   return container;
 };
 
@@ -57,7 +57,7 @@ Blockly.ScratchBlocks.ProcedureUtils.callerMutationToDom = function() {
 Blockly.ScratchBlocks.ProcedureUtils.callerDomToMutation = function(xmlElement) {
   this.procCode_ = xmlElement.getAttribute('proccode');
   this.argumentIds_ = JSON.parse(xmlElement.getAttribute('argumentids'));
-  this.warp_ = xmlElement.getAttribute('warp');
+  this.warp_ = JSON.parse(xmlElement.getAttribute('warp'));
   this.updateDisplay_();
 };
 
@@ -74,7 +74,7 @@ Blockly.ScratchBlocks.ProcedureUtils.definitionMutationToDom = function() {
   container.setAttribute('argumentnames', JSON.stringify(this.displayNames_));
   container.setAttribute('argumentdefaults',
       JSON.stringify(this.argumentDefaults_));
-  container.setAttribute('warp', this.warp_);
+  container.setAttribute('warp', JSON.stringify(this.warp_));
   return container;
 };
 
@@ -86,7 +86,7 @@ Blockly.ScratchBlocks.ProcedureUtils.definitionMutationToDom = function() {
  */
 Blockly.ScratchBlocks.ProcedureUtils.definitionDomToMutation = function(xmlElement) {
   this.procCode_ = xmlElement.getAttribute('proccode');
-  this.warp_ = xmlElement.getAttribute('warp');
+  this.warp_ = JSON.parse(xmlElement.getAttribute('warp'));
 
   this.argumentIds_ = JSON.parse(xmlElement.getAttribute('argumentids'));
   this.displayNames_ = JSON.parse(xmlElement.getAttribute('argumentnames'));
@@ -613,6 +613,24 @@ Blockly.ScratchBlocks.ProcedureUtils.addStringNumberExternal = function() {
 };
 
 /**
+ * Externally-visible function to get the warp on procedure declaration.
+ * @return {boolean} The value of the warp_ property.
+ * @public
+ */
+Blockly.ScratchBlocks.ProcedureUtils.getWarp = function() {
+  return this.warp_;
+};
+
+/**
+ * Externally-visible function to set the warp on procedure declaration.
+ * @param {boolean} warp The value of the warp_ property.
+ * @public
+ */
+Blockly.ScratchBlocks.ProcedureUtils.setWarp = function(warp) {
+  this.warp_ = warp;
+};
+
+/**
  * Callback to remove a field, only for the declaration block.
  * @param {Blockly.Field} field The field being removed.
  * @public
@@ -781,6 +799,8 @@ Blockly.Blocks['procedures_declaration'] = {
   // Only exist on procedures_declaration.
   createArgumentEditor_: Blockly.ScratchBlocks.ProcedureUtils.createArgumentEditor_,
   focusLastEditor_: Blockly.ScratchBlocks.ProcedureUtils.focusLastEditor_,
+  getWarp: Blockly.ScratchBlocks.ProcedureUtils.getWarp,
+  setWarp: Blockly.ScratchBlocks.ProcedureUtils.setWarp,
   addLabelExternal: Blockly.ScratchBlocks.ProcedureUtils.addLabelExternal,
   addBooleanExternal: Blockly.ScratchBlocks.ProcedureUtils.addBooleanExternal,
   addStringNumberExternal: Blockly.ScratchBlocks.ProcedureUtils.addStringNumberExternal,


### PR DESCRIPTION
I know that warp is not actually used as a boolean from within
scratch-blocks, but parsing/stringifying just allows us to guarantee it
is a boolean even after being modified by domToMutation.

### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-blocks/issues/1277

See PR linked below to see it used in the GUI.