### PR TITLE
Refresh the toolbox after deleting a custom procedure definition.

### DIFF
--- a/core/procedures.js
+++ b/core/procedures.js
@@ -557,9 +557,17 @@ Blockly.Procedures.deleteProcedureDefCallback = function(procCode,
   if (callers.length > 0) {
     return false;
   }
+
+  var workspace = definitionRoot.workspace;
+
   // Delete the whole stack.
   Blockly.Events.setGroup(true);
   definitionRoot.dispose();
   Blockly.Events.setGroup(false);
+
+  // TODO (#1354) Update this function when '_' is removed
+  // Refresh toolbox, so caller doesn't appear there anymore
+  workspace.refreshToolboxSelection_();
+
   return true;
 };

--- a/core/workspace.js
+++ b/core/workspace.js
@@ -104,6 +104,16 @@ Blockly.Workspace.prototype.rendered = false;
  */
 Blockly.Workspace.prototype.MAX_UNDO = 1024;
 
+// TODO (#1354) Update this function when it is fixed upstream
+/**
+ * Refresh the toolbox. This is a no-op in a non-rendered workspace,
+ * but may be overriden by subclasses.
+ * @private
+ */
+Blockly.Workspace.prototype.refreshToolboxSelection_ = function() {
+  // No-op. Overriden by subclass.
+};
+
 /**
  * Dispose of this workspace.
  * Unlink from all DOM elements to prevent memory leaks.


### PR DESCRIPTION
### Resolves

[scratch-gui#1261](https://github.com/LLK/scratch-gui/issues/1261)

### Proposed Changes

Refreshes the toolbox after deleting custom procedure definition so that the caller is removed from the toolbox.

#### Additional Notes
WorkspaceSvg.refreshToolboxSelection_ is a private function that is getting called outside of the WorkspaceSvg class. The function needs to be made a package function upstream. This is being tracked in [blockly #1554](https://github.com/google/blockly/issues/1554).

Once this is fixed upstream, need to resolve issue #1354 

### Reason for Changes

[scratch-gui#1261](https://github.com/LLK/scratch-gui/issues/1261)

### Test Coverage

Existing tests pass.
