### PR TITLE
Fix GUI issue #1474

### DIFF
--- a/core/css.js
+++ b/core/css.js
@@ -145,7 +145,7 @@ Blockly.Css.CONTENT = [
   '.blocklyWidgetDiv {',
     'display: none;',
     'position: absolute;',
-    'z-index: 99999;', /* big value for bootstrap3 compatibility */
+    'z-index: 1000;',
   '}',
 
   '.injectionDiv {',


### PR DESCRIPTION
### Resolves

[This issue (in LLK/scratch-gui)](https://github.com/LLK/scratch-gui/issues/1474)

### Proposed Changes

Prevents `blocklyWidgetDiv` from coming over the stage.
![image](https://user-images.githubusercontent.com/3812168/36502902-53b12818-1719-11e8-9b26-0059b8c15a8a.png)

### Reason for Changes

To stop `blocklyWidgetDiv`s (such as text fields in blocks) from coming over the stage.

### Test Coverage

Tested in Chrome console
