### PR TITLE
Modify costume and backdrop reporters to be more consistent / flexible

### DIFF
--- a/blocks_vertical/default_toolbox.js
+++ b/blocks_vertical/default_toolbox.js
@@ -201,9 +201,8 @@ Blockly.Blocks.defaultToolbox = '<xml id="toolbox-categories" style="display: no
         '</shadow>'+
       '</value>'+
     '</block>'+
-    '<block type="looks_costumeorder" id="looks_costumeorder"></block>'+
-    '<block type="looks_backdroporder" id="looks_backdroporder"></block>'+
-    '<block type="looks_backdropname" id="looks_backdropname"></block>'+
+    '<block type="looks_costumenumbername" id="looks_costumenumbername"></block>'+
+    '<block type="looks_backdropnumbername" id="looks_backdropnumbername"></block>'+
     '<block type="looks_size" id="looks_size"></block>'+
   '</category>'+
   '<category name="Sound" colour="#D65CD6" secondaryColour="#BD42BD">'+

--- a/blocks_vertical/looks.js
+++ b/blocks_vertical/looks.js
@@ -436,14 +436,24 @@ Blockly.Blocks['looks_goforwardbackwardlayers'] = {
   }
 };
 
-Blockly.Blocks['looks_backdropname'] = {
+Blockly.Blocks['looks_backdropnumbername'] = {
   /**
-   * Block to report backdrop's name
+   * Block to report backdrop's number or name
    * @this Blockly.Block
    */
   init: function() {
     this.jsonInit({
-      "message0": "backdrop name",
+      "message0": "backdrop %1",
+      "args0": [
+        {
+          "type": "field_dropdown",
+          "name": "NUMBER_NAME",
+          "options": [
+            ['number', 'number'],
+            ['name', 'name']
+          ]
+        }
+      ],
       "category": Blockly.Categories.looks,
       "checkboxInFlyout": true,
       "extensions": ["colours_looks", "output_number"]
@@ -451,29 +461,24 @@ Blockly.Blocks['looks_backdropname'] = {
   }
 };
 
-Blockly.Blocks['looks_costumeorder'] = {
+Blockly.Blocks['looks_costumenumbername'] = {
   /**
-   * Block to report costume's order
+   * Block to report costume's number or name
    * @this Blockly.Block
    */
   init: function() {
     this.jsonInit({
-      "message0": "costume #",
-      "category": Blockly.Categories.looks,
-      "checkboxInFlyout": true,
-      "extensions": ["colours_looks", "output_number"]
-    });
-  }
-};
-
-Blockly.Blocks['looks_backdroporder'] = {
-  /**
-   * Block to report backdrop's order
-   * @this Blockly.Block
-   */
-  init: function() {
-    this.jsonInit({
-      "message0": "backdrop #",
+      "message0": "costume %1",
+      "args0": [
+        {
+          "type": "field_dropdown",
+          "name": "NUMBER_NAME",
+          "options": [
+            ['number', 'number'],
+            ['name', 'name']
+          ]
+        }
+      ],
       "category": Blockly.Categories.looks,
       "checkboxInFlyout": true,
       "extensions": ["colours_looks", "output_number"]


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Blocks part of https://github.com/LLK/scratch-blocks/issues/1318. Will be closable after VM and GUI parts are also merged, those depend on this.

### Proposed Changes

_Describe what this Pull Request does_

Make the reporters for costume and backdrop number / name consistent by using a menu to switch between number and name

```
(costume [number / name])
(backdrop [number / name])
```

Here is what the new blocks look like (ordering and appearance based on active sprite/backdrop is handled by the GUI, this is just what the blocks look like). 

![image](https://user-images.githubusercontent.com/654102/34570535-0d986a26-f13a-11e7-99fd-d6fc20fad884.png)