### PR TITLE
Don’t scroll the toolbox to the top on populate

### DIFF
--- a/core/toolbox.js
+++ b/core/toolbox.js
@@ -183,7 +183,7 @@ Blockly.Toolbox.prototype.createFlyout_ = function() {
 Blockly.Toolbox.prototype.populate_ = function(newTree) {
   this.categoryMenu_.populate(newTree);
   this.showAll_();
-  this.setSelectedItem(this.categoryMenu_.categories_[0]);
+  this.setSelectedItem(this.categoryMenu_.categories_[0], false);
 };
 
 /**
@@ -340,8 +340,12 @@ Blockly.Toolbox.prototype.getSelectedItem = function() {
 /**
  * Set the currently selected category.
  * @param {Blockly.Toolbox.Category} item The category to select.
+ * @param {boolean} [shouldScroll=true] Whether or not to scroll to the selected category.
  */
-Blockly.Toolbox.prototype.setSelectedItem = function(item) {
+Blockly.Toolbox.prototype.setSelectedItem = function(item, shouldScroll) {
+  if (typeof shouldScroll === 'undefined') {
+    shouldScroll = true;
+  }
   if (this.selectedItem_) {
     // They selected a different category but one was already open.  Close it.
     this.selectedItem_.setSelected(false);
@@ -351,7 +355,9 @@ Blockly.Toolbox.prototype.setSelectedItem = function(item) {
     this.selectedItem_.setSelected(true);
     // Scroll flyout to the top of the selected category
     var categoryName = item.name_;
-    this.scrollToCategoryByName(categoryName);
+    if (shouldScroll) {
+      this.scrollToCategoryByName(categoryName);
+    }
   }
 };
 

--- a/core/toolbox.js
+++ b/core/toolbox.js
@@ -340,7 +340,7 @@ Blockly.Toolbox.prototype.getSelectedItem = function() {
 /**
  * Set the currently selected category.
  * @param {Blockly.Toolbox.Category} item The category to select.
- * @param {boolean} [shouldScroll=true] Whether or not to scroll to the selected category.
+ * @param {boolean=} opt_shouldScroll Whether to scroll to the selected category. Defaults to true.
  */
 Blockly.Toolbox.prototype.setSelectedItem = function(item, shouldScroll) {
   if (typeof shouldScroll === 'undefined') {

--- a/core/toolbox.js
+++ b/core/toolbox.js
@@ -342,9 +342,9 @@ Blockly.Toolbox.prototype.getSelectedItem = function() {
  * @param {Blockly.Toolbox.Category} item The category to select.
  * @param {boolean=} opt_shouldScroll Whether to scroll to the selected category. Defaults to true.
  */
-Blockly.Toolbox.prototype.setSelectedItem = function(item, shouldScroll) {
-  if (typeof shouldScroll === 'undefined') {
-    shouldScroll = true;
+Blockly.Toolbox.prototype.setSelectedItem = function(item, opt_shouldScroll) {
+  if (typeof opt_shouldScroll === 'undefined') {
+    opt_shouldScroll = true;
   }
   if (this.selectedItem_) {
     // They selected a different category but one was already open.  Close it.
@@ -355,7 +355,7 @@ Blockly.Toolbox.prototype.setSelectedItem = function(item, shouldScroll) {
     this.selectedItem_.setSelected(true);
     // Scroll flyout to the top of the selected category
     var categoryName = item.name_;
-    if (shouldScroll) {
+    if (opt_shouldScroll) {
       this.scrollToCategoryByName(categoryName);
     }
   }


### PR DESCRIPTION
### Resolves

Resolves https://github.com/LLK/scratch-blocks/issues/1401

### Proposed Changes

Add an optional parameter to setSelectedItem for whether or not to scroll to the new category, defaulting to true. Other calls to setSelectedItem work the same, but now the populate function does not cause a scroll.

### Reason for Changes

This prevents the problem where switching sprites scrolled to the top and then back down to the selected category.

There's still scrolling when switching to or from the stage, but that's for a different reason, and will require a different fix.