### PR TITLE
Add "item # of (thing) in (list)" block

### DIFF
--- a/blocks_vertical/data.js
+++ b/blocks_vertical/data.js
@@ -363,6 +363,33 @@ Blockly.Blocks['data_itemoflist'] = {
   }
 };
 
+Blockly.Blocks['data_itemnumoflist'] = {
+  /**
+   * Block for reporting the item # of a string in a list.
+   * @this Blockly.Block
+   */
+  init: function() {
+    this.jsonInit({
+      "message0": "item # of %1 in %2",
+      "args0": [
+        {
+          "type": "input_value",
+          "name": "ITEM"
+        },
+        {
+          "type": "field_variable",
+          "name": "LIST",
+          "variableTypes": [Blockly.LIST_VARIABLE_TYPE]
+        }
+      ],
+      "output": null,
+      "category": Blockly.Categories.dataLists,
+      "extensions": ["colours_data_lists"],
+      "outputShape": Blockly.OUTPUT_SHAPE_ROUND
+    });
+  }
+};
+
 Blockly.Blocks['data_lengthoflist'] = {
   /**
    * Block for reporting length of list.

--- a/core/data_category.js
+++ b/core/data_category.js
@@ -79,6 +79,7 @@ Blockly.DataCategory = function(workspace) {
     Blockly.DataCategory.addInsertAtList(xmlList, firstVariable);
     Blockly.DataCategory.addReplaceItemOfList(xmlList, firstVariable);
     Blockly.DataCategory.addItemOfList(xmlList, firstVariable);
+    Blockly.DataCategory.addItemNumberOfList(xmlList, firstVariable);
     Blockly.DataCategory.addLengthOfList(xmlList, firstVariable);
     Blockly.DataCategory.addListContainsItem(xmlList, firstVariable);
     // TODO (#1276): uncomment these when their implementations are finished.
@@ -285,6 +286,23 @@ Blockly.DataCategory.addItemOfList = function(xmlList, variable) {
   // </block>
   Blockly.DataCategory.addBlock(xmlList, variable, 'data_itemoflist', 'LIST',
     ['INDEX', 'math_integer', 1]);
+};
+
+/** Construct and add a data_itemnumoflist block to xmlList.
+ * @param {!Array.<!Element>} xmlList Array of XML block elements.
+ * @param {?Blockly.VariableModel} variable Variable to select in the field.
+ */
+Blockly.DataCategory.addItemNumberOfList = function(xmlList, variable) {
+  // <block type="data_itemnumoflist">
+  //   <value name="ITEM">
+  //     <shadow type="text">
+  //       <field name="TEXT">thing</field>
+  //     </shadow>
+  //   </value>
+  //   <field name="LIST" variabletype="list" id="">variablename</field>
+  // </block>
+  Blockly.DataCategory.addBlock(xmlList, variable, 'data_itemnumoflist',
+    'LIST', ['ITEM', 'text', 'thing']);
 };
 
 /**


### PR DESCRIPTION
### Resolves

Towards LLK/scratch-gui#600. This should be merged alongside LLK/scratch-vm#1008, which contains the functionality of this block.

### Proposed Changes

Adds the "item # of (thing) in (list)" block, where "(thing)" is a text input and "(list)" is a list selection. This block is added to the palette alongside the other list blocks, and is placed below the "item (1) of (list)" block (per the spec).

### Reason for Changes

To implement the help-wanted feature.

### Test Coverage

Tested manually. Lint says this looks good!