### PR TITLE
Optimize block.setParent during clearing workspace

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -272,18 +272,23 @@ Blockly.BlockSvg.prototype.getIcons = function() {
  * @param {Blockly.BlockSvg} newParent New parent block.
  */
 Blockly.BlockSvg.prototype.setParent = function(newParent) {
-  if (newParent == this.parentBlock_) {
+  if (newParent === this.parentBlock_) {
     return;
   }
   var svgRoot = this.getSvgRoot();
+  var oldXY = this.getRelativeToSurfaceXY();
   if (this.parentBlock_ && svgRoot) {
     // Move this block up the DOM.  Keep track of x/y translations.
-    var xy = this.getRelativeToSurfaceXY();
+
     // Avoid moving a block up the DOM if it's currently selected/dragging,
     // so as to avoid taking things off the drag surface.
-    if (Blockly.selected != this) {
+
+    // Also do not move it if the workspace is clearing, no need, we will be deleted
+    // Also, if we have a new parent, we should avoid calling `appendChild` twice with
+    // the same child, so we will just move ourselves later in the newParent block
+    if (Blockly.selected !== this && !newParent && !this.workspace.isClearing) {
       this.workspace.getCanvas().appendChild(svgRoot);
-      this.translate(xy.x, xy.y);
+      this.translate(oldXY.x, oldXY.y);
     }
   }
 
@@ -292,7 +297,6 @@ Blockly.BlockSvg.prototype.setParent = function(newParent) {
   Blockly.Field.stopCache();
 
   if (newParent) {
-    var oldXY = this.getRelativeToSurfaceXY();
     newParent.getSvgRoot().appendChild(svgRoot);
     var newXY = this.getRelativeToSurfaceXY();
     // Move the connections to match the child's new position.

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -277,15 +277,18 @@ Blockly.BlockSvg.prototype.setParent = function(newParent) {
   }
   var svgRoot = this.getSvgRoot();
   var oldXY = this.getRelativeToSurfaceXY();
+
   if (this.parentBlock_ && svgRoot) {
     // Move this block up the DOM.  Keep track of x/y translations.
 
     // Avoid moving a block up the DOM if it's currently selected/dragging,
     // so as to avoid taking things off the drag surface.
 
-    // Also do not move it if the workspace is clearing, no need, we will be deleted
-    // Also, if we have a new parent, we should avoid calling `appendChild` twice with
-    // the same child, so we will just move ourselves later in the newParent block
+    // Also if we have a new parent, we should avoid calling `appendChild` twice with
+    // the same child, so we will just move ourselves later in the newParent block.
+
+    // Also do not move it if the workspace is clearing, we will only `removeChild`
+    // a few cycles later.
     if (Blockly.selected !== this && !newParent && !this.workspace.isClearing) {
       this.workspace.getCanvas().appendChild(svgRoot);
       this.translate(oldXY.x, oldXY.y);

--- a/core/workspace.js
+++ b/core/workspace.js
@@ -202,6 +202,7 @@ Blockly.Workspace.prototype.getAllBlocks = function() {
  * Dispose of all blocks in workspace.
  */
 Blockly.Workspace.prototype.clear = function() {
+  this.isClearing = true;
   var existingGroup = Blockly.Events.getGroup();
   if (!existingGroup) {
     Blockly.Events.setGroup(true);
@@ -223,6 +224,7 @@ Blockly.Workspace.prototype.clear = function() {
   if (this.potentialVariableMap_) {
     this.potentialVariableMap_.clear();
   }
+  this.isClearing = false;
 };
 
 /* Begin functions that are just pass-throughs to the variable map. */

--- a/core/workspace.js
+++ b/core/workspace.js
@@ -111,6 +111,12 @@ Blockly.Workspace = function(opt_options) {
 Blockly.Workspace.prototype.rendered = false;
 
 /**
+ * Returns `true` if the workspace is currently in the process of a bulk clear.
+ * @type {boolean}
+ */
+Blockly.Workspace.prototype.isClearing = false;
+
+/**
  * Maximum number of undo events in stack. `0` turns off undo, `Infinity` sets it to unlimited.
  * @type {number}
  */

--- a/core/workspace.js
+++ b/core/workspace.js
@@ -113,6 +113,7 @@ Blockly.Workspace.prototype.rendered = false;
 /**
  * Returns `true` if the workspace is currently in the process of a bulk clear.
  * @type {boolean}
+ * @package
  */
 Blockly.Workspace.prototype.isClearing = false;
 


### PR DESCRIPTION
### Proposed Changes

* Tracks an `isClearing` on workspaces, and when clearing, avoids reattaching the SVG nodes to the workspace

### Reason for Changes
* Saves a lot of useless calls to `appendNode` which are followed up slightly later by `removeNode`