### PR TITLE
Make sensing "key pressed" block input droppable

### DIFF
--- a/blocks_vertical/default_toolbox.js
+++ b/blocks_vertical/default_toolbox.js
@@ -377,7 +377,11 @@ Blockly.Blocks.defaultToolbox = '<xml id="toolbox-categories" style="display: no
         '<shadow type="sensing_distancetomenu"></shadow>'+
       '</value>'+
     '</block>'+
-    '<block type="sensing_keypressed" id="sensing_keypressed"></block>'+
+    '<block type="sensing_keypressed" id="sensing_keypressed">'+
+        '<value name="KEY_OPTION">'+
+          '<shadow type="sensing_keyoptions"></shadow>'+
+        '</value>'+
+    '</block>'+
     '<block type="sensing_mousedown" id="sensing_mousedown"></block>'+
     '<block type="sensing_mousex" id="sensing_mousex"></block>'+
     '<block type="sensing_mousey" id="sensing_mousey"></block>'+

--- a/blocks_vertical/sensing.js
+++ b/blocks_vertical/sensing.js
@@ -204,6 +204,26 @@ Blockly.Blocks['sensing_keypressed'] = {
       "message0": "key %1 pressed?",
       "args0": [
         {
+          "type": "input_value",
+          "name": "KEY_OPTION"
+        }
+      ],
+      "category": Blockly.Categories.sensing,
+      "extensions": ["colours_sensing", "output_boolean"]
+    });
+  }
+};
+
+Blockly.Blocks['sensing_keyoptions'] = {
+  /**
+   * Options for Keys
+   * @this Blockly.Block
+   */
+  init: function() {
+    this.jsonInit({
+      "message0": "%1",
+      "args0": [
+        {
           "type": "field_dropdown",
           "name": "KEY_OPTION",
           "options": [
@@ -253,8 +273,7 @@ Blockly.Blocks['sensing_keypressed'] = {
           ]
         }
       ],
-      "category": Blockly.Categories.sensing,
-      "extensions": ["colours_sensing", "output_boolean"]
+      "extensions": ["colours_sensing", "output_string"]
     });
   }
 };


### PR DESCRIPTION
### Resolves

Towards #1370. LLK/scratch-gui#1384 must be merged before the issue is actually fixed, but this supports that PR (so this should be merged first).

### Proposed Changes

This reverts parts of commit 367776523a789e8c2f352dde02a8e5d27f90c6e8 (issue #1339) to make the dropdown of the "key pressed?" sensing block droppable.

### Reason for Changes

To implement a help wanted feature request; to make the "key pressed" block more powerful. (See discussion in #1370.)

### Test Coverage

Opened `tests/horizontal_playground.html`. Also tested the GUI (relevant PR to be made).
