### PR TITLE
Remove monitor on of

### DIFF
--- a/blocks_vertical/sensing.js
+++ b/blocks_vertical/sensing.js
@@ -601,7 +601,6 @@ Blockly.Blocks['sensing_of'] = {
       "output": true,
       "category": Blockly.Categories.sensing,
       "outputShape": Blockly.OUTPUT_SHAPE_ROUND,
-      "checkboxInFlyout": true,
       "extensions": ["colours_sensing"]
     });
   }


### PR DESCRIPTION
We left this on by mistake? 2.0 doesn't have () of () monitored.
