### PR TITLE
Fix issue #1095

### DIFF
--- a/core/block.js
+++ b/core/block.js
@@ -1513,7 +1513,7 @@ Blockly.Block.newFieldImageFromJson_ = function(options) {
   var height =
     Number(Blockly.utils.replaceMessageReferences(options['height']));
   var alt = Blockly.utils.replaceMessageReferences(options['alt']);
-  var flip_rtl = !!options['flip_rtl'];
+  var flip_rtl = !!options['flip_rtl'] || !!options['flipRtl'];
   return new Blockly.FieldImage(src, width, height, alt, flip_rtl);
 };
 

--- a/core/xml.js
+++ b/core/xml.js
@@ -345,21 +345,10 @@ Blockly.Xml.domToPrettyText = function(dom) {
  * @param {string} text Text representation.
  * @return {!Element} A tree of XML elements.
  */
- function hackReplaceFlipRtl(text){
-	 
-	 function replacer(match, p1, p2, p3, offset, string){
-		 
-		return("flipRtl"); 
-		 
-	 };
-	 
-	 return(text.replace(/flip\_rtl/,replacer));
-	 
- };
- 
+
 Blockly.Xml.textToDom = function(text) {
   var oParser = new DOMParser();
-  var dom = oParser.parseFromString(hackReplaceFlipRtl(text), 'text/xml');
+  var dom = oParser.parseFromString(text, 'text/xml');
   // The DOM should have one and only one top-level node, an XML tag.
   if (!dom || !dom.firstChild ||
       dom.firstChild.nodeName.toLowerCase() != 'xml' ||

--- a/core/xml.js
+++ b/core/xml.js
@@ -345,9 +345,21 @@ Blockly.Xml.domToPrettyText = function(dom) {
  * @param {string} text Text representation.
  * @return {!Element} A tree of XML elements.
  */
+ function hackReplaceFlipRtl(text){
+	 
+	 function replacer(match, p1, p2, p3, offset, string){
+		 
+		return("flipRtl"); 
+		 
+	 };
+	 
+	 return(text.replace(/flip\_rtl/,replacer));
+	 
+ };
+ 
 Blockly.Xml.textToDom = function(text) {
   var oParser = new DOMParser();
-  var dom = oParser.parseFromString(text, 'text/xml');
+  var dom = oParser.parseFromString(hackReplaceFlipRtl(text), 'text/xml');
   // The DOM should have one and only one top-level node, an XML tag.
   if (!dom || !dom.firstChild ||
       dom.firstChild.nodeName.toLowerCase() != 'xml' ||

--- a/core/xml.js
+++ b/core/xml.js
@@ -345,7 +345,6 @@ Blockly.Xml.domToPrettyText = function(dom) {
  * @param {string} text Text representation.
  * @return {!Element} A tree of XML elements.
  */
-
 Blockly.Xml.textToDom = function(text) {
   var oParser = new DOMParser();
   var dom = oParser.parseFromString(text, 'text/xml');


### PR DESCRIPTION
### Resolves

Fixes issue #1095 by adding support for both "flip_rtl" and "flipRtl" in the JSON fields. The actual fields in question weren't changed.

### Proposed Changes
### Reason for Changes
_Explain why these changes should be made_

For more context on what flipRtl does, see issue #1095

### Test Coverage

To test my changes, I went into the block JSON and changed "flip_rtl" into "flipRtl". There were no errors. This was done for both horizontal and vertical blocks.

This was just a test, though. Like I said, the actual JSON remains unchanged.
