### PR TITLE
Fix the "edit" option for flyout custom block menu

### DIFF
--- a/core/procedures.js
+++ b/core/procedures.js
@@ -456,9 +456,12 @@ Blockly.Procedures.editProcedureCallback_ = function(block) {
     }
     block = innerBlock;
   } else if (block.type == Blockly.PROCEDURES_CALL_BLOCK_TYPE) {
-    // This is a call block, find the prototype corresponding to the procCode
+    // This is a call block, find the prototype corresponding to the procCode.
+    // Make sure to search the correct workspace, call block can be in flyout.
+    var workspaceToSearch = block.workspace.isFlyout ?
+        block.workspace.targetWorkspace : block.workspace;
     block = Blockly.Procedures.getPrototypeBlock(
-        block.getProcCode(), block.workspace);
+        block.getProcCode(), workspaceToSearch);
   }
   // Block now refers to the procedure prototype block, it is safe to proceed.
   Blockly.Procedures.externalProcedureDefCallback(


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-blocks/issues/1286

### Proposed Changes

_Describe what this Pull Request does_

Searches the target workspace if trying to call edit on the call block in the flyout.
![working-edit](https://user-images.githubusercontent.com/654102/34383235-e77bca8a-eae1-11e7-9fad-714b3a7f30e9.gif)
