### PR TITLE
Bugfix: LLK/scratch-gui/issues/919

### DIFF
--- a/blocks_vertical/event.js
+++ b/blocks_vertical/event.js
@@ -99,11 +99,8 @@ Blockly.Blocks['event_whenbackdropswitchesto'] = {
       "message0": "when backdrop switches to %1",
       "args0": [
         {
-          "type": "field_dropdown",
-          "name": "BACKDROP",
-          "options": [
-              ['backdrop1', 'BACKDROP1']
-          ]
+          "type": "input_value",
+          "name": "BACKDROP"
         }
       ],
       "category": Blockly.Categories.event,


### PR DESCRIPTION
### Resolves
<https://github.com/LLK/scratch-gui/issues/919>
### Proposed Changes
Deleted  "options" array and changed line 102 from "field_dropdown" to "input_value" in scratch-blocks/blocks_vertical/event.js ,"event_whenbackdropswitchesto"
### Reason for Changes
This code makes a bug.