### PR TITLE
Fix shadow block IDs for procedure call blocks

### DIFF
--- a/blocks_vertical/procedures.js
+++ b/blocks_vertical/procedures.js
@@ -56,6 +56,8 @@ Blockly.ScratchBlocks.ProcedureUtils.callerMutationToDom = function() {
  */
 Blockly.ScratchBlocks.ProcedureUtils.callerDomToMutation = function(xmlElement) {
   this.procCode_ = xmlElement.getAttribute('proccode');
+  this.generateShadows_ =
+      JSON.parse(xmlElement.getAttribute('generateShadows'));
   this.argumentIds_ = JSON.parse(xmlElement.getAttribute('argumentids'));
   this.warp_ = JSON.parse(xmlElement.getAttribute('warp'));
   this.updateDisplay_();
@@ -382,11 +384,11 @@ Blockly.ScratchBlocks.ProcedureUtils.populateArgumentOnCaller_ = function(type,
     // Reattach the old block.
     connectionMap[input.name] = null;
     oldBlock.outputConnection.connect(input.connection);
-    if (type != 'b') {
+    if (type != 'b' && this.generateShadows_) {
       // TODO: Preserve old shadow DOM.
       input.connection.setShadowDom(this.buildShadowDom_(type));
     }
-  } else {
+  } else if (this.generateShadows_) {
     this.attachShadow_(input, type);
   }
 };

--- a/blocks_vertical/procedures.js
+++ b/blocks_vertical/procedures.js
@@ -57,7 +57,7 @@ Blockly.ScratchBlocks.ProcedureUtils.callerMutationToDom = function() {
 Blockly.ScratchBlocks.ProcedureUtils.callerDomToMutation = function(xmlElement) {
   this.procCode_ = xmlElement.getAttribute('proccode');
   this.generateShadows_ =
-      JSON.parse(xmlElement.getAttribute('generateShadows'));
+      JSON.parse(xmlElement.getAttribute('generateshadows'));
   this.argumentIds_ = JSON.parse(xmlElement.getAttribute('argumentids'));
   this.warp_ = JSON.parse(xmlElement.getAttribute('warp'));
   this.updateDisplay_();
@@ -66,11 +66,18 @@ Blockly.ScratchBlocks.ProcedureUtils.callerDomToMutation = function(xmlElement) 
 /**
  * Create XML to represent the (non-editable) name and arguments of a
  * procedures_prototype block or a procedures_declaration block.
+ * @param {boolean=} opt_generateShadows Whether to include the generateshadows
+ *     flag in the generated XML.  False if not provided.
  * @return {!Element} XML storage element.
  * @this Blockly.Block
  */
-Blockly.ScratchBlocks.ProcedureUtils.definitionMutationToDom = function() {
+Blockly.ScratchBlocks.ProcedureUtils.definitionMutationToDom = function(
+    opt_generateShadows) {
   var container = document.createElement('mutation');
+
+  if (opt_generateShadows) {
+    container.setAttribute('generateshadows', true);
+  }
   container.setAttribute('proccode', this.procCode_);
   container.setAttribute('argumentids', JSON.stringify(this.argumentIds_));
   container.setAttribute('argumentnames', JSON.stringify(this.displayNames_));

--- a/core/procedures.js
+++ b/core/procedures.js
@@ -84,7 +84,7 @@ Blockly.Procedures.allProcedureMutations = function(root) {
   var mutations = [];
   for (var i = 0; i < blocks.length; i++) {
     if (blocks[i].type == Blockly.PROCEDURES_PROTOTYPE_BLOCK_TYPE) {
-      var mutation = blocks[i].mutationToDom();
+      var mutation = blocks[i].mutationToDom(/* opt_generateShadows */ true);
       if (mutation) {
         mutations.push(mutation);
       }

--- a/tests/custom_procedure_playground.html
+++ b/tests/custom_procedure_playground.html
@@ -164,7 +164,9 @@
     }
 
     function applyMutation() {
-      callback(mutationRoot.mutationToDom());
+      var mutation = mutationRoot.mutationToDom(/* opt_generateShadows */ true)
+      console.log(mutation);
+      callback(mutation);
       callback = null;
       mutationRoot = null;
       declarationWorkspace.clear();


### PR DESCRIPTION
### Resolves

https://github.com/LLK/scratch-vm/issues/1011
### Proposed Changes

Add a "generateShadows" attribute to the mutation parsing. Provide it when setting the mutation from the custom procedure editor callbacks. This makes the current code paths happen.

By default, do not generate shadow blocks when creating inputs. XML generated by scratch-blocks (when saving the project) and by scratch-vm (for loading a project) should not set "generateShadows". That means that a shadow block will not auto-generate, and the shadow DOM from the XML will be respected.
### Reason for Changes

See https://github.com/LLK/scratch-vm/issues/1011
### Test Coverage

Tested in the playground.