### PR TITLE
Add for-each block

### DIFF
--- a/blocks_vertical/control.js
+++ b/blocks_vertical/control.js
@@ -296,6 +296,39 @@ Blockly.Blocks['control_repeat_until'] = {
   }
 };
 
+Blockly.Blocks['control_for_each'] = {
+  /**
+   * Block for for-each. This is an obsolete block that is implemented for
+   * compatibility with Scratch 2.0 projects.
+   * @this Blockly.Block
+   */
+  init: function() {
+    this.jsonInit({
+      "type": "control_for_each",
+      "message0": "for each %1 in %2",
+      "message1": "%1",
+      "args0": [
+        {
+          "type": "field_variable",
+          "name": "VARIABLE"
+        },
+        {
+          "type": "input_value",
+          "name": "VALUE"
+        }
+      ],
+      "args1": [
+        {
+          "type": "input_statement",
+          "name": "SUBSTACK"
+        }
+      ],
+      "category": Blockly.Categories.control,
+      "extensions": ["colours_control", "shape_statement"]
+    })
+  }
+};
+
 Blockly.Blocks['control_start_as_clone'] = {
   /**
    * Block for "when I start as a clone" hat.

--- a/blocks_vertical/control.js
+++ b/blocks_vertical/control.js
@@ -334,7 +334,7 @@ Blockly.Blocks['control_for_each'] = {
       ],
       "category": Blockly.Categories.control,
       "extensions": ["colours_control", "shape_statement"]
-    })
+    });
   }
 };
 

--- a/blocks_vertical/default_toolbox.js
+++ b/blocks_vertical/default_toolbox.js
@@ -344,13 +344,6 @@ Blockly.Blocks.defaultToolbox = '<xml id="toolbox-categories" style="display: no
     '<block type="control_if_else" id="control_if_else"></block>'+
     '<block type="control_wait_until" id="control_wait_until"></block>'+
     '<block type="control_repeat_until" id="control_repeat_until"></block>'+
-    '<block type="control_for_each" id="control_for_each">'+
-      '<value name="VALUE">'+
-        '<shadow type="text">'+
-          '<field name="TEXT">abc</field>'+
-        '</shadow>'+
-      '</value>'+
-    '</block>'+
     '<block type="control_stop" id="control_stop"></block>'+
     '<block type="control_start_as_clone" id="control_start_as_clone"></block>'+
     '<block type="control_create_clone_of" id="control_create_clone_of">'+

--- a/blocks_vertical/default_toolbox.js
+++ b/blocks_vertical/default_toolbox.js
@@ -344,6 +344,13 @@ Blockly.Blocks.defaultToolbox = '<xml id="toolbox-categories" style="display: no
     '<block type="control_if_else" id="control_if_else"></block>'+
     '<block type="control_wait_until" id="control_wait_until"></block>'+
     '<block type="control_repeat_until" id="control_repeat_until"></block>'+
+    '<block type="control_for_each" id="control_for_each">'+
+      '<value name="VALUE">'+
+        '<shadow type="text">'+
+          '<field name="TEXT">abc</field>'+
+        '</shadow>'+
+      '</value>'+
+    '</block>'+
     '<block type="control_stop" id="control_stop"></block>'+
     '<block type="control_start_as_clone" id="control_start_as_clone"></block>'+
     '<block type="control_create_clone_of" id="control_create_clone_of">'+


### PR DESCRIPTION
### Resolves

Towards LLK/scratch-vm#959. Should be merged before LLK/scratch-vm#963 (do read that PR as well).

### Proposed Changes

Adds a "for each" block to the Control category:

![For each (i) in (abc)](https://user-images.githubusercontent.com/9948030/36997817-403249c6-2091-11e8-8d7b-3c60081bf7ed.png)

Both strings and numbers may go in the "abc" input.

The block is also placed into the block palette, below "repeat until".

### Reason for Changes

Compatibility with Scratch 2.0 projects that include the hacked "for in" block. (See LLK/scratch-vm#959.)

The block is placed into the palette for the sake of testing, but this can easily be reverted if it's preferred to be hidden. I have made an identical change in the GUI's default block palette so I could test the VM code for this, which I can make a PR for, if wanted.

### Test Coverage

No new tests. Manually tested (variable dropdown does behave like a variable dropdown, anything can be typed in the text input).