### PR TITLE
Add min-height to empty monitors

### DIFF
--- a/core/css.js
+++ b/core/css.js
@@ -246,7 +246,7 @@ Blockly.Css.CONTENT = [
     'box-shadow: 0px 0px 8px 1px ' + Blockly.Colours.dropDownShadow + ';',
     'padding: 4px;',
     '-webkit-user-select: none;',
-    'min-height: 26px',
+    'min-height: 15px',
   '}',
 
   '.blocklyDropDownContent {',


### PR DESCRIPTION
### Resolves

#1227

Let me explain. When I made pull request #1402, I didn't realize that this would actually break something else. This new pull request hopefully fixes the damage from #1402, as well as fixing #1227

### Proposed Changes

Makes empty monitors have a `min-height` of `15px`

### Reason for Changes

Without this, empty monitors look like this:
![image](https://user-images.githubusercontent.com/2855464/32634142-2f15c4de-c578-11e7-9abe-8ceed8bf69df.png)