### PR TITLE
Move block animation code to a new file

### DIFF
--- a/core/block_animations.js
+++ b/core/block_animations.js
@@ -93,7 +93,9 @@ Blockly.BlockAnimations.connectionUiEffect = function(block) {
  * @param {!Blockly.BlockSvg} _block The block being disconnected.
  * @package
  */
-Blockly.BlockAnimations.disconnectUiEffect = function(_block) {
+Blockly.BlockAnimations.disconnectUiEffect = function(
+    /* eslint-disable no-unused-vars */ _block
+    /* eslint-enable no-unused-vars */) {
 };
 
 /**

--- a/core/block_animations.js
+++ b/core/block_animations.js
@@ -1,0 +1,105 @@
+/**
+ * @license
+ * Visual Blocks Editor
+ *
+ * Copyright 2018 Google Inc.
+ * https://developers.google.com/blockly/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Methods animating a block on connection and disconnection.
+ * @author fenichel@google.com (Rachel Fenichel)
+ */
+'use strict';
+
+goog.provide('Blockly.BlockAnimations');
+
+
+/**
+ * Play some UI effects (sound, animation) when disposing of a block.
+ * @param {!Blockly.BlockSvg} block The block being disposed of.
+ * @package
+ */
+Blockly.BlockAnimations.disposeUiEffect = function(block) {
+  var workspace = block.workspace;
+  var svgGroup = block.getSvgRoot();
+  workspace.getAudioManager().play('delete');
+
+  var xy = workspace.getSvgXY(svgGroup);
+  // Deeply clone the current block.
+  var clone = svgGroup.cloneNode(true);
+  clone.translateX_ = xy.x;
+  clone.translateY_ = xy.y;
+  clone.setAttribute('transform', 'translate(' + xy.x + ',' + xy.y + ')');
+  workspace.getParentSvg().appendChild(clone);
+  clone.bBox_ = clone.getBBox();
+  // Start the animation.
+  Blockly.BlockAnimations.disposeUiStep_(clone, workspace.RTL, new Date,
+      workspace.scale);
+};
+
+/**
+ * Animate a cloned block and eventually dispose of it.
+ * This is a class method, not an instance method since the original block has
+ * been destroyed and is no longer accessible.
+ * @param {!Element} clone SVG element to animate and dispose of.
+ * @param {boolean} rtl True if RTL, false if LTR.
+ * @param {!Date} start Date of animation's start.
+ * @param {number} workspaceScale Scale of workspace.
+ * @private
+ */
+Blockly.BlockAnimations.disposeUiStep_ = function(clone, rtl, start,
+    workspaceScale) {
+  var ms = new Date - start;
+  var percent = ms / 150;
+  if (percent > 1) {
+    goog.dom.removeNode(clone);
+  } else {
+    var x = clone.translateX_ +
+        (rtl ? -1 : 1) * clone.bBox_.width * workspaceScale / 2 * percent;
+    var y = clone.translateY_ + clone.bBox_.height * workspaceScale * percent;
+    var scale = (1 - percent) * workspaceScale;
+    clone.setAttribute('transform', 'translate(' + x + ',' + y + ')' +
+        ' scale(' + scale + ')');
+    setTimeout(Blockly.BlockAnimations.disposeUiStep_, 10, clone, rtl, start,
+        workspaceScale);
+  }
+};
+
+/**
+ * Play some UI effects (sound, ripple) after a connection has been established.
+ * @param {!Blockly.BlockSvg} block The block being connected.
+ * @package
+ */
+Blockly.BlockAnimations.connectionUiEffect = function(block) {
+  block.workspace.getAudioManager().play('click');
+};
+
+/**
+ * Play some UI effects (sound, animation) when disconnecting a block.
+ * No-op in scratch-blocks, which has no disconnect animation.
+ * @param {!Blockly.BlockSvg} _block The block being disconnected.
+ * @package
+ */
+Blockly.BlockAnimations.disconnectUiEffect = function(_block) {
+};
+
+/**
+ * Stop the disconnect UI animation immediately.
+ * No-op in scratch-blocks, which has no disconnect animation.
+ * @package
+ */
+Blockly.BlockAnimations.disconnectUiStop = function() {
+};

--- a/core/block_dragger.js
+++ b/core/block_dragger.js
@@ -26,6 +26,7 @@
 
 goog.provide('Blockly.BlockDragger');
 
+goog.require('Blockly.BlockAnimations');
 goog.require('Blockly.InsertionMarkerManager');
 
 goog.require('goog.math.Coordinate');
@@ -159,7 +160,7 @@ Blockly.BlockDragger.prototype.startBlockDrag = function(currentDragDeltaXY) {
   }
 
   this.workspace_.setResizesEnabled(false);
-  Blockly.BlockSvg.disconnectUiStop_();
+  Blockly.BlockAnimations.disconnectUiStop();
 
   if (this.draggingBlock_.getParent()) {
     this.draggingBlock_.unplug();
@@ -167,7 +168,7 @@ Blockly.BlockDragger.prototype.startBlockDrag = function(currentDragDeltaXY) {
     var newLoc = goog.math.Coordinate.sum(this.startXY_, delta);
 
     this.draggingBlock_.translate(newLoc.x, newLoc.y);
-    this.draggingBlock_.disconnectUiEffect();
+    Blockly.BlockAnimations.disconnectUiEffect(this.draggingBlock_);
   }
   this.draggingBlock_.setDragging(true);
   // For future consideration: we may be able to put moveToDragSurface inside
@@ -223,7 +224,7 @@ Blockly.BlockDragger.prototype.endBlockDrag = function(e, currentDragDeltaXY) {
   this.fireEndDragEvent_(isOutside);
   this.draggingBlock_.setMouseThroughStyle(false);
 
-  Blockly.BlockSvg.disconnectUiStop_();
+  Blockly.BlockAnimations.disconnectUiStop();
 
   var delta = this.pixelsToWorkspaceUnits_(currentDragDeltaXY);
   var newLoc = goog.math.Coordinate.sum(this.startXY_, delta);

--- a/core/dragged_connection_manager.js
+++ b/core/dragged_connection_manager.js
@@ -26,6 +26,7 @@
 
 goog.provide('Blockly.DraggedConnectionManager');
 
+goog.require('Blockly.BlockAnimations');
 goog.require('Blockly.RenderedConnection');
 
 goog.require('goog.math.Coordinate');
@@ -138,7 +139,8 @@ Blockly.DraggedConnectionManager.prototype.applyConnections = function() {
       // Determine which connection is inferior (lower in the source stack).
       var inferiorConnection = this.localConnection_.isSuperior() ?
           this.closestConnection_ : this.localConnection_;
-      inferiorConnection.getSourceBlock().connectionUiEffect();
+      Blockly.BlockAnimations.connectionUiEffect(
+          inferiorConnection.getSourceBlock());
       // Bring the just-edited stack to the front.
       var rootBlock = this.topBlock_.getRootBlock();
       rootBlock.bringToFront();

--- a/core/gesture.js
+++ b/core/gesture.js
@@ -27,6 +27,7 @@
 
 goog.provide('Blockly.Gesture');
 
+goog.require('Blockly.BlockAnimations');
 goog.require('Blockly.BlockDragger');
 goog.require('Blockly.constants');
 goog.require('Blockly.Events');
@@ -423,7 +424,7 @@ Blockly.Gesture.prototype.doStart = function(e) {
   }
   this.hasStarted_ = true;
 
-  Blockly.BlockSvg.disconnectUiStop_();
+  Blockly.BlockAnimations.disconnectUiStop();
   this.startWorkspace_.updateScreenCalculationsIfScrolled();
   if (this.startWorkspace_.isMutator) {
     // Mutator's coordinate system could be out of date because the bubble was

--- a/core/insertion_marker_manager.js
+++ b/core/insertion_marker_manager.js
@@ -26,6 +26,7 @@
 
 goog.provide('Blockly.InsertionMarkerManager');
 
+goog.require('Blockly.BlockAnimations');
 goog.require('Blockly.Events');
 goog.require('Blockly.RenderedConnection');
 
@@ -204,7 +205,8 @@ Blockly.InsertionMarkerManager.prototype.applyConnections = function() {
       // Determine which connection is inferior (lower in the source stack).
       var inferiorConnection = this.localConnection_.isSuperior() ?
           this.closestConnection_ : this.localConnection_;
-      inferiorConnection.getSourceBlock().connectionUiEffect();
+      Blockly.BlockAnimations.connectionUiEffect(
+          inferiorConnection.getSourceBlock());
       // Bring the just-edited stack to the front.
       var rootBlock = this.topBlock_.getRootBlock();
       rootBlock.bringToFront();


### PR DESCRIPTION
See https://github.com/google/blockly/pull/1787

### Resolves

None

### Proposed Changes

Move code for block animations to a new file.
### Reason for Changes

Simplify pulls from Blockly. Generally make it easier for forks to override animations without merge problems.

### Test Coverage

Tested in the vertical playground.