### PR TITLE
Handling variable naming/renaming -- case sensitivity, and used name checking

### DIFF
--- a/core/variable_map.js
+++ b/core/variable_map.js
@@ -77,11 +77,11 @@ Blockly.VariableMap.prototype.renameVariable = function(variable, newName) {
     if (!conflictVar) {
       this.renameVariableAndUses_(variable, newName, blocks);
     } else {
-      // We don't want to rename if the variable if one with the exact new name
+      // We don't want to rename the variable if one with the exact new name
       // already exists.
       console.warn('Unexpected conflict when attempting to rename ' +
         'variable with name: ' + variable.name + ' and id: ' + variable.getId() +
-        ' to new name: ' + newName + '. Variable with the new name already exist' +
+        ' to new name: ' + newName + '. A variable with the new name already exists' +
         ' and has id: ' + conflictVar.getId());
 
     }

--- a/core/variable_map.js
+++ b/core/variable_map.js
@@ -74,10 +74,16 @@ Blockly.VariableMap.prototype.renameVariable = function(variable, newName) {
   Blockly.Events.setGroup(true);
   try {
     // The IDs may match if the rename is a simple case change (name1 -> Name1).
-    if (!conflictVar || conflictVar.getId() == variable.getId()) {
+    if (!conflictVar) {
       this.renameVariableAndUses_(variable, newName, blocks);
     } else {
-      this.renameVariableWithConflict_(variable, newName, conflictVar, blocks);
+      // We don't want to rename if the variable if one with the exact new name
+      // already exists.
+      console.warn('Unexpected conflict when attempting to rename ' +
+        'variable with name: ' + variable.name + ' and id: ' + variable.getId() +
+        ' to new name: ' + newName + '. Variable with the new name already exist' +
+        ' and has id: ' + conflictVar.getId());
+
     }
   } finally {
     Blockly.Events.setGroup(false);
@@ -299,7 +305,7 @@ Blockly.VariableMap.prototype.getVariable = function(name, opt_type) {
   var list = this.variableMap_[type];
   if (list) {
     for (var j = 0, variable; variable = list[j]; j++) {
-      if (Blockly.Names.equals(variable.name, name)) {
+      if (variable.name == name) {
         return variable;
       }
     }

--- a/core/variable_map.js
+++ b/core/variable_map.js
@@ -73,7 +73,6 @@ Blockly.VariableMap.prototype.renameVariable = function(variable, newName) {
   var blocks = this.workspace.getAllBlocks();
   Blockly.Events.setGroup(true);
   try {
-    // The IDs may match if the rename is a simple case change (name1 -> Name1).
     if (!conflictVar) {
       this.renameVariableAndUses_(variable, newName, blocks);
     } else {

--- a/core/variables.js
+++ b/core/variables.js
@@ -272,6 +272,7 @@ Blockly.Variables.createVariable = function(workspace, opt_callback, opt_type) {
   if (opt_type === Blockly.LIST_VARIABLE_TYPE) {
     newMsg = Blockly.Msg.NEW_LIST_TITLE;
     modalTitle = Blockly.Msg.LIST_MODAL_TITLE;
+
   } else if (opt_type === Blockly.BROADCAST_MESSAGE_VARIABLE_TYPE) {
     newMsg = Blockly.Msg.NEW_BROADCAST_MESSAGE_TITLE;
     modalTitle = Blockly.Msg.BROADCAST_MODAL_TITLE;
@@ -286,7 +287,7 @@ Blockly.Variables.createVariable = function(workspace, opt_callback, opt_type) {
         if (text) {
           if (workspace.getVariable(text, opt_type)) {
             Blockly.alert(Blockly.Msg.VARIABLE_ALREADY_EXISTS.replace('%1',
-                text.toLowerCase()),
+                text),
                 function() {
                   promptAndCheckWithAlert(text);  // Recurse
                 });
@@ -354,7 +355,15 @@ Blockly.Variables.renameVariable = function(workspace, variable,
     Blockly.Variables.promptName(promptText, defaultName,
         function(newName) {
           if (newName) {
-            workspace.renameVariableById(variable.getId(), newName);
+            if (workspace.getVariable(newName, variable.type)) {
+              Blockly.alert(Blockly.Msg.VARIABLE_ALREADY_EXISTS.replace('%1',
+                  newName),
+                  function() {
+                    promptAndCheckWithAlert(newName);  // Recurse
+                  });
+            } else {
+              workspace.renameVariableById(variable.getId(), newName);
+            }
             if (opt_callback) {
               opt_callback(newName);
             }

--- a/core/variables.js
+++ b/core/variables.js
@@ -291,15 +291,7 @@ Blockly.Variables.createVariable = function(workspace, opt_callback, opt_type) {
                 function() {
                   promptAndCheckWithAlert(text);  // Recurse
                 });
-          }
-          else if (!Blockly.Procedures.isNameUsed(text, workspace)) {
-            Blockly.alert(Blockly.Msg.PROCEDURE_ALREADY_EXISTS.replace('%1',
-                text.toLowerCase()),
-                function() {
-                  promptAndCheckWithAlert(text);  // Recurse
-                });
-          }
-          else {
+          } else {
             var potentialVarMap = workspace.getPotentialVariableMap();
             var variable;
             // This check ensures that if a new variable is being created from a

--- a/tests/jsunit/workspace_test.js
+++ b/tests/jsunit/workspace_test.js
@@ -235,8 +235,8 @@ function test_renameVariable_ReferenceExists() {
 }
 
 function test_renameVariable_TwoVariablesSameType() {
-  // Expect 'renameVariable' to change oldName variable name to newName.
-  // Expect oldName block name to change to newName
+  // Cannot rename variable to a name that already exists
+  // for a variable of the same type.
   workspaceTest_setUp();
   var id1 = 'id1';
   var id2 = 'id2';
@@ -252,18 +252,18 @@ function test_renameVariable_TwoVariablesSameType() {
   createMockBlock(id2);
 
   workspace.renameVariableById(id1, newName);
-  checkVariableValues(workspace, newName, type, id2);
-  // The old variable should have been deleted.
-  var variable = workspace.getVariableById(id1);
-  assertNull(variable);
 
-  // There should only be one variable left.
-  assertEquals(1, workspace.getAllVariables().length);
+  // Both variables should retain the same names/ids as before.
+  checkVariableValues(workspace, oldName, type, id1);
+  checkVariableValues(workspace, newName, type, id2);
+
+  // Both variables should remain on the workspace.
+  assertEquals(2, workspace.getAllVariables().length);
 
   // References should have the correct names.
   var block_var_name_1 = workspace.topBlocks_[0].getVarModels()[0].name;
   var block_var_name_2 = workspace.topBlocks_[1].getVarModels()[0].name;
-  assertEquals(newName, block_var_name_1);
+  assertEquals(oldName, block_var_name_1);
   assertEquals(newName, block_var_name_2);
 
   workspaceTest_tearDown();
@@ -306,10 +306,9 @@ function test_renameVariable_OldCase() {
 
 function test_renameVariable_TwoVariablesAndOldCase() {
   // Test renaming a variable to an in-use name, but with different
-  // capitalization.  The new capitalization should apply everywhere.
+  // capitalization. Two variables with different capitalizations should
+  // co-exist.
 
-  // TODO (fenichel): What about different capitalization but also different
-  // types?
   workspaceTest_setUp();
   var oldName = 'name1';
   var oldCase = 'Name2';
@@ -325,22 +324,29 @@ function test_renameVariable_TwoVariablesAndOldCase() {
   createMockBlock(id1);
   createMockBlock(id2);
 
+  // Blocks should have the correct variable names
+  var old_block_var_name_1 = workspace.topBlocks_[0].getVarModels()[0].name;
+  var old_block_var_name_2 = workspace.topBlocks_[1].getVarModels()[0].name;
+  assertEquals(oldName, old_block_var_name_1);
+  assertEquals(oldCase, old_block_var_name_2);
+
   workspace.renameVariableById(id1, newName);
 
-  checkVariableValues(workspace, newName, type, id2);
+  // The old variable gets properly renamed to the new name,
+  // since variables are case sensitive.
+  checkVariableValues(workspace, newName, type, id1);
 
-  // The old variable should have been deleted.
-  var variable = workspace.getVariableById(id1);
-  assertNull(variable);
+  // Both variables should still exist
+  assertEquals(2, workspace.getAllVariables().length);
 
-  // There should only be one variable left.
-  assertEquals(1, workspace.getAllVariables().length);
-
-  // Blocks should now use the new capitalization.
+  // Block which had oldName should have been updated to use newName, while
+  // block with oldCase should still have the same name.
   var block_var_name_1 = workspace.topBlocks_[0].getVarModels()[0].name;
   var block_var_name_2 = workspace.topBlocks_[1].getVarModels()[0].name;
   assertEquals(newName, block_var_name_1);
-  assertEquals(newName, block_var_name_2);
+  assertNotEquals(old_block_var_name_1, block_var_name_1);
+  assertEquals(oldCase, block_var_name_2);
+  assertEquals(old_block_var_name_2, block_var_name_2);
   workspaceTest_tearDown();
 }
 

--- a/tests/jsunit/workspace_test.js
+++ b/tests/jsunit/workspace_test.js
@@ -237,6 +237,9 @@ function test_renameVariable_ReferenceExists() {
 function test_renameVariable_TwoVariablesSameType() {
   // Cannot rename variable to a name that already exists
   // for a variable of the same type.
+  // Note: this behavior is different from that of blockly which allows
+  // renaming variables to a name that already exists if the variables have the
+  // same type.
   workspaceTest_setUp();
   var id1 = 'id1';
   var id2 = 'id2';
@@ -308,6 +311,10 @@ function test_renameVariable_TwoVariablesAndOldCase() {
   // Test renaming a variable to an in-use name, but with different
   // capitalization. Two variables with different capitalizations should
   // co-exist.
+  // Note: this behavior is different from that of blockly which does not allow
+  // two variables of the same name to exist with different capitalization. In
+  // blockly, variable names are case insensitive, so different capitalizations
+  // of a variable name are treated as the same name.
 
   workspaceTest_setUp();
   var oldName = 'name1';


### PR DESCRIPTION
### Resolves

Resolves #1292 
Resolves [scratch-gui#1008](https://github.com/LLK/scratch-gui/issues/1008)
Resolves #1343 
Resolves #1183

### Proposed Changes

Allows variables, lists, and broadcast messages to have case sensitive names. In the case of variables and lists, X and x are different names. In the case of broadcast messages, as in Scratch 2.0, users can create new messages with different capitalizations of the same message name  (e.g. 'message', 'mEssaGe', and 'Message' can all co-exist in the same broadcast message dropdown menu, but will all trigger the same 'when I receive' hats. This means that even though the dropdown has the three different capitalizations listed above, all of these name options refer to the same underlying message being broadcasted. This is consistent with the behavior of Scratch 2.0.

This PR also disallows renaming variables to the name of an existing variable. The previous behavior was to replace the variable being renamed with a reference to the existing variable that shares a name and type with the new name.

### Reason for Changes

The issues listed above, and backwards compatibility with scratch 2.0.

#1183 is closed by a combination of this PR and the variables_by_id work. This is explained in [this comment](https://github.com/LLK/scratch-blocks/issues/1183#issuecomment-359558583).

### Test Coverage

Tests have been modified to reflect new variable case sensitivity and the new rules about disallowing a variable to be renamed to an existing variable name.

#### Additional Notes

This work should be updated when the upstream [blockly issue#1537](https://github.com/google/blockly/issues/1537) is resolved. Validators for creating and renaming variables will move into their own separate functions to handle type-specific variable name validators.