### PR TITLE
Update the color sliders when eyedropper changes the value.

### DIFF
--- a/core/field_colour_slider.js
+++ b/core/field_colour_slider.js
@@ -256,6 +256,11 @@ Blockly.FieldColourSlider.prototype.sliderCallbackFactory_ = function(channel) {
 Blockly.FieldColourSlider.prototype.activateEyedropperInternal_ = function() {
   var thisField = this;
   Blockly.FieldColourSlider.activateEyedropper_(function(value) {
+    // Update the internal hue/saturation/brightness values so sliders update.
+    var hsv = goog.color.hexToHsv(value);
+    thisField.hue_ = hsv[0];
+    thisField.saturation_ = hsv[1];
+    thisField.brightness_ = hsv[2];
     thisField.setValue(value);
   });
 };


### PR DESCRIPTION
The hsv slider values are intentionally kept separate from the field
value so they are more stable when changed. They are initialized when
the editor is opened and only updated by the sliders. This was causing
the sliders not to update when a new color was chosen via eyedropper. To
get around this, manually update the internal hsv values when coming
back from the eyedropper callback so that the sliders get updated (which
happens in setValue).

Current behavior
![slider-update--develop](https://user-images.githubusercontent.com/654102/35157825-2ca936f0-fd03-11e7-86e1-10979c5818d3.gif)

Fixed 
![slider-update--fixed](https://user-images.githubusercontent.com/654102/35157830-31d1fa40-fd03-11e7-991e-2b6875636574.gif)


Fixes https://github.com/LLK/scratch-gui/issues/823