### PR TITLE
Bugfix: LLK/scratch-gui/issues/919 (CHANGED)

### DIFF
--- a/blocks_vertical/default_toolbox.js
+++ b/blocks_vertical/default_toolbox.js
@@ -304,6 +304,9 @@ Blockly.Blocks.defaultToolbox = '<xml id="toolbox-categories" style="display: no
     '</block>'+
     '<block type="event_whenthisspriteclicked" id="event_whenthisspriteclicked"></block>'+
     '<block type="event_whenbackdropswitchesto" id="event_whenbackdropswitchesto">'+
+       '<value name="BACKDROP">'+
+         '<shadow type="looks_backdrops"></shadow>'+
+       '</value>'+
     '</block>'+
     '<block type="event_whengreaterthan" id="event_whengreaterthan">'+
       '<value name="VALUE">'+

--- a/blocks_vertical/event.js
+++ b/blocks_vertical/event.js
@@ -99,11 +99,8 @@ Blockly.Blocks['event_whenbackdropswitchesto'] = {
       "message0": "when backdrop switches to %1",
       "args0": [
         {
-          "type": "field_dropdown",
-          "name": "BACKDROP",
-          "options": [
-              ['backdrop1', 'BACKDROP1']
-          ]
+          "type": "input_value",
+          "name": "BACKDROP"
         }
       ],
       "category": Blockly.Categories.event,


### PR DESCRIPTION
### Resolves
LLK/scratch-gui#919
### Proposed Changes
Deleted "options" array and changed line 102 from "field_dropdown" to "input_value" in scratch-blocks/blocks_vertical/event.js ,"event_whenbackdropswitchesto".

Add```

       '<value name="BACKDROP">'+
         '<shadow type="looks_backdrops"></shadow>'+
       '</value>'+

```

to blocks_vertical/default_toolbox.js
### Reason for Changes
Bug request.
Old request was wrong because it won't change default_toolbox.js