### PR TITLE
Change wording in create new block dialog

### DIFF
--- a/blocks_vertical/procedures.js
+++ b/blocks_vertical/procedures.js
@@ -605,7 +605,7 @@ Blockly.ScratchBlocks.ProcedureUtils.addBooleanExternal = function() {
 Blockly.ScratchBlocks.ProcedureUtils.addStringNumberExternal = function() {
   Blockly.WidgetDiv.hide(true);
   this.procCode_ = this.procCode_ + ' %s';
-  this.displayNames_.push('string or number');
+  this.displayNames_.push('number or text');
   this.argumentIds_.push(Blockly.utils.genUid());
   this.argumentDefaults_.push('todo');
   this.updateDisplay_();


### PR DESCRIPTION
### Resolves

[GUI issue #1019](https://github.com/LLK/scratch-gui/issues/1019) 

### Proposed Changes

In the "Create new block" dialog, when a "number or text" input is added to the block, have its default content be "number or text" instead of "string or number."

### Reason for Changes

The terminology "string" may be confusing for beginners.

### Test Coverage

None.
