### PR TITLE
Use the parent SVG to get the blocks area.

### DIFF
--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1108,7 +1108,11 @@ Blockly.WorkspaceSvg.prototype.recordDeleteAreas_ = function() {
  * @private
  */
 Blockly.WorkspaceSvg.prototype.recordBlocksArea_ = function() {
-  var bounds = this.svgGroup_.getBoundingClientRect();
+  if (!this.getParentSvg()) {
+    this.blocksArea_ = null;
+    return;
+  }
+  var bounds = this.getParentSvg().getBoundingClientRect();
   this.blocksArea_ = new goog.math.Rect(bounds.left, bounds.top, bounds.width, bounds.height);
 };
 

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1108,12 +1108,13 @@ Blockly.WorkspaceSvg.prototype.recordDeleteAreas_ = function() {
  * @private
  */
 Blockly.WorkspaceSvg.prototype.recordBlocksArea_ = function() {
-  if (!this.getParentSvg()) {
+  var parentSvg = this.getParentSvg();
+  if (parentSvg) {
+    var bounds = parentSvg.getBoundingClientRect();
+    this.blocksArea_ = new goog.math.Rect(bounds.left, bounds.top, bounds.width, bounds.height);
+  } else {
     this.blocksArea_ = null;
-    return;
   }
-  var bounds = this.getParentSvg().getBoundingClientRect();
-  this.blocksArea_ = new goog.math.Rect(bounds.left, bounds.top, bounds.width, bounds.height);
 };
 
 /**


### PR DESCRIPTION
The parent SVG doesn't include the space taken up by blocks.

### Resolves
Resolves https://github.com/LLK/scratch-blocks/issues/1392
