### PR TITLE
Fix vertical alignment of Flyout buttons in Firefox and Edge

### DIFF
--- a/core/flyout_button.js
+++ b/core/flyout_button.js
@@ -174,7 +174,9 @@ Blockly.FlyoutButton.prototype.createDom = function() {
   rect.setAttribute('height', this.height);
 
   svgText.setAttribute('text-anchor', 'middle');
-  svgText.setAttribute('alignment-baseline', 'central');
+  svgText.setAttribute('dominant-baseline', 'central');
+  svgText.setAttribute('dy', goog.userAgent.EDGE_OR_IE ?
+    Blockly.Field.IE_TEXT_OFFSET : '0');
   svgText.setAttribute('x', this.width / 2);
   svgText.setAttribute('y', this.height / 2);
 


### PR DESCRIPTION
### Resolves

Fixes https://github.com/LLK/scratch-blocks/issues/1352
Fixed https://github.com/LLK/scratch-blocks/issues/1376

### Proposed Changes

Use dominant-baseline for Firefox and a similar fix to #1340 for Edge (explicitly setting the dy attribute)

### Reason for Changes

Flyout buttons aren't vertically aligned on Firefox and Edge.

Only the following elements can use alignment-baseline on Firefox: 
```
<tspan>
<tref>
<altglyph>
<textpath>
```
We're using ``<text>`` in this case.

### Test Coverage

Tested on Edge 16
Firefox 59 Mac
Chrome 65 Mac
Safari 11
