### PR TITLE
Remove 'help' option from block context menu

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -764,8 +764,6 @@ Blockly.BlockSvg.prototype.showContextMenu_ = function(e) {
     return;
   }
 
-  menuOptions.push(Blockly.ContextMenu.blockHelpOption(block));
-
   // Allow the block to add or modify menuOptions.
   if (this.customContextMenu) {
     this.customContextMenu(menuOptions);


### PR DESCRIPTION
### Resolves

Resolves #1397.

### Proposed Changes

Removes the "help" option from blocks. The actual `blockHelpOption` function is still left in the codebase, so that it's easier to add back the help option.

### Reason for Changes

As per @thisandagain:

>When right clicking on a block you currently get a disabled "help" option in the contextual menu. Until we have a design / solution for "block help" this should be removed.

### Test Coverage

Manually tested locally. I noticed that blocks in the block palette don't create context menus at all, since without the "help" option their menus are empty. Blocks that are in the block area still have their other options (duplicate, delete).