### PR TITLE
Fix empty moniters

### DIFF
--- a/core/css.js
+++ b/core/css.js
@@ -246,6 +246,7 @@ Blockly.Css.CONTENT = [
     'box-shadow: 0px 0px 8px 1px ' + Blockly.Colours.dropDownShadow + ';',
     'padding: 4px;',
     '-webkit-user-select: none;',
+    'min-height: 26px',
   '}',
 
   '.blocklyDropDownContent {',


### PR DESCRIPTION
### Resolves

#1227 
### Proposed Changes

Makes empty monitors have a `min-height` of `26px`

### Reason for Changes

Without this, empty monitors look like this:
![image](https://user-images.githubusercontent.com/2855464/32634142-2f15c4de-c578-11e7-9abe-8ceed8bf69df.png)
