### PR TITLE
Keep stop block mutation in sync with dropdown value

### DIFF
--- a/blocks_vertical/control.js
+++ b/blocks_vertical/control.js
@@ -191,7 +191,17 @@ Blockly.Blocks['control_stop'] = {
         ['other scripts in sprite', OTHER_SCRIPTS]
       ];
     }, function(option) {
+      // Create an event group to keep field value and mutator in sync
+      // Return null at the end because setValue is called here already.
+      Blockly.Events.setGroup(true);
+      var oldMutation = Blockly.Xml.domToText(this.sourceBlock_.mutationToDom());
       this.sourceBlock_.setNextStatement(option == OTHER_SCRIPTS);
+      var newMutation = Blockly.Xml.domToText(this.sourceBlock_.mutationToDom());
+      Blockly.Events.fire(new Blockly.Events.BlockChange(this.sourceBlock_,
+          'mutation', null, oldMutation, newMutation));
+      this.setValue(option);
+      Blockly.Events.setGroup(false);
+      return null;
     });
     this.appendDummyInput()
         .appendField('stop')
@@ -205,8 +215,7 @@ Blockly.Blocks['control_stop'] = {
   },
   mutationToDom: function() {
     var container = document.createElement('mutation');
-    var hasNext = (this.getFieldValue('STOP_OPTION') == 'other scripts in sprite');
-    container.setAttribute('hasnext', hasNext);
+    container.setAttribute('hasnext', this.nextConnection != null);
     return container;
   },
   domToMutation: function(xmlElement) {


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_
Fixes https://github.com/LLK/scratch-blocks/issues/1357
Fixes https://github.com/LLK/scratch-blocks/issues/1357

### Proposed Changes

_Describe what this Pull Request does_

Fire mutator event change to keep the stop dropdown field value in sync with the mutator.

I had to include the call to `setValue` in the validator in order to group the events so that the value change and the mutator change cannot get out of sync. That feels wrong, is there a better way @rachel-fenichel?

### Reason for Changes

_Explain why these changes should be made_

The two bugs listed above were the result of a mutation change not being emitted. Now a mutation change is emitted manually.

This bug is not reproducible in the playground, although you could see that there was no mutation event being emitted when the value was changed. A full test of the bugs reported above requires VM integration. 