### PR TITLE
Fix behavior of color picker on sensor blocks

### DIFF
--- a/core/css.js
+++ b/core/css.js
@@ -830,7 +830,7 @@ Blockly.Css.CONTENT = [
   '.blocklyDropDownDiv .goog-slider-horizontal .goog-slider-thumb {',
     'width: 26px;',
     'height: 26px;',
-    'margin-top: -1px;',
+    'top: -1px;',
     'position: absolute;',
     'background-color: white;',
     'border-radius: 100%;',

--- a/core/field_colour_slider.js
+++ b/core/field_colour_slider.js
@@ -67,6 +67,13 @@ Blockly.FieldColourSlider.activateEyedropper_ = null;
 Blockly.FieldColourSlider.EYEDROPPER_PATH = 'eyedropper.svg';
 
 /**
+ * Factor to convert between slider integer range and saturation decimal range 0 - 1.
+ * google closure sliderbase only allows whole step integers,
+ * so we cannot step between 0 and 1 fractionally.
+ */
+Blockly.FieldColourSlider.prototype.SATURATION_CONV = 100;
+
+/**
  * Install this field on a block.
  * @param {!Blockly.Block} block The block containing this field.
  */
@@ -178,7 +185,7 @@ Blockly.FieldColourSlider.prototype.updateDom_ = function() {
 Blockly.FieldColourSlider.prototype.updateSliderHandles_ = function() {
   if (this.hueSlider_) {
     this.hueSlider_.setValue(this.hue_);
-    this.saturationSlider_.setValue(this.saturation_);
+    this.saturationSlider_.setValue(this.saturation_ * this.SATURATION_CONV);
     this.brightnessSlider_.setValue(this.brightness_);
   }
 };
@@ -232,7 +239,7 @@ Blockly.FieldColourSlider.prototype.sliderCallbackFactory_ = function(channel) {
         hsv[0] = thisField.hue_ = channelValue;
         break;
       case 'saturation':
-        hsv[1] = thisField.saturation_ = channelValue;
+        hsv[1] = thisField.saturation_ = channelValue / thisField.SATURATION_CONV;
         break;
       case 'brightness':
         hsv[2] = thisField.brightness_ = channelValue;
@@ -288,6 +295,7 @@ Blockly.FieldColourSlider.prototype.showEditor_ = function() {
   this.hueSlider_.setUnitIncrement(5);
   this.hueSlider_.setMinimum(0);
   this.hueSlider_.setMaximum(360);
+  this.hueSlider_.moveToPointEnabled_ = true;
   this.hueSlider_.render(div);
 
   var saturationElements = this.createLabelDom_(
@@ -296,10 +304,11 @@ Blockly.FieldColourSlider.prototype.showEditor_ = function() {
   div.appendChild(saturationElements[0]);
   this.saturationReadout_ = saturationElements[1];
   this.saturationSlider_ = new goog.ui.Slider();
-  this.saturationSlider_.setUnitIncrement(0.01);
-  this.saturationSlider_.setStep(0.001);
+  this.saturationSlider_.setUnitIncrement(1);
   this.saturationSlider_.setMinimum(0);
-  this.saturationSlider_.setMaximum(1.0);
+  this.saturationSlider_.setMaximum(this.SATURATION_CONV);
+  this.saturationSlider_.moveToPointEnabled_ = true;
+
   this.saturationSlider_.render(div);
 
   var brightnessElements = this.createLabelDom_(
@@ -308,9 +317,10 @@ Blockly.FieldColourSlider.prototype.showEditor_ = function() {
   div.appendChild(brightnessElements[0]);
   this.brightnessReadout_ = brightnessElements[1];
   this.brightnessSlider_ = new goog.ui.Slider();
-  this.brightnessSlider_.setUnitIncrement(2);
+  this.brightnessSlider_.setUnitIncrement(1);
   this.brightnessSlider_.setMinimum(0);
   this.brightnessSlider_.setMaximum(255);
+  this.brightnessSlider_.moveToPointEnabled_ = true;
   this.brightnessSlider_.render(div);
 
   Blockly.FieldColourSlider.hueChangeEventKey_ = goog.events.listen(this.hueSlider_,

--- a/core/field_colour_slider.js
+++ b/core/field_colour_slider.js
@@ -295,7 +295,7 @@ Blockly.FieldColourSlider.prototype.showEditor_ = function() {
   this.hueSlider_.setUnitIncrement(5);
   this.hueSlider_.setMinimum(0);
   this.hueSlider_.setMaximum(360);
-  this.hueSlider_.moveToPointEnabled_ = true;
+  this.hueSlider_.setMoveToPointEnabled(true);
   this.hueSlider_.render(div);
 
   var saturationElements = this.createLabelDom_(
@@ -307,8 +307,7 @@ Blockly.FieldColourSlider.prototype.showEditor_ = function() {
   this.saturationSlider_.setUnitIncrement(1);
   this.saturationSlider_.setMinimum(0);
   this.saturationSlider_.setMaximum(this.SATURATION_CONV);
-  this.saturationSlider_.moveToPointEnabled_ = true;
-
+  this.saturationSlider_.setMoveToPointEnabled(true);
   this.saturationSlider_.render(div);
 
   var brightnessElements = this.createLabelDom_(
@@ -320,7 +319,7 @@ Blockly.FieldColourSlider.prototype.showEditor_ = function() {
   this.brightnessSlider_.setUnitIncrement(1);
   this.brightnessSlider_.setMinimum(0);
   this.brightnessSlider_.setMaximum(255);
-  this.brightnessSlider_.moveToPointEnabled_ = true;
+  this.brightnessSlider_.setMoveToPointEnabled(true);
   this.brightnessSlider_.render(div);
 
   Blockly.FieldColourSlider.hueChangeEventKey_ = goog.events.listen(this.hueSlider_,

--- a/core/field_colour_slider.js
+++ b/core/field_colour_slider.js
@@ -67,13 +67,6 @@ Blockly.FieldColourSlider.activateEyedropper_ = null;
 Blockly.FieldColourSlider.EYEDROPPER_PATH = 'eyedropper.svg';
 
 /**
- * Factor to convert between slider integer range and saturation decimal range 0 - 1.
- * google closure sliderbase only allows whole step integers,
- * so we cannot step between 0 and 1 fractionally.
- */
-Blockly.FieldColourSlider.prototype.SATURATION_CONV = 100;
-
-/**
  * Install this field on a block.
  * @param {!Blockly.Block} block The block containing this field.
  */
@@ -185,7 +178,7 @@ Blockly.FieldColourSlider.prototype.updateDom_ = function() {
 Blockly.FieldColourSlider.prototype.updateSliderHandles_ = function() {
   if (this.hueSlider_) {
     this.hueSlider_.setValue(this.hue_);
-    this.saturationSlider_.setValue(this.saturation_ * this.SATURATION_CONV);
+    this.saturationSlider_.setValue(this.saturation_);
     this.brightnessSlider_.setValue(this.brightness_);
   }
 };
@@ -239,7 +232,7 @@ Blockly.FieldColourSlider.prototype.sliderCallbackFactory_ = function(channel) {
         hsv[0] = thisField.hue_ = channelValue;
         break;
       case 'saturation':
-        hsv[1] = thisField.saturation_ = channelValue / thisField.SATURATION_CONV;
+        hsv[1] = thisField.saturation_ = channelValue;
         break;
       case 'brightness':
         hsv[2] = thisField.brightness_ = channelValue;
@@ -304,10 +297,11 @@ Blockly.FieldColourSlider.prototype.showEditor_ = function() {
   div.appendChild(saturationElements[0]);
   this.saturationReadout_ = saturationElements[1];
   this.saturationSlider_ = new goog.ui.Slider();
-  this.saturationSlider_.setUnitIncrement(1);
-  this.saturationSlider_.setMinimum(0);
-  this.saturationSlider_.setMaximum(this.SATURATION_CONV);
   this.saturationSlider_.setMoveToPointEnabled(true);
+  this.saturationSlider_.setUnitIncrement(0.01);
+  this.saturationSlider_.setStep(0.001);
+  this.saturationSlider_.setMinimum(0);
+  this.saturationSlider_.setMaximum(1.0);
   this.saturationSlider_.render(div);
 
   var brightnessElements = this.createLabelDom_(
@@ -316,7 +310,7 @@ Blockly.FieldColourSlider.prototype.showEditor_ = function() {
   div.appendChild(brightnessElements[0]);
   this.brightnessReadout_ = brightnessElements[1];
   this.brightnessSlider_ = new goog.ui.Slider();
-  this.brightnessSlider_.setUnitIncrement(1);
+  this.brightnessSlider_.setUnitIncrement(2);
   this.brightnessSlider_.setMinimum(0);
   this.brightnessSlider_.setMaximum(255);
   this.brightnessSlider_.setMoveToPointEnabled(true);


### PR DESCRIPTION
### Resolves
https://github.com/LLK/scratch-blocks/issues/1381

Expectation:
Users expect behavior to mimic that of color picker found in paint editor.
Upon tapping or clicking in the color range of the slider, the thumb should move to that position

Actual Behavior, 2 issues:
1) For hue and brightness the thumb moves incrementally while the mouse button is held down.
2) The saturation does not work at all and can only be adjusted by dragging the thumb.

### Proposed Changes
For issue 1:
a)  All 3 sliders ( Color, Saturation, Brightness ) should call setMoveToPointEnabled(true) .

For issue 2:
a)  orginal code was using range of  0 to 1 using step of 0.001.  However the sliderbase class rounds up steps so can only use steps of 1 or greater, this requires a max range to be scaled up as well, which in turn requires an external conversion (SATURATION_CONV) to be used to convert back to range of 0 to 1 outside the slider.  Note that this issue and solution is not enabled when setMoveToPointEnable(true) is called. 
However this fix should remain in case in future it is decided that incrementally thumb movement is desired again.
 
### Reason for Changes
Provide consistent color pick behavior with that on paint editor and as reported in
original issue on scratch-gui.


### Test Coverage
Test manually using Chromebrowser on test file
file://.../scratch-blocks/tests/vertical_playground.html

1) drag 'touching color' block from sensors category onto workspace.
2) click on color,  color picker dialog pop ups.
3) move mouse pointer to some part of colored range bar for each of Color, Saturation, Brightness
4) Click or press down on left mouse button.

Expectation:
-  thumb to move to position
- value to also be adjusted base on new thumb position
Results 
- passed with minor issue

Minior issue:
Repeated clicking in color range will cause thumb to move up and off of slider!
I traced this down to an issue with google ui sliderbase and its animation logic.
Issue will be submitted to github on that repo shortly later.
The issue is revealed because scratch uses thumb style property of margin-top: -1.
However, I believe this is a bug in google ui sliderbase.js, not in scratch code.

 


