### PR TITLE
Constants for variable/list renaming prompts.

### DIFF
--- a/msg/messages.js
+++ b/msg/messages.js
@@ -123,6 +123,8 @@ Blockly.Msg.CHANGE_VALUE_TITLE = 'Change value:';
 Blockly.Msg.RENAME_VARIABLE = 'Rename variable';
 /// prompt - Prompts the user to enter the new name for the selected variable.  See [https://github.com/google/blockly/wiki/Variables#dropdown-menu https://github.com/google/blockly/wiki/Variables#dropdown-menu].\n\nParameters:\n* %1 - the name of the variable to be renamed.
 Blockly.Msg.RENAME_VARIABLE_TITLE = 'Rename all "%1" variables to:';
+/// prompt title - Title for the rename variable modal
+Blockly.Msg.RENAME_VARIABLE_MODAL_TITLE = 'Rename Variable';
 
 // Variable creation
 /// button text - Text on the button used to launch the variable creation dialogue.
@@ -149,6 +151,14 @@ Blockly.Msg.NEW_LIST = 'Make a List';
 Blockly.Msg.NEW_LIST_TITLE = 'New list name:';
 /// prompt title - Title of the prompt asking the user to enter the name for the new list.
 Blockly.Msg.LIST_MODAL_TITLE = 'New List';
+/// alert - Tells the user that the name they entered is already in use.
+Blockly.Msg.LIST_ALREADY_EXISTS = 'A list named "%1" already exists.';
+
+// List renaming
+/// prompt - Prompts the user to enter the new name for the selected list.
+Blockly.Msg.RENAME_LIST_TITLE = 'Rename all "%1" lists to:';
+/// prompt title - Title of the prompt asking the user to rename the list
+Blockly.Msg.RENAME_LIST_MODAL_TITLE = 'Rename List';
 
 // Broadcast Message creation
 /// dropdown choice - Create a new message.


### PR DESCRIPTION
In the PR https://github.com/LLK/scratch-blocks/pull/1361, I accidentally forgot to commit the messages file. Without this, the variable/list specific prompt messages don't work, and the lack of this file introduces a regression where attempting to rename a list causes a type error.

Existing tests pass.
