### PR TITLE
Switch to Blockly.Field.fromJson

### DIFF
--- a/core/block.js
+++ b/core/block.js
@@ -1408,76 +1408,20 @@ Blockly.Block.prototype.interpolate_ = function(message, args, lastDummyAlign) {
             case 'input_dummy':
               input = this.appendDummyInput(element['name']);
               break;
-            case 'field_label':
-              field = Blockly.Block.newFieldLabelFromJson_(element);
-              break;
-            case 'field_label_serializable':
-              field = Blockly.Block.newFieldLabelSerializableFromJson_(element);
-              break;
-            case 'field_input':
-              field = Blockly.Block.newFieldTextInputFromJson_(element);
-              break;
-            case 'field_input_removable':
-              field = Blockly.FieldTextInputRemovable.fromJson(element);
-              break;
-            case 'field_textdropdown':
-              field = new Blockly.FieldTextDropdown(element['text'], element['options']);
-              if (typeof element['spellcheck'] == 'boolean') {
-                field.setSpellcheck(element['spellcheck']);
-              }
-              break;
-            case 'field_numberdropdown':
-              field = new Blockly.FieldNumberDropdown(
-                element['value'], element['options'],
-                element['min'], element['max'], element['precision']
-              );
-              break;
-            case 'field_angle':
-              field = new Blockly.FieldAngle(element['angle']);
-              break;
-            case 'field_checkbox':
-              field = new Blockly.FieldCheckbox(
-                  element['checked'] ? 'TRUE' : 'FALSE');
-              break;
-            case 'field_colour':
-              field = new Blockly.FieldColour(element['colour']);
-              break;
-            case 'field_colour_slider':
-              field = new Blockly.FieldColourSlider(element['colour']);
-              break;
-            case 'field_variable':
-              field = Blockly.Block.newFieldVariableFromJson_(element);
-              break;
-            case 'field_dropdown':
-              field = new Blockly.FieldDropdown(element['options']);
-              break;
-            case 'field_iconmenu':
-              field = new Blockly.FieldIconMenu(element['options']);
-              break;
-            case 'field_image':
-              field = Blockly.Block.newFieldImageFromJson_(element);
-              break;
-            case 'field_number':
-              field = new Blockly.FieldNumber(element['value'],
-                  element['min'], element['max'], element['precision']);
-              break;
-            case 'field_variable_getter':
-              field = Blockly.Block.newFieldVariableGetterFromJson_(element);
-              break;
-            case 'field_vertical_separator':
-              field = new Blockly.FieldVerticalSeparator();
-              break;
-            case 'field_date':
-              if (Blockly.FieldDate) {
-                field = new Blockly.FieldDate(element['date']);
-                break;
-              }
-              // Fall through if FieldDate is not compiled in.
             default:
+              field = Blockly.Field.fromJson(element);
+
               // Unknown field.
-              if (element['alt']) {
-                element = element['alt'];
-                altRepeat = true;
+              if (!field) {
+                if (element['alt']) {
+                  element = element['alt'];
+                  altRepeat = true;
+                } else {
+                  console.warn('Blockly could not create a field of type ' +
+                      element['type'] +
+                      '. You may need to register your custom field.  See ' +
+                      'github.com/google/blockly/issues/1584');
+                }
               }
           }
         }
@@ -1498,90 +1442,6 @@ Blockly.Block.prototype.interpolate_ = function(message, args, lastDummyAlign) {
       }
     }
   }
-};
-
-/**
- * Helper function to construct a FieldImage from a JSON arg object,
- * dereferencing any string table references.
- * @param {!Object} options A JSON object with options (src, width, height, and alt).
- * @returns {!Blockly.FieldImage} The new image.
- * @private
- */
-Blockly.Block.newFieldImageFromJson_ = function(options) {
-  var src = Blockly.utils.replaceMessageReferences(options['src']);
-  var width = Number(Blockly.utils.replaceMessageReferences(options['width']));
-  var height =
-    Number(Blockly.utils.replaceMessageReferences(options['height']));
-  var alt = Blockly.utils.replaceMessageReferences(options['alt']);
-  var flip_rtl = !!options['flip_rtl'] || !!options['flipRtl'];
-  return new Blockly.FieldImage(src, width, height, alt, flip_rtl);
-};
-
-/**
- * Helper function to construct a FieldLabel from a JSON arg object,
- * dereferencing any string table references.
- * @param {!Object} options A JSON object with options (text, and class).
- * @returns {!Blockly.FieldLabel} The new label.
- * @private
- */
-Blockly.Block.newFieldLabelFromJson_ = function(options) {
-  var text = Blockly.utils.replaceMessageReferences(options['text']);
-  return new Blockly.FieldLabel(text, options['class']);
-};
-
-/**
- * Helper function to construct a FieldLabelSerializable from a JSON arg object,
- * dereferencing any string table references.
- * @param {!Object} options A JSON object with options (text, and class).
- * @returns {!Blockly.FieldLabelSerializable} The new label.
- * @private
- */
-Blockly.Block.newFieldLabelSerializableFromJson_ = function(options) {
-  var text = Blockly.utils.replaceMessageReferences(options['text']);
-  return new Blockly.FieldLabelSerializable(text, options['class']);
-};
-
-/**
- * Helper function to construct a FieldTextInput from a JSON arg object,
- * dereferencing any string table references.
- * @param {!Object} options A JSON object with options (text, class, and
- *                          spellcheck).
- * @returns {!Blockly.FieldTextInput} The new text input.
- * @private
- */
-Blockly.Block.newFieldTextInputFromJson_ = function(options) {
-  var text = Blockly.utils.replaceMessageReferences(options['text']);
-  var field = new Blockly.FieldTextInput(text, options['class']);
-  if (typeof options['spellcheck'] == 'boolean') {
-    field.setSpellcheck(options['spellcheck']);
-  }
-  return field;
-};
-
-/**
- * Helper function to construct a FieldVariable from a JSON arg object,
- * dereferencing any string table references.
- * @param {!Object} options A JSON object with options (variable).
- * @returns {!Blockly.FieldVariable} The variable field.
- * @private
- */
-Blockly.Block.newFieldVariableFromJson_ = function(options) {
-  var varname = Blockly.utils.replaceMessageReferences(options['variable']);
-  var variableTypes = options['variableTypes'];
-  return new Blockly.FieldVariable(varname, null, variableTypes);
-};
-
-/**
- * Helper function to construct a FieldVariableGetter from a JSON arg object,
- * dereferencing any string table references.
- * @param {!Object} options A JSON object with options (variable).
- * @returns {!Blockly.FieldImage} The new image.
- * @private
- */
-Blockly.Block.newFieldVariableGetterFromJson_ = function(options) {
-  var varname = Blockly.utils.replaceMessageReferences(options['text']);
-  return new Blockly.FieldVariableGetter(varname, options['name'],
-      options['class'], options['variableType']);
 };
 
 /**

--- a/core/field.js
+++ b/core/field.js
@@ -61,6 +61,53 @@ Blockly.Field = function(text, opt_validator) {
   this.maxDisplayLength = Blockly.BlockSvg.MAX_DISPLAY_LENGTH;
 };
 
+
+/**
+ * The set of all registered fields, keyed by field type as used in the JSON
+ * definition of a block.
+ * @type {!Object<string, !{fromJson: Function}>}
+ * @private
+ */
+Blockly.Field.TYPE_MAP_ = {};
+
+/**
+ * Registers a field type. May also override an existing field type.
+ * Blockly.Field.fromJson uses this registry to find the appropriate field.
+ * @param {!string} type The field type name as used in the JSON definition.
+ * @param {!{fromJson: Function}} fieldClass The field class containing a
+ *     fromJson function that can construct an instance of the field.
+ * @throws {Error} if the type name is empty, or the fieldClass is not an
+ *     object containing a fromJson function.
+ */
+Blockly.Field.register = function(type, fieldClass) {
+  if (!goog.isString(type) || goog.string.isEmptyOrWhitespace(type)) {
+    throw new Error('Invalid field type "' + type + '"');
+  }
+  if (!goog.isObject(fieldClass) || !goog.isFunction(fieldClass.fromJson)) {
+    throw new Error('Field "' + fieldClass +
+        '" must have a fromJson function');
+  }
+  Blockly.Field.TYPE_MAP_[type] = fieldClass;
+};
+
+/**
+ * Construct a Field from a JSON arg object.
+ * Finds the appropriate registered field by the type name as registered using
+ * Blockly.Field.register.
+ * @param {!Object} options A JSON object with a type and options specific
+ *     to the field type.
+ * @returns {?Blockly.Field} The new field instance or null if a field wasn't
+ *     found with the given type name
+ * @package
+ */
+Blockly.Field.fromJson = function(options) {
+  var fieldClass = Blockly.Field.TYPE_MAP_[options['type']];
+  if (fieldClass) {
+    return fieldClass.fromJson(options);
+  }
+  return null;
+};
+
 /**
  * Temporary cache of text widths.
  * @type {Object}

--- a/core/field_angle.js
+++ b/core/field_angle.js
@@ -56,6 +56,17 @@ Blockly.FieldAngle = function(opt_value, opt_validator) {
 goog.inherits(Blockly.FieldAngle, Blockly.FieldTextInput);
 
 /**
+ * Construct a FieldAngle from a JSON arg object.
+ * @param {!Object} options A JSON object with options (angle).
+ * @returns {!Blockly.FieldAngle} The new field instance.
+ * @package
+ * @nocollapse
+ */
+Blockly.FieldAngle.fromJson = function(options) {
+  return new Blockly.FieldAngle(options['angle']);
+};
+
+/**
  * Round angles to the nearest 15 degrees when using mouse.
  * Set to 0 to disable rounding.
  */
@@ -377,3 +388,5 @@ Blockly.FieldAngle.prototype.classValidator = function(text) {
   }
   return String(n);
 };
+
+Blockly.Field.register('field_angle', Blockly.FieldAngle);

--- a/core/field_checkbox.js
+++ b/core/field_checkbox.js
@@ -48,6 +48,17 @@ Blockly.FieldCheckbox = function(state, opt_validator) {
 goog.inherits(Blockly.FieldCheckbox, Blockly.Field);
 
 /**
+ * Construct a FieldCheckbox from a JSON arg object.
+ * @param {!Object} options A JSON object with options (checked).
+ * @returns {!Blockly.FieldCheckbox} The new field instance.
+ * @package
+ * @nocollapse
+ */
+Blockly.FieldCheckbox.fromJson = function(options) {
+  return new Blockly.FieldCheckbox(options['checked'] ? 'TRUE' : 'FALSE');
+};
+
+/**
  * Character for the checkmark.
  */
 Blockly.FieldCheckbox.CHECK_CHAR = '\u2713';
@@ -118,3 +129,5 @@ Blockly.FieldCheckbox.prototype.showEditor_ = function() {
     this.setValue(String(newState).toUpperCase());
   }
 };
+
+Blockly.Field.register('field_checkbox', Blockly.FieldCheckbox);

--- a/core/field_colour.js
+++ b/core/field_colour.js
@@ -52,6 +52,17 @@ Blockly.FieldColour = function(colour, opt_validator) {
 goog.inherits(Blockly.FieldColour, Blockly.Field);
 
 /**
+ * Construct a FieldColour from a JSON arg object.
+ * @param {!Object} options A JSON object with options (colour).
+ * @returns {!Blockly.FieldColour} The new field instance.
+ * @package
+ * @nocollapse
+ */
+Blockly.FieldColour.fromJson = function(options) {
+  return new Blockly.FieldColour(options['colour']);
+};
+
+/**
  * By default use the global constants for colours.
  * @type {Array.<string>}
  * @private
@@ -237,3 +248,5 @@ Blockly.FieldColour.widgetDispose_ = function() {
   }
   Blockly.Events.setGroup(false);
 };
+
+Blockly.Field.register('field_colour', Blockly.FieldColour);

--- a/core/field_colour_slider.js
+++ b/core/field_colour_slider.js
@@ -51,6 +51,16 @@ Blockly.FieldColourSlider = function(colour, opt_validator) {
 };
 goog.inherits(Blockly.FieldColourSlider, Blockly.Field);
 
+/**
+ * Construct a FieldColourSlider from a JSON arg object.
+ * @param {!Object} options A JSON object with options (colour).
+ * @returns {!Blockly.FieldColourSlider} The new field instance.
+ * @package
+ * @nocollapse
+ */
+Blockly.FieldColourSlider.fromJson = function(options) {
+  return new Blockly.FieldColourSlider(options['colour']);
+};
 
 /**
  * Function to be called if eyedropper can be activated.
@@ -363,3 +373,5 @@ Blockly.FieldColourSlider.prototype.dispose = function() {
   Blockly.Events.setGroup(false);
   Blockly.FieldColourSlider.superClass_.dispose.call(this);
 };
+
+Blockly.Field.register('field_colour_slider', Blockly.FieldColourSlider);

--- a/core/field_date.js
+++ b/core/field_date.js
@@ -60,6 +60,17 @@ Blockly.FieldDate = function(date, opt_validator) {
 goog.inherits(Blockly.FieldDate, Blockly.Field);
 
 /**
+ * Construct a FieldDate from a JSON arg object.
+ * @param {!Object} options A JSON object with options (date).
+ * @returns {!Blockly.FieldDate} The new field instance.
+ * @package
+ * @nocollapse
+ */
+Blockly.FieldDate.fromJson = function(options) {
+  return new Blockly.FieldDate(options['date']);
+};
+
+/**
  * Mouse cursor style when over the hotspot that initiates the editor.
  */
 Blockly.FieldDate.prototype.CURSOR = 'text';
@@ -337,3 +348,5 @@ Blockly.FieldDate.CSS = [
   '  color: #fff;',
   '}'
 ];
+
+Blockly.Field.register('field_date', Blockly.FieldDate);

--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -63,6 +63,17 @@ Blockly.FieldDropdown = function(menuGenerator, opt_validator) {
 goog.inherits(Blockly.FieldDropdown, Blockly.Field);
 
 /**
+ * Construct a FieldDropdown from a JSON arg object.
+ * @param {!Object} element A JSON object with options.
+ * @returns {!Blockly.FieldDropdown} The new field instance.
+ * @package
+ * @nocollapse
+ */
+Blockly.FieldDropdown.fromJson = function(element) {
+  return new Blockly.FieldDropdown(element['options']);
+};
+
+/**
  * Horizontal distance that a checkmark overhangs the dropdown.
  */
 Blockly.FieldDropdown.CHECKMARK_OVERHANG = 25;
@@ -481,3 +492,5 @@ Blockly.FieldDropdown.prototype.dispose = function() {
   Blockly.WidgetDiv.hideIfOwner(this);
   Blockly.FieldDropdown.superClass_.dispose.call(this);
 };
+
+Blockly.Field.register('field_dropdown', Blockly.FieldDropdown);

--- a/core/field_iconmenu.js
+++ b/core/field_iconmenu.js
@@ -49,6 +49,16 @@ Blockly.FieldIconMenu = function(icons) {
 };
 goog.inherits(Blockly.FieldIconMenu, Blockly.Field);
 
+/**
+ * Construct a FieldIconMenu from a JSON arg object.
+ * @param {!Object} element A JSON object with options.
+ * @returns {!Blockly.FieldIconMenu} The new field instance.
+ * @package
+ * @nocollapse
+ */
+Blockly.FieldIconMenu.fromJson = function(element) {
+  return new Blockly.FieldIconMenu(element['options']);
+};
 
 /**
  * Fixed width of the drop-down, in px. Icon buttons will flow inside this width.
@@ -292,3 +302,5 @@ Blockly.FieldIconMenu.prototype.onHide_ = function() {
   // Unflip the arrow if appropriate
   this.arrowIcon_.setAttribute('transform', 'translate(' + this.arrowX_ + ',' + this.arrowY_ + ')');
 };
+
+Blockly.Field.register('field_iconmenu', Blockly.FieldIconMenu);

--- a/core/field_image.js
+++ b/core/field_image.js
@@ -56,6 +56,25 @@ Blockly.FieldImage = function(src, width, height, opt_alt, flip_rtl) {
 goog.inherits(Blockly.FieldImage, Blockly.Field);
 
 /**
+ * Construct a FieldImage from a JSON arg object,
+ * dereferencing any string table references.
+ * @param {!Object} options A JSON object with options (src, width, height, alt,
+ *     and flipRtl/flip_rtl).
+ * @returns {!Blockly.FieldImage} The new field instance.
+ * @package
+ * @nocollapse
+ */
+Blockly.FieldImage.fromJson = function(options) {
+  var src = Blockly.utils.replaceMessageReferences(options['src']);
+  var width = Number(Blockly.utils.replaceMessageReferences(options['width']));
+  var height =
+      Number(Blockly.utils.replaceMessageReferences(options['height']));
+  var alt = Blockly.utils.replaceMessageReferences(options['alt']);
+  var flip_rtl = !!options['flip_rtl'] || !!options['flipRtl'];
+  return new Blockly.FieldImage(src, width, height, alt, flip_rtl);
+};
+
+/**
  * Editable fields are saved by the XML renderer, non-editable fields are not.
  */
 Blockly.FieldImage.prototype.EDITABLE = false;
@@ -170,3 +189,5 @@ Blockly.FieldImage.prototype.render_ = function() {
 Blockly.FieldImage.prototype.updateWidth = function() {
  // NOP
 };
+
+Blockly.Field.register('field_image', Blockly.FieldImage);

--- a/core/field_label.js
+++ b/core/field_label.js
@@ -48,6 +48,19 @@ Blockly.FieldLabel = function(text, opt_class) {
 goog.inherits(Blockly.FieldLabel, Blockly.Field);
 
 /**
+ * Construct a FieldLabel from a JSON arg object,
+ * dereferencing any string table references.
+ * @param {!Object} options A JSON object with options (text, and class).
+ * @returns {!Blockly.FieldLabel} The new field instance.
+ * @package
+ * @nocollapse
+ */
+Blockly.FieldLabel.fromJson = function(options) {
+  var text = Blockly.utils.replaceMessageReferences(options['text']);
+  return new Blockly.FieldLabel(text, options['class']);
+};
+
+/**
  * Editable fields usually show some sort of UI for the user to change them.
  * @type {boolean}
  * @public
@@ -118,3 +131,5 @@ Blockly.FieldLabel.prototype.getSvgRoot = function() {
 Blockly.FieldLabel.prototype.setTooltip = function(newTip) {
   this.textElement_.tooltip = newTip;
 };
+
+Blockly.Field.register('field_label', Blockly.FieldLabel);

--- a/core/field_label_serializable.js
+++ b/core/field_label_serializable.js
@@ -47,6 +47,19 @@ Blockly.FieldLabelSerializable = function(text, opt_class) {
 goog.inherits(Blockly.FieldLabelSerializable, Blockly.FieldLabel);
 
 /**
+ * Construct a FieldLabelSerializable from a JSON arg object,
+ * dereferencing any string table references.
+ * @param {!Object} options A JSON object with options (text, and class).
+ * @returns {!Blockly.FieldLabelSerializable} The new field instance.
+ * @package
+ * @nocollapse
+ */
+Blockly.FieldLabelSerializable.fromJson = function(options) {
+  var text = Blockly.utils.replaceMessageReferences(options['text']);
+  return new Blockly.FieldLabelSerializable(text, options['class']);
+};
+
+/**
  * Editable fields usually show some sort of UI for the user to change them.
  * This field should be serialized, but only edited programmatically.
  * @type {boolean}
@@ -107,3 +120,6 @@ Blockly.FieldLabelSerializable.prototype.render_ = function() {
     this.textElement_.setAttribute('x', centerTextX);
   }
 };
+
+Blockly.Field.register(
+    'field_label_serializable', Blockly.FieldLabelSerializable);

--- a/core/field_number.js
+++ b/core/field_number.js
@@ -62,6 +62,19 @@ Blockly.FieldNumber = function(opt_value, opt_min, opt_max, opt_precision,
 goog.inherits(Blockly.FieldNumber, Blockly.FieldTextInput);
 
 /**
+ * Construct a FieldNumber from a JSON arg object.
+ * @param {!Object} options A JSON object with options (value, min, max, and
+ *                          precision).
+ * @returns {!Blockly.FieldNumber} The new field instance.
+ * @package
+ * @nocollapse
+ */
+Blockly.FieldNumber.fromJson = function(options) {
+  return new Blockly.FieldNumber(options['value'],
+      options['min'], options['max'], options['precision']);
+};
+
+/**
  * Fixed width of the num-pad drop-down, in px.
  * @type {number}
  * @const
@@ -335,3 +348,5 @@ Blockly.FieldNumber.prototype.onHide_ = function() {
   Blockly.DropDownDiv.content_.removeAttribute('role');
   Blockly.DropDownDiv.content_.removeAttribute('aria-haspopup');
 };
+
+Blockly.Field.register('field_number', Blockly.FieldNumber);

--- a/core/field_numberdropdown.js
+++ b/core/field_numberdropdown.js
@@ -57,5 +57,21 @@ Blockly.FieldNumberDropdown = function(value, menuGenerator, opt_min, opt_max,
   );
   this.addArgType('numberdropdown');
 };
-
 goog.inherits(Blockly.FieldNumberDropdown, Blockly.FieldTextDropdown);
+
+/**
+ * Construct a FieldTextDropdown from a JSON arg object,
+ * dereferencing any string table references.
+ * @param {!Object} element A JSON object with options.
+ * @returns {!Blockly.FieldNumberDropdown} The new field instance.
+ * @package
+ * @nocollapse
+ */
+Blockly.FieldNumberDropdown.fromJson = function(element) {
+  return new Blockly.FieldNumberDropdown(
+      element['value'], element['options'],
+      element['min'], element['max'], element['precision']
+  );
+};
+
+Blockly.Field.register('field_numberdropdown', Blockly.FieldNumberDropdown);

--- a/core/field_textdropdown.js
+++ b/core/field_textdropdown.js
@@ -56,6 +56,23 @@ Blockly.FieldTextDropdown = function(text, menuGenerator, opt_validator, opt_res
 goog.inherits(Blockly.FieldTextDropdown, Blockly.FieldTextInput);
 
 /**
+ * Construct a FieldTextDropdown from a JSON arg object,
+ * dereferencing any string table references.
+ * @param {!Object} element A JSON object with options.
+ * @returns {!Blockly.FieldTextDropdown} The new field instance.
+ * @package
+ * @nocollapse
+ */
+Blockly.FieldTextDropdown.fromJson = function(element) {
+  var field =
+      new Blockly.FieldTextDropdown(element['text'], element['options']);
+  if (typeof element['spellcheck'] == 'boolean') {
+    field.setSpellcheck(element['spellcheck']);
+  }
+  return field;
+};
+
+/**
  * Install this text drop-down field on a block.
  */
 Blockly.FieldTextDropdown.prototype.init = function() {
@@ -143,3 +160,5 @@ Blockly.FieldTextDropdown.prototype.showDropdown_ = Blockly.FieldDropdown.protot
  * Callback when the drop-down menu is hidden.
  */
 Blockly.FieldTextDropdown.prototype.onHide = Blockly.FieldDropdown.prototype.onHide;
+
+Blockly.Field.register('field_textdropdown', Blockly.FieldTextDropdown);

--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -59,6 +59,24 @@ Blockly.FieldTextInput = function(text, opt_validator, opt_restrictor) {
 goog.inherits(Blockly.FieldTextInput, Blockly.Field);
 
 /**
+ * Construct a FieldTextInput from a JSON arg object,
+ * dereferencing any string table references.
+ * @param {!Object} options A JSON object with options (text, class, and
+ *                          spellcheck).
+ * @returns {!Blockly.FieldTextInput} The new field instance.
+ * @package
+ * @nocollapse
+ */
+Blockly.FieldTextInput.fromJson = function(options) {
+  var text = Blockly.utils.replaceMessageReferences(options['text']);
+  var field = new Blockly.FieldTextInput(text, options['class']);
+  if (typeof options['spellcheck'] === 'boolean') {
+    field.setSpellcheck(options['spellcheck']);
+  }
+  return field;
+};
+
+/**
  * Length of animations in seconds.
  */
 Blockly.FieldTextInput.ANIMATION_TIME = 0.25;
@@ -622,3 +640,5 @@ Blockly.FieldTextInput.nonnegativeIntegerValidator = function(text) {
   }
   return n;
 };
+
+Blockly.Field.register('field_input', Blockly.FieldTextInput);

--- a/core/field_textinput_removable.js
+++ b/core/field_textinput_removable.js
@@ -100,3 +100,6 @@ Blockly.FieldTextInputRemovable.fromJson = function(options) {
   }
   return field;
 };
+
+Blockly.Field.register(
+    'field_input_removable', Blockly.FieldTextInputRemovable);

--- a/core/field_variable.js
+++ b/core/field_variable.js
@@ -63,6 +63,20 @@ Blockly.FieldVariable = function(varname, opt_validator, opt_variableTypes) {
 };
 goog.inherits(Blockly.FieldVariable, Blockly.FieldDropdown);
 
+/**
+ * Construct a FieldVariable from a JSON arg object,
+ * dereferencing any string table references.
+ * @param {!Object} options A JSON object with options (variable,
+ *                          variableTypes, and defaultType).
+ * @returns {!Blockly.FieldVariable} The new field instance.
+ * @package
+ * @nocollapse
+ */
+Blockly.FieldVariable.fromJson = function(options) {
+  var varname = Blockly.utils.replaceMessageReferences(options['variable']);
+  var variableTypes = options['variableTypes'];
+  return new Blockly.FieldVariable(varname, null, variableTypes);
+};
 
 /**
  * Initialize everything needed to render this field.  This includes making sure
@@ -343,3 +357,5 @@ Blockly.FieldVariable.prototype.onItemSelected = function(menu, menuItem) {
   }
   this.setValue(id);
 };
+
+Blockly.Field.register('field_variable', Blockly.FieldVariable);

--- a/core/field_variable_getter.js
+++ b/core/field_variable_getter.js
@@ -57,6 +57,21 @@ Blockly.FieldVariableGetter = function(text, name, opt_varType) {
 goog.inherits(Blockly.FieldVariableGetter, Blockly.Field);
 
 /**
+ * Construct a FieldVariableGetter from a JSON arg object,
+ * dereferencing any string table references.
+ * @param {!Object} options A JSON object with options (variable,
+ *                          variableTypes, and defaultType).
+ * @returns {!Blockly.FieldVariableGetter} The new field instance.
+ * @package
+ * @nocollapse
+ */
+Blockly.FieldVariableGetter.fromJson = function(options) {
+  var varname = Blockly.utils.replaceMessageReferences(options['text']);
+  return new Blockly.FieldVariableGetter(varname, options['name'],
+      options['class'], options['variableType']);
+};
+
+/**
  * Editable fields usually show some sort of UI for the user to change them.
  * This field should be serialized, but only edited programmatically.
  * @type {boolean}
@@ -155,3 +170,5 @@ Blockly.FieldVariableGetter.prototype.showEditor_ = function() {
 Blockly.FieldVariableGetter.prototype.updateEditable = function() {
   // nop.
 };
+
+Blockly.Field.register('field_variable_getter', Blockly.FieldVariableGetter);

--- a/core/field_vertical_separator.js
+++ b/core/field_vertical_separator.js
@@ -45,6 +45,19 @@ Blockly.FieldVerticalSeparator = function() {
 goog.inherits(Blockly.FieldVerticalSeparator, Blockly.Field);
 
 /**
+ * Construct a FieldVerticalSeparator from a JSON arg object.
+ * @param {!Object} _element A JSON object with options (unused, but passed in
+ *     by Field.fromJson).
+ * @returns {!Blockly.FieldVerticalSeparator} The new field instance.
+ * @package
+ * @nocollapse
+ */
+Blockly.FieldVerticalSeparator.fromJson = function(
+    /* eslint-disable no-unused-vars */ _element
+    /* eslint-enable no-unused-vars */) {
+  return new Blockly.FieldVerticalSeparator();
+};
+/**
  * Editable fields are saved by the XML renderer, non-editable fields are not.
  */
 Blockly.FieldVerticalSeparator.prototype.EDITABLE = false;
@@ -142,3 +155,6 @@ Blockly.FieldVerticalSeparator.prototype.render_ = function() {
 Blockly.FieldVerticalSeparator.prototype.updateWidth = function() {
  // NOP
 };
+
+Blockly.Field.register(
+    'field_vertical_separator', Blockly.FieldVerticalSeparator);

--- a/tests/jsunit/field_angle_test.js
+++ b/tests/jsunit/field_angle_test.js
@@ -37,3 +37,8 @@ function test_fieldangle_constructor() {
   assertEquals(new Blockly.FieldAngle('bad').getValue(), '0');
   assertEquals(new Blockly.FieldAngle(NaN).getValue(), '0');
 }
+
+function test_fieldangle_fromJson() {
+  assertEquals(Blockly.FieldAngle.fromJson({}).getValue(), '0');
+  assertEquals(Blockly.FieldAngle.fromJson({ angle: 1 }).getValue(), '1');
+}

--- a/tests/jsunit/field_number_test.js
+++ b/tests/jsunit/field_number_test.js
@@ -65,3 +65,20 @@ function test_fieldnumber_constructor() {
   field = new Blockly.FieldNumber(NaN);
   assertEquals(field.getValue(), '0');
 }
+
+function test_fieldnumber_fromJson() {
+  assertEquals(Blockly.FieldNumber.fromJson({}).getValue(), '0');
+  assertEquals(Blockly.FieldNumber.fromJson({ value: 1 }).getValue(), '1');
+
+  // All options
+  var field = Blockly.FieldNumber.fromJson({
+      value: 0,
+      min: -128,
+      max: 127,
+      precision: 1
+  });
+  assertEquals(field.getValue(), '0');
+  assertEquals(field.min_, -128);
+  assertEquals(field.max_, 127);
+  assertEquals(field.precision_, 1);
+}

--- a/tests/jsunit/field_number_test.js
+++ b/tests/jsunit/field_number_test.js
@@ -70,7 +70,8 @@ function test_fieldnumber_fromJson() {
   assertEquals(Blockly.FieldNumber.fromJson({}).getValue(), '0');
   assertEquals(Blockly.FieldNumber.fromJson({ value: 1 }).getValue(), '1');
 
-  // All options
+  // All options, but scratch-blocks parses min/max/precision differently from
+  // Blockly.  See notes in field_number.js.
   var field = Blockly.FieldNumber.fromJson({
       value: 0,
       min: -128,
@@ -78,7 +79,4 @@ function test_fieldnumber_fromJson() {
       precision: 1
   });
   assertEquals(field.getValue(), '0');
-  assertEquals(field.min_, -128);
-  assertEquals(field.max_, 127);
-  assertEquals(field.precision_, 1);
 }

--- a/tests/jsunit/field_test.js
+++ b/tests/jsunit/field_test.js
@@ -97,3 +97,29 @@ function test_field_isEditable_nonEditableBlock_false() {
   assertFalse('Non-editable field with non-editable block is not editable',
       field.isCurrentlyEditable());
 }
+
+function test_field_register_with_custom_field() {
+  var CustomFieldType = function(value) {
+    CustomFieldType.superClass_.constructor.call(this, value);
+  };
+  goog.inherits(CustomFieldType, Blockly.Field);
+
+  CustomFieldType.fromJson = function(options) {
+    return new CustomFieldType(options['value']);
+  };
+
+  var json = {
+    type: 'field_custom_test',
+    value: 'ok'
+  };
+
+  // before registering
+  var field = Blockly.Field.fromJson(json);
+  assertNull(field);
+
+  Blockly.Field.register('field_custom_test', CustomFieldType);
+
+  // after registering
+  field = Blockly.Field.fromJson(json);
+  assertNotNull(field);
+  assertEquals(field.getValue(), 'ok');


### PR DESCRIPTION
### Resolves

None

### Proposed Changes

See https://github.com/google/blockly/pull/1594 and https://github.com/google/blockly/pull/1592

This is the combination of those two, applied to scratch-blocks.

### Reason for Changes

Make it easier to add fields without changing core blockly/scratch-blocks.  close gap in API between blockly and scratch-blocks.

### Test Coverage

jsunit tests pass.  A few new tests added.