### PR TITLE
Improve visibility of stack glow

### DIFF
--- a/core/colours.js
+++ b/core/colours.js
@@ -96,8 +96,10 @@ Blockly.Colours = {
   "insertionMarkerOpacity": 0.2,
   "dragShadowOpacity": 0.3,
   "stackGlow": "#FFF200",
+  "stackGlowSize": 1.3,
   "stackGlowOpacity": 1,
   "replacementGlow": "#FFFFFF",
+  "replacementGlowSize": 2,
   "replacementGlowOpacity": 1,
   "colourPickerStroke": "#FFFFFF",
   // CSS colours: support RGBA

--- a/core/colours.js
+++ b/core/colours.js
@@ -96,7 +96,7 @@ Blockly.Colours = {
   "insertionMarkerOpacity": 0.2,
   "dragShadowOpacity": 0.3,
   "stackGlow": "#FFF200",
-  "stackGlowSize": 1.3,
+  "stackGlowSize": 4,
   "stackGlowOpacity": 1,
   "replacementGlow": "#FFFFFF",
   "replacementGlowSize": 2,

--- a/core/constants.js
+++ b/core/constants.js
@@ -245,20 +245,6 @@ Blockly.OUTPUT_SHAPE_ROUND = 2;
 Blockly.OUTPUT_SHAPE_SQUARE = 3;
 
 /**
- * Radius of stack glow, in px.
- * @type {number}
- * @const
- */
-Blockly.STACK_GLOW_RADIUS = 1.3;
-
-/**
- * Radius of replacement glow, in px.
- * @type {number}
- * @const
- */
-Blockly.REPLACEMENT_GLOW_RADIUS = 2;
-
-/**
  * ENUM for categories.
  * @const
  */

--- a/core/inject.js
+++ b/core/inject.js
@@ -135,7 +135,7 @@ Blockly.createDom_ = function(container, options) {
         'height': '160%', 'width': '180%', y: '-30%', x: '-40%'}, defs);
   options.stackGlowBlur = Blockly.utils.createSvgElement('feGaussianBlur',
       {'in': 'SourceGraphic',
-      'stdDeviation': Blockly.STACK_GLOW_RADIUS}, stackGlowFilter);
+      'stdDeviation': Blockly.Colours.stackGlowSize}, stackGlowFilter);
   // Set all gaussian blur pixels to 1 opacity before applying flood
   var componentTransfer = Blockly.utils.createSvgElement('feComponentTransfer', {'result': 'outBlur'}, stackGlowFilter);
   Blockly.utils.createSvgElement('feFuncA',
@@ -156,7 +156,7 @@ Blockly.createDom_ = function(container, options) {
         'height': '160%', 'width': '180%', y: '-30%', x: '-40%'}, defs);
   Blockly.utils.createSvgElement('feGaussianBlur',
       {'in': 'SourceGraphic',
-      'stdDeviation': Blockly.REPLACEMENT_GLOW_RADIUS}, replacementGlowFilter);
+      'stdDeviation': Blockly.Colours.replacementGlowSize}, replacementGlowFilter);
   // Set all gaussian blur pixels to 1 opacity before applying flood
   var componentTransfer = Blockly.utils.createSvgElement('feComponentTransfer',
       {'result': 'outBlur'}, replacementGlowFilter);

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1658,7 +1658,7 @@ Blockly.WorkspaceSvg.prototype.updateStackGlowScale_ = function() {
   // No such def in the flyout workspace.
   if (this.options.stackGlowBlur) {
     this.options.stackGlowBlur.setAttribute('stdDeviation',
-      Blockly.STACK_GLOW_RADIUS / this.scale
+      Blockly.Colours.stackGlowSize / this.scale
     );
   }
 };


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Resolves https://github.com/LLK/scratch-blocks/issues/1378

### Proposed Changes

_Describe what this Pull Request does_

Increases the default stack glow size, and also makes it externally settable like the rest of the stack glow params (color, opacity). Depending on background color, a different stack glow size might be better.

I also moved out the "replacement glow size" parameter, which is used in the horizontal grammar, just to be consistent. I did not change its value, however.