### PR TITLE
Don't leak input outline paths

### DIFF
--- a/core/input.js
+++ b/core/input.js
@@ -266,6 +266,12 @@ Blockly.Input.prototype.dispose = function() {
  * @package
  */
 Blockly.Input.prototype.initOutlinePath = function(svgRoot) {
+  if (!this.sourceBlock_.workspace.rendered) {
+    return;  // Headless blocks don't need field outlines.
+  }
+  if (this.outlinePath) {
+    return;
+  }
   if (this.type == Blockly.INPUT_VALUE) {
     this.outlinePath = Blockly.utils.createSvgElement(
       'path',


### PR DESCRIPTION
Don't create a new input outline path if one already exists.
 
I don't believe this affects any of the scratch-blocks blocks as I don't see any blocks using mutations with inputs, but anyone using the library that uses mutations with an input will run into this issue. 

initSvg is called twice (once for the mutation: https://github.com/LLK/scratch-blocks/blob/develop/core/xml.js#L649) and (once when rendering the block: https://github.com/LLK/scratch-blocks/blob/develop/core/xml.js#L539)
which means initOutlinePath is in turn called multiple times

### Resolves

No open issue (that i know of)

### Proposed Changes

The PR only creates a new outline path associated with the input if one doesn't already exist. Otherwise we're okay using the current one. 

### Reason for Changes

Leaking input outlinePaths:
<img width="748" alt="screen shot 2018-04-22 at 5 22 31 pm" src="https://user-images.githubusercontent.com/16690124/39101711-c71644ca-4651-11e8-946c-32e0f17f8ce7.png">

In most cases these are invisible, but I've seen a few cases where it ends up visible, and you just end up with floating input outline paths, something that looks like this: 
<img width="352" alt="screen shot 2018-04-22 at 5 16 34 pm" src="https://user-images.githubusercontent.com/16690124/39101642-f54e557c-4650-11e8-8de3-35fcfc445743.png">

@rachel-fenichel this is probably more your kind of PR

### Test Coverage

Disclaimer: not too familiar with the testing process for this repo, but I checked: 
- there's no change to any of the blocks in the vertical playground
- there's no change to the custom procedure playground blocks