### PR TITLE
Add "while" block

### DIFF
--- a/blocks_vertical/control.js
+++ b/blocks_vertical/control.js
@@ -268,11 +268,52 @@ Blockly.Blocks['control_wait_until'] = {
 
 Blockly.Blocks['control_repeat_until'] = {
   /**
-   * Block for repeat until a condition becomes true.
+   * Block to repeat until a condition becomes true.
+   * @this Blockly.Block
    */
   init: function() {
     this.jsonInit({
       "message0": "repeat until %1",
+      "message1": "%1",
+      "message2": "%1",
+      "lastDummyAlign2": "RIGHT",
+      "args0": [
+        {
+          "type": "input_value",
+          "name": "CONDITION",
+          "check": "Boolean"
+        }
+      ],
+      "args1": [
+        {
+          "type": "input_statement",
+          "name": "SUBSTACK"
+        }
+      ],
+      "args2": [
+        {
+          "type": "field_image",
+          "src": Blockly.mainWorkspace.options.pathToMedia + "repeat.svg",
+          "width": 24,
+          "height": 24,
+          "alt": "*",
+          "flip_rtl": true
+        }
+      ],
+      "category": Blockly.Categories.control,
+      "extensions": ["colours_control", "shape_statement"]
+    });
+  }
+};
+
+Blockly.Blocks['control_while'] = {
+  /**
+   * Block to repeat until a condition becomes false.
+   * (This is an obsolete "hacked" block, for compatibility with 2.0.)
+   */
+  init: function() {
+    this.jsonInit({
+      "message0": "while %1",
       "message1": "%1",
       "message2": "%1",
       "lastDummyAlign2": "RIGHT",


### PR DESCRIPTION
### Resolves

Towards LLK/scratch-vm#355 (adds "doWhile"). Should be merged alongside LLK/scratch-vm#1032.

### Proposed Changes

Adds a `control_while` block. (This block isn't added to the block palette because it's a hacked, compatibility-purpose block. Naturally, it's functionally equivalent to "repeat until (not (condition))".)

![An empty "while" block](https://user-images.githubusercontent.com/9948030/38457959-ec8e5fe8-3a6d-11e8-9648-4d6b51575d65.png)

### Reason for Changes

Compatibility with Scratch 2.0 projects. This is a hacked block; in total, [1505 projects use the `while` loop](https://github.com/LLK/scratch-vm/issues/355#issuecomment-379418752).

### Test Coverage

No new tests, but tested manually (see VM PR).