### PR TITLE
Support for scroll position stability

### DIFF
--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -595,9 +595,9 @@ Blockly.Flyout.prototype.stepScrollAnimation = function() {
  * @return {number} The current scroll position.
  */
 Blockly.Flyout.prototype.getScrollPos = function() {
-    var pos = this.horizontalLayout_ ?
-      -this.workspace_.scrollX : -this.workspace_.scrollY;
-    return pos / this.workspace_.scale;
+  var pos = this.horizontalLayout_ ?
+    -this.workspace_.scrollX : -this.workspace_.scrollY;
+  return pos / this.workspace_.scale;
 };
 
 /**

--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -591,6 +591,24 @@ Blockly.Flyout.prototype.stepScrollAnimation = function() {
 };
 
 /**
+ * Get the scaled scroll position.
+ * @return {number} The current scroll position.
+ */
+Blockly.Flyout.prototype.getScrollPos = function() {
+    var pos = this.horizontalLayout_ ?
+      -this.workspace_.scrollX : -this.workspace_.scrollY;
+    return pos / this.workspace_.scale;
+};
+
+/**
+ * Set the scroll position, scaling it.
+ * @param {number} pos The scroll position to set.
+ */
+Blockly.Flyout.prototype.setScrollPos = function(pos) {
+  this.scrollbar_.set(pos * this.workspace_.scale);
+};
+
+/**
  * Delete blocks and background buttons from a previous showing of the flyout.
  * @private
  */

--- a/core/toolbox.js
+++ b/core/toolbox.js
@@ -338,6 +338,45 @@ Blockly.Toolbox.prototype.getSelectedItem = function() {
 };
 
 /**
+ * @return {string} The name of the currently selected category.
+ */
+Blockly.Toolbox.prototype.getSelectedCategoryName = function() {
+  return this.selectedItem_.name_;
+};
+
+/**
+ * @return {number} The distance flyout is scrolled below the top of the currently
+ * selected category.
+ */
+Blockly.Toolbox.prototype.getCategoryScrollOffset = function() {
+  var categoryPos = this.getCategoryPositionByName(this.getSelectedCategoryName());
+  return this.flyout_.getScrollPos() - categoryPos;
+};
+
+/**
+ * Get the position of a category by name.
+ * @param  {string} name The name of the category.
+ * @return {number} The position of the category.
+ */
+Blockly.Toolbox.prototype.getCategoryPositionByName = function(name) {
+  var scrollPositions = this.flyout_.categoryScrollPositions;
+  for (var i = 0; i < scrollPositions.length; i++) {
+    if (name === scrollPositions[i].categoryName) {
+      return scrollPositions[i].position;
+    }
+  }
+};
+
+/**
+ * Set the scroll position of the flyout.
+ * @param {number} pos The position to set.
+ */
+Blockly.Toolbox.prototype.setFlyoutScrollPos = function(pos) {
+  this.flyout_.setScrollPos(pos);
+};
+
+
+/**
  * Set the currently selected category.
  * @param {Blockly.Toolbox.Category} item The category to select.
  * @param {boolean} [shouldScroll=true] Whether or not to scroll to the selected category.


### PR DESCRIPTION
### Resolves

Progress on https://github.com/LLK/scratch-blocks/issues/1406, which will also require a [GUI PR](https://github.com/LLK/scratch-gui/pull/1620).

### Proposed Changes

Add some functions to support more stable scroll position behavior when switching sprites. These include:

- get and set scaled position of the flyout
- get name of the current category
- get the scroll offset from the top of the current category
- get position of a category by name