### PR TITLE
Seconds secs

### DIFF
--- a/blocks_vertical/control.js
+++ b/blocks_vertical/control.js
@@ -232,7 +232,7 @@ Blockly.Blocks['control_wait'] = {
   init: function() {
     this.jsonInit({
       "id": "control_wait",
-      "message0": "wait %1 seconds",
+      "message0": "wait %1 secs",
       "args0": [
         {
           "type": "input_value",

--- a/blocks_vertical/looks.js
+++ b/blocks_vertical/looks.js
@@ -35,7 +35,7 @@ Blockly.Blocks['looks_sayforsecs'] = {
    */
   init: function() {
     this.jsonInit({
-      "message0": "say %1 for %2 seconds",
+      "message0": "say %1 for %2 secs",
       "args0": [
         {
           "type": "input_value",
@@ -79,7 +79,7 @@ Blockly.Blocks['looks_thinkforsecs'] = {
    */
   init: function() {
     this.jsonInit({
-      "message0": "think %1 for %2 seconds",
+      "message0": "think %1 for %2 secs",
       "args0": [
         {
           "type": "input_value",


### PR DESCRIPTION
### Resolves

#1410 

### Proposed Changes

Changes "seconds" to "secs" in `control_wait`, `looks_sayforsecs` and `looks_thinkforsecs`

### Reason for Changes

This is the way it is in Scratch 2.0, and blocks get really long with seconds.

