### PR TITLE
Fix text alignment on Edge

### DIFF
--- a/core/field.js
+++ b/core/field.js
@@ -132,6 +132,12 @@ Blockly.Field.prototype.validator_ = null;
 Blockly.Field.NBSP = '\u00A0';
 
 /**
+ * Text offset used for IE/Edge.
+ * @const
+ */
+Blockly.Field.IE_TEXT_OFFSET = '0.3em';
+
+/**
  * Editable fields usually show some sort of UI for the user to change them.
  * @type {boolean}
  * @public
@@ -187,7 +193,7 @@ Blockly.Field.prototype.init = function() {
        'x': fieldX,
        'y': size.height / 2 + Blockly.BlockSvg.FIELD_TOP_PADDING,
        'dominant-baseline': 'middle',
-       'dy': goog.userAgent.EDGE_OR_IE ? '0.35em' : '0',
+       'dy': goog.userAgent.EDGE_OR_IE ? Blockly.Field.IE_TEXT_OFFSET : '0',
        'text-anchor': 'middle'},
       this.fieldGroup_);
 

--- a/core/field.js
+++ b/core/field.js
@@ -187,6 +187,7 @@ Blockly.Field.prototype.init = function() {
        'x': fieldX,
        'y': size.height / 2 + Blockly.BlockSvg.FIELD_TOP_PADDING,
        'dominant-baseline': 'middle',
+       'dy': goog.userAgent.EDGE_OR_IE ? '0.35em' : '0',
        'text-anchor': 'middle'},
       this.fieldGroup_);
 

--- a/core/field_label.js
+++ b/core/field_label.js
@@ -76,7 +76,7 @@ Blockly.FieldLabel.prototype.init = function() {
       'y': Blockly.BlockSvg.FIELD_TOP_PADDING,
       'text-anchor': 'middle',
       'dominant-baseline': 'middle',
-      'dy': goog.userAgent.EDGE_OR_IE ? '0.35em' : '0'
+      'dy': goog.userAgent.EDGE_OR_IE ? Blockly.Field.IE_TEXT_OFFSET : '0'
     }, null);
   if (this.class_) {
     Blockly.utils.addClass(this.textElement_, this.class_);

--- a/core/field_label.js
+++ b/core/field_label.js
@@ -30,6 +30,7 @@ goog.require('Blockly.Field');
 goog.require('Blockly.Tooltip');
 goog.require('goog.dom');
 goog.require('goog.math.Size');
+goog.require('goog.userAgent');
 
 
 /**
@@ -74,7 +75,8 @@ Blockly.FieldLabel.prototype.init = function() {
       {'class': 'blocklyText',
       'y': Blockly.BlockSvg.FIELD_TOP_PADDING,
       'text-anchor': 'middle',
-      'dominant-baseline': 'middle'
+      'dominant-baseline': 'middle',
+      'dy': goog.userAgent.EDGE_OR_IE ? '0.35em' : '0'
     }, null);
   if (this.class_) {
     Blockly.utils.addClass(this.textElement_, this.class_);


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-blocks/issues/1054

Not the ideal fix, but I think figuring out a pixel perfect fix may take quite a bit of time. Unless @rachel-fenichel you have any thoughts.

### Proposed Changes

_Describe what this Pull Request does_

Manually offset svg text elements using `dy` property. Value chosen empirically. 

### Reason for Changes

_Explain why these changes should be made_

Edge still doesn't respect the `dominant-baseline` SVG property. It has been nearly 8 years since the spec for it was finalized, so I'm assuming they never will.

Before
![image](https://user-images.githubusercontent.com/654102/34835766-cf7bc0a0-f6c3-11e7-8e67-ce6daa211e4f.png)

After
![image](https://user-images.githubusercontent.com/654102/34835768-d1047dcc-f6c3-11e7-8556-c119c9bc999e.png)

This is in an effort to get Edge not to look terrible at first impression. Again, a wider reaching fix may be needed further down the line.
