### PR TITLE
Recycle flyout blocks

### DIFF
--- a/core/data_category.js
+++ b/core/data_category.js
@@ -399,7 +399,7 @@ Blockly.DataCategory.addBlock = function(xmlList,
 
     var gap = 8;
     var blockText = '<xml>' +
-        '<block type="' + blockType + '" gap="' + gap + '" dynamic>' +
+        '<block type="' + blockType + '" gap="' + gap + '" dynamic="true">' +
         Blockly.Variables.generateVariableFieldXml_(variable, fieldName) +
         firstValueField + secondValueField +
         '</block>' +

--- a/core/data_category.js
+++ b/core/data_category.js
@@ -399,7 +399,7 @@ Blockly.DataCategory.addBlock = function(xmlList,
 
     var gap = 8;
     var blockText = '<xml>' +
-        '<block type="' + blockType + '" gap="' + gap + '">' +
+        '<block type="' + blockType + '" gap="' + gap + '" dynamic>' +
         Blockly.Variables.generateVariableFieldXml_(variable, fieldName) +
         firstValueField + secondValueField +
         '</block>' +

--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -55,12 +55,12 @@ Blockly.Flyout = function(workspaceOptions) {
   this.workspace_ = new Blockly.WorkspaceSvg(workspaceOptions);
   this.workspace_.isFlyout = true;
 
-  // when we create blocks for this workspace, make the default id
-  // the same as the prototype for easier re-use
+  // When we create blocks for this workspace, instead of using the "optional" id
+  // make the default `id` the same as the `type` for easier re-use.
   var newBlock = this.workspace_.newBlock;
-  this.workspace_.newBlock = function(proto, id) {
-    // this here is workspace
-    return newBlock.call(this, proto, id || proto);
+  this.workspace_.newBlock = function(type, id) {
+    // Use `type` if `id` isn't passed. `this` will be workspace.
+    return newBlock.call(this, proto, id || type);
   };
 
   /**
@@ -482,8 +482,9 @@ Blockly.Flyout.prototype.show = function(xmlList) {
       var tagName = xml.tagName.toUpperCase();
       var default_gap = this.horizontalLayout_ ? this.GAP_X : this.GAP_Y;
       if (tagName == 'BLOCK') {
-        // this is probably a naive assumption, but we are going to assume
-        // that in a flyout, the same ID block is the same
+
+        // We assume that in a flyout, the same block id/type means
+        // the same output SVG nodes.  Check for a recycled element.
         var id = xml.getAttribute('id') || xml.getAttribute('type');
         var recycled = this.recycleBlocks_.findIndex(function(block) {
           return block.id === id;
@@ -491,8 +492,8 @@ Blockly.Flyout.prototype.show = function(xmlList) {
         var curBlock;
 
         if (recycled > -1) {
-          // delete the recycled element out of the recycle bin and
-          // assign it to curBlock
+          // Delete the recycled element out of the recycle bin and
+          // assign it to curBlock.
           curBlock = this.recycleBlocks_.splice(recycled, 1)[0];
         } else {
           var curBlock = Blockly.Xml.domToBlock(xml, this.workspace_);
@@ -544,7 +545,7 @@ Blockly.Flyout.prototype.show = function(xmlList) {
   this.listeners_.push(Blockly.bindEvent_(this.svgBackground_, 'mouseover',
       this, deselectAll));
 
-  // Clean out the old recycle bin
+  // Clean out the old recycle bin.
   var oldBlocks = this.recycleBlocks_;
   this.recycleBlocks_ = [];
   for (var i = 0; i < oldBlocks.length; i++) {

--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -484,7 +484,7 @@ Blockly.Flyout.prototype.show = function(xmlList) {
       if (tagName == 'BLOCK') {
 
         // We assume that in a flyout, the same block id/type means
-        // the same output SVG nodes.  Check for a recycled element.
+        // the same output BlockSvg.  Check for a recycled element.
         var id = xml.getAttribute('id') || xml.getAttribute('type');
         var recycled = this.recycleBlocks_.findIndex(function(block) {
           return block.id === id;
@@ -531,6 +531,8 @@ Blockly.Flyout.prototype.show = function(xmlList) {
     }
   }
 
+  this.emptyRecycleBlocks_();
+
   this.layout_(contents, gaps);
 
   // IE 11 is an incompetent browser that fails to fire mouseout events.
@@ -545,13 +547,6 @@ Blockly.Flyout.prototype.show = function(xmlList) {
   this.listeners_.push(Blockly.bindEvent_(this.svgBackground_, 'mouseover',
       this, deselectAll));
 
-  // Clean out the old recycle bin.
-  var oldBlocks = this.recycleBlocks_;
-  this.recycleBlocks_ = [];
-  for (var i = 0; i < oldBlocks.length; i++) {
-    oldBlocks[i].dispose(false, false);
-  }
-
   this.workspace_.setResizesEnabled(true);
   this.reflow();
 
@@ -562,6 +557,19 @@ Blockly.Flyout.prototype.show = function(xmlList) {
   this.workspace_.addChangeListener(this.reflowWrapper_);
 
   this.recordCategoryScrollPositions_();
+};
+
+/**
+ * Empty out the recycled blocks, properly destroying everything.
+ * @private
+ */
+Blockly.Flyout.prototype.emptyRecycleBlocks_ = function() {
+  // Clean out the old recycle bin.
+  var oldBlocks = this.recycleBlocks_;
+  this.recycleBlocks_ = [];
+  for (var i = 0; i < oldBlocks.length; i++) {
+    oldBlocks[i].dispose(false, false);
+  }
 };
 
 /**
@@ -853,7 +861,7 @@ Blockly.Flyout.prototype.placeNewBlock_ = function(oldBlock) {
  * @param {!Blockly.BlockSvg} block The block to recycle.
  */
 Blockly.Flyout.prototype.recycleBlock = function(block) {
-  var g = block.getSvgRoot();
-  g.setAttribute('transform', '');
+  var xy = block.getRelativeToSurfaceXY();
+  block.moveBy(-xy.x, -xy.y);
   this.recycleBlocks_.push(block);
 };

--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -852,7 +852,6 @@ Blockly.Flyout.prototype.placeNewBlock_ = function(oldBlock) {
  * @param {!Blockly.BlockSvg} block The block to recycle.
  */
 Blockly.Flyout.prototype.recycleBlock = function(block) {
-  block.rendered = false;
   var g = block.getSvgRoot();
   g.setAttribute('transform', '');
   this.recycleBlocks_.push(block);

--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -60,7 +60,7 @@ Blockly.Flyout = function(workspaceOptions) {
   var newBlock = this.workspace_.newBlock;
   this.workspace_.newBlock = function(type, id) {
     // Use `type` if `id` isn't passed. `this` will be workspace.
-    return newBlock.call(this, proto, id || type);
+    return newBlock.call(this, type, id || type);
   };
 
   /**

--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -483,21 +483,26 @@ Blockly.Flyout.prototype.show = function(xmlList) {
       var default_gap = this.horizontalLayout_ ? this.GAP_X : this.GAP_Y;
       if (tagName == 'BLOCK') {
 
-        // We assume that in a flyout, the same block id/type means
-        // the same output BlockSvg.  Check for a recycled element.
+        // We assume that in a flyout, the same block id (or type if missing id) means
+        // the same output BlockSVG.
+
+        // Look for a block that matches the id or type, our createBlock will assign
+        // id = type if none existed.
         var id = xml.getAttribute('id') || xml.getAttribute('type');
         var recycled = this.recycleBlocks_.findIndex(function(block) {
           return block.id === id;
         });
-        var curBlock;
 
+
+        // If we found a recycled item, reuse the BlockSVG from last time.
+        // Otherwise, convert the XML block to a BlockSVG.
+        var curBlock;
         if (recycled > -1) {
-          // Delete the recycled element out of the recycle bin and
-          // assign it to curBlock.
           curBlock = this.recycleBlocks_.splice(recycled, 1)[0];
         } else {
-          var curBlock = Blockly.Xml.domToBlock(xml, this.workspace_);
+          curBlock = Blockly.Xml.domToBlock(xml, this.workspace_);
         }
+
         if (curBlock.disabled) {
           // Record blocks that were initially disabled.
           // Do not enable these blocks as a result of capacity filtering.
@@ -663,7 +668,7 @@ Blockly.Flyout.prototype.clearOldBlocks_ = function() {
   var oldBlocks = this.workspace_.getTopBlocks(false);
   for (var i = 0, block; block = oldBlocks[i]; i++) {
     if (block.workspace == this.workspace_) {
-      this.recycleBlock(block);
+      this.recycleBlock_(block);
     }
   }
   // Delete any background buttons from a previous showing.
@@ -859,8 +864,9 @@ Blockly.Flyout.prototype.placeNewBlock_ = function(oldBlock) {
  * workspace swaps to limit the number of new dom elements we need to create
  *
  * @param {!Blockly.BlockSvg} block The block to recycle.
+ * @private
  */
-Blockly.Flyout.prototype.recycleBlock = function(block) {
+Blockly.Flyout.prototype.recycleBlock_ = function(block) {
   var xy = block.getRelativeToSurfaceXY();
   block.moveBy(-xy.x, -xy.y);
   this.recycleBlocks_.push(block);

--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -851,7 +851,7 @@ Blockly.Flyout.prototype.placeNewBlock_ = function(oldBlock) {
  *
  * @param {!Blockly.BlockSvg} block The block to recycle.
  */
-Blockly.WorkspaceSvg.prototype.recycleBlock = function(block) {
+Blockly.Flyout.prototype.recycleBlock = function(block) {
   block.rendered = false;
   var g = block.getSvgRoot();
   g.setAttribute('transform', '');

--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -488,6 +488,7 @@ Blockly.Flyout.prototype.show = function(xmlList) {
 
         // Look for a block that matches the id or type, our createBlock will assign
         // id = type if none existed.
+        var dynamic = xml.hasAttribute('dynamic');
         var id = xml.getAttribute('id') || xml.getAttribute('type');
         var recycled = this.recycleBlocks_.findIndex(function(block) {
           return block.id === id;
@@ -497,7 +498,7 @@ Blockly.Flyout.prototype.show = function(xmlList) {
         // If we found a recycled item, reuse the BlockSVG from last time.
         // Otherwise, convert the XML block to a BlockSVG.
         var curBlock;
-        if (recycled > -1) {
+        if (!dynamic && recycled > -1) {
           curBlock = this.recycleBlocks_.splice(recycled, 1)[0];
         } else {
           curBlock = Blockly.Xml.domToBlock(xml, this.workspace_);


### PR DESCRIPTION
### Proposed Changes

* Flyout stores a "recycle bin" of the svg nodes it's about to throw out and reuses them when recreating a flyout

### Reason for Changes

* Avoids a bunch of DOM GC and trash for every sprite swap with swapping toolbars.
