### PR TITLE
Prevent jumping up a category when switching sprites

### DIFF
--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -556,11 +556,11 @@ Blockly.Flyout.prototype.selectCategoryByScrollPosition = function(pos) {
   if (this.scrollTarget) {
     return;
   }
-  var workspacePos = pos / this.workspace_.scale;
+  var workspacePos = Math.round(pos / this.workspace_.scale);
   // Traverse the array of scroll positions in reverse, so we can select the furthest
   // category that the scroll position is beyond.
   for (var i = this.categoryScrollPositions.length - 1; i >= 0; i--) {
-    if (workspacePos > this.categoryScrollPositions[i].position) {
+    if (workspacePos >= this.categoryScrollPositions[i].position) {
       this.parentToolbox_.selectCategoryByName(this.categoryScrollPositions[i].categoryName);
       return;
     }


### PR DESCRIPTION
### Resolves

Resolves https://github.com/LLK/scratch-gui/issues/1221

### Proposed Changes

Prevent a small numeric error when selecting blocks category by scroll position. 

### Reason for Changes

Previously, before switching sprites, the scroll position could be very slight above the recorded scroll position of the current category, so that after switching sprites it would jump up by one category. Here I round the position and use `>=` to make sure we stay on the same category when switching sprites.