### PR TITLE
Add counter blocks

### DIFF
--- a/blocks_vertical/control.js
+++ b/blocks_vertical/control.js
@@ -414,3 +414,48 @@ Blockly.Blocks['control_delete_this_clone'] = {
     });
   }
 };
+
+Blockly.Blocks['control_get_counter'] = {
+  /**
+   * Block to get the counter value. This is an obsolete block that is
+   * implemented for compatibility with Scratch 2.0 projects.
+   * @this Blockly.Block
+   */
+  init: function() {
+    this.jsonInit({
+      "message0": "counter",
+      "category": Blockly.Categories.control,
+      "extensions": ["colours_control", "output_number"]
+    });
+  }
+};
+
+Blockly.Blocks['control_incr_counter'] = {
+  /**
+   * Block to add one to the counter value. This is an obsolete block that is
+   * implemented for compatibility with Scratch 2.0 projects.
+   * @this Blockly.Block
+   */
+  init: function() {
+    this.jsonInit({
+      "message0": "incr counter",
+      "category": Blockly.Categories.control,
+      "extensions": ["colours_control", "shape_statement"]
+    });
+  }
+};
+
+Blockly.Blocks['control_clear_counter'] = {
+  /**
+   * Block to clear the counter value. This is an obsolete block that is
+   * implemented for compatibility with Scratch 2.0 projects.
+   * @this Blockly.Block
+   */
+  init: function() {
+    this.jsonInit({
+      "message0": "clear counter",
+      "category": Blockly.Categories.control,
+      "extensions": ["colours_control", "shape_statement"]
+    });
+  }
+};


### PR DESCRIPTION
### Resolves

Towards LLK/scratch-vm#355 (adds counter blocks). Should be merged alongside LLK/scratch-vm#1033.

### Proposed Changes

Adds three blocks: `control_get_counter`, `control_incr_counter`, and `control_clear_counter`. (These aren't added to the block palette, because they're hacked, compatibility-purpose blocks. Variables work just as well as these.)

![The three new blocks: "counter", "incr counter", "clear counter"](https://user-images.githubusercontent.com/9948030/38459340-c244cae0-3a7e-11e8-9b12-01940591e3e3.png)

### Reason for Changes

Compatibility with Scratch 2.0 projects. These are hacked blocks; in total, [around 1000 projects use the counter blocks](https://github.com/LLK/scratch-vm/issues/355#issuecomment-379418752).

### Test Coverage

No new tests, but tested manually (see VM PR).
