### PR TITLE
Adding variable type info to blockly prompt so scratch-gui can pick it up

### DIFF
--- a/core/blockly.js
+++ b/core/blockly.js
@@ -334,10 +334,13 @@ Blockly.confirm = function(message, callback) {
  * @param {string} defaultValue The value to initialize the prompt with.
  * @param {!function(string)} callback The callback for handling user response.
  * @param {?string} opt_title An optional title for the prompt.
+ * @param {?string} opt_varType An optional variable type for variable specific
+ *     prompt behavior.
  */
-Blockly.prompt = function(message, defaultValue, callback, opt_title) {
-  // opt_title is unused because we only need it to pass information to the
-  // scratch-gui, which overwrites this function
+Blockly.prompt = function(message, defaultValue, callback, opt_title,
+    opt_varType) {
+  // opt_title and opt_varType are unused because we only need them to pass
+  // information to the scratch-gui, which overwrites this function
   callback(window.prompt(message, defaultValue));
 };
 /* eslint-enable no-unused-vars */

--- a/core/variables.js
+++ b/core/variables.js
@@ -323,7 +323,7 @@ Blockly.Variables.createVariable = function(workspace, opt_callback, opt_type) {
             opt_callback(null);
           }
         }
-      }, modalTitle);
+      }, modalTitle, opt_type);
 };
 
 /**
@@ -474,7 +474,7 @@ Blockly.Variables.renameVariable = function(workspace, variable,
             opt_callback(null);
           }
         }
-      }, modalTitle);
+      }, modalTitle, varType);
 };
 
 /**


### PR DESCRIPTION
### Resolves

Towards resolving https://github.com/LLK/scratch-gui/issues/1361. (To be followed up with associated change in scratch-gui).

### Proposed Changes

Provides Blockly.prompt with variable type information for the three different variable type modals. This is so that ScratchBlocks can pick this info up and act on it (e.g. hide 'More Options' div for broadcast message modal, but show it for variable/list modal).

### Reason for Changes

https://github.com/LLK/scratch-gui/issues/1361

### Test Coverage

Existing tests pass.