### PR TITLE
Replace goog.dom.removeNode with parentNode.removeChild

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -934,7 +934,7 @@ Blockly.BlockSvg.prototype.dispose = function(healStack, animate) {
   }
   Blockly.BlockSvg.superClass_.dispose.call(this, healStack);
 
-  goog.dom.removeNode(this.svgGroup_);
+  if (this.svgGroup_ && this.svgGroup_.parentNode) this.svgGroup_.parentNode.removeChild(this.svgGroup_);
   blockWorkspace.resizeContents();
   // Sever JavaScript to DOM connections.
   this.svgGroup_ = null;
@@ -983,7 +983,7 @@ Blockly.BlockSvg.disposeUiStep_ = function(clone, rtl, start, workspaceScale) {
   var ms = new Date - start;
   var percent = ms / 150;
   if (percent > 1) {
-    goog.dom.removeNode(clone);
+    if (clone && clone.parentNode) clone.parentNode.removeChild(clone);
   } else {
     var x = clone.translateX_ +
         (rtl ? -1 : 1) * clone.bBox_.width * workspaceScale / 2 * percent;

--- a/core/field.js
+++ b/core/field.js
@@ -223,7 +223,7 @@ Blockly.Field.prototype.dispose = function() {
     this.mouseDownWrapper_ = null;
   }
   this.sourceBlock_ = null;
-  goog.dom.removeNode(this.fieldGroup_);
+  if (this.fieldGroup_ && this.fieldGroup_.parentNode) this.fieldGroup_.parentNode.removeChild(this.fieldGroup_);
   this.fieldGroup_ = null;
   this.textElement_ = null;
   this.validator_ = null;

--- a/core/field_image.js
+++ b/core/field_image.js
@@ -94,7 +94,7 @@ Blockly.FieldImage.prototype.init = function() {
  * Dispose of all DOM objects belonging to this text.
  */
 Blockly.FieldImage.prototype.dispose = function() {
-  goog.dom.removeNode(this.fieldGroup_);
+  if (this.fieldGroup_ && this.fieldGroup_.parentNode) this.fieldGroup_.parentNode.removeChild(this.fieldGroup_);
   this.fieldGroup_ = null;
   this.imageElement_ = null;
 };

--- a/core/field_label.js
+++ b/core/field_label.js
@@ -97,7 +97,7 @@ Blockly.FieldLabel.prototype.init = function() {
  * Dispose of all DOM objects belonging to this text.
  */
 Blockly.FieldLabel.prototype.dispose = function() {
-  goog.dom.removeNode(this.textElement_);
+  if (this.textElement_ && this.textElement_.parentNode) this.textElement_.parentNode.removeChild(this.textElement_);
   this.textElement_ = null;
 };
 

--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -318,7 +318,7 @@ Blockly.Flyout.prototype.dispose = function() {
     this.workspace_ = null;
   }
   if (this.svgGroup_) {
-    goog.dom.removeNode(this.svgGroup_);
+    if (this.svgGroup_ && this.svgGroup_.parentNode) this.svgGroup_.parentNode.removeChild(this.svgGroup_);
     this.svgGroup_ = null;
   }
   this.parentToolbox_ = null;
@@ -623,7 +623,7 @@ Blockly.Flyout.prototype.clearOldBlocks_ = function() {
   // Delete any background buttons from a previous showing.
   for (var j = 0; j < this.backgroundButtons_.length; j++) {
     var rect = this.backgroundButtons_[j];
-    if (rect) goog.dom.removeNode(rect);
+    if (rect && rect.parentNode) rect.parentNode.removeChild(rect);
   }
   this.backgroundButtons_.length = 0;
 

--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -317,10 +317,8 @@ Blockly.Flyout.prototype.dispose = function() {
     this.workspace_.dispose();
     this.workspace_ = null;
   }
-  if (this.svgGroup_) {
-    if (this.svgGroup_ && this.svgGroup_.parentNode) this.svgGroup_.parentNode.removeChild(this.svgGroup_);
-    this.svgGroup_ = null;
-  }
+  if (this.svgGroup_ && this.svgGroup_.parentNode) this.svgGroup_.parentNode.removeChild(this.svgGroup_);
+  this.svgGroup_ = null;
   this.parentToolbox_ = null;
   this.svgBackground_ = null;
   this.targetWorkspace_ = null;

--- a/core/flyout_button.js
+++ b/core/flyout_button.js
@@ -254,10 +254,8 @@ Blockly.FlyoutButton.prototype.dispose = function() {
   if (this.onMouseUpWrapper_) {
     Blockly.unbindEvent_(this.onMouseUpWrapper_);
   }
-  if (this.svgGroup_) {
-    if (this.svgGroup_ && this.svgGroup_.parentNode) this.svgGroup_.parentNode.removeChild(this.svgGroup_);
-    this.svgGroup_ = null;
-  }
+  if (this.svgGroup_ && this.svgGroup_.parentNode) this.svgGroup_.parentNode.removeChild(this.svgGroup_);
+  this.svgGroup_ = null;
   this.workspace_ = null;
   this.targetWorkspace_ = null;
 };

--- a/core/flyout_button.js
+++ b/core/flyout_button.js
@@ -255,7 +255,7 @@ Blockly.FlyoutButton.prototype.dispose = function() {
     Blockly.unbindEvent_(this.onMouseUpWrapper_);
   }
   if (this.svgGroup_) {
-    goog.dom.removeNode(this.svgGroup_);
+    if (this.svgGroup_ && this.svgGroup_.parentNode) this.svgGroup_.parentNode.removeChild(this.svgGroup_);
     this.svgGroup_ = null;
   }
   this.workspace_ = null;

--- a/core/flyout_vertical.js
+++ b/core/flyout_vertical.js
@@ -397,7 +397,7 @@ Blockly.VerticalFlyout.prototype.clearOldBlocks_ = function() {
   // Do the same for checkboxes.
   for (var i = 0, elem; elem = this.checkboxes_[i]; i++) {
     elem.block.flyoutCheckbox = null;
-    goog.dom.removeNode(elem.svgRoot);
+    if (elem.svgRoot && elem.svgRoot.parentNode) elem.svgRoot.parentNode.removeChild(elem.svgRoot);
   }
   this.checkboxes_ = [];
 };

--- a/core/input.js
+++ b/core/input.js
@@ -248,9 +248,7 @@ Blockly.Input.prototype.init = function() {
  * Sever all links to this input.
  */
 Blockly.Input.prototype.dispose = function() {
-  if (this.outlinePath) {
-    if (this.outlinePath && this.outlinePath.parentNode) this.outlinePath.parentNode.removeChild(this.outlinePath);
-  }
+  if (this.outlinePath && this.outlinePath.parentNode) this.outlinePath.parentNode.removeChild(this.outlinePath);
   for (var i = 0, field; field = this.fieldRow[i]; i++) {
     field.dispose();
   }

--- a/core/input.js
+++ b/core/input.js
@@ -249,7 +249,7 @@ Blockly.Input.prototype.init = function() {
  */
 Blockly.Input.prototype.dispose = function() {
   if (this.outlinePath) {
-    goog.dom.removeNode(this.outlinePath);
+    if (this.outlinePath && this.outlinePath.parentNode) this.outlinePath.parentNode.removeChild(this.outlinePath);
   }
   for (var i = 0, field; field = this.fieldRow[i]; i++) {
     field.dispose();


### PR DESCRIPTION
### Resolves

* Removes a good 10-20% of time spent doing a workspace update when switching sprites.

### Proposed Changes

* replaces `goog.dom.removeNode(node)` with `if (node && node.parentNode) node.parentNode.removeChild(node)` 

### Reason for Changes

![image](https://user-images.githubusercontent.com/549355/38579935-8aa11bca-3cd6-11e8-853e-0926cf431651.png)
* this is exactly what the `goog.dom.removeNode` method does, however since it avoids yet-another-function-call-for-every-node-removed we save a ton of time (at least with chrome)
