### PR TITLE
Update 'mouse' and 'clicked' language to 'pointer' and 'tapped'

### DIFF
--- a/blocks_vertical/default_toolbox.js
+++ b/blocks_vertical/default_toolbox.js
@@ -323,11 +323,6 @@ Blockly.Blocks.defaultToolbox = '<xml id="toolbox-categories" style="display: no
         '<shadow type="colour_picker"></shadow>'+
       '</value>'+
     '</block>'+
-    '<block type="sensing_distanceto" id="sensing_distanceto">'+
-      '<value name="DISTANCETOMENU">'+
-        '<shadow type="sensing_distancetomenu"></shadow>'+
-      '</value>'+
-    '</block>'+
     '<block type="sensing_keypressed" id="sensing_keypressed">'+
         '<value name="KEY_OPTION">'+
           '<shadow type="sensing_keyoptions"></shadow>'+
@@ -336,6 +331,11 @@ Blockly.Blocks.defaultToolbox = '<xml id="toolbox-categories" style="display: no
     '<block type="sensing_mousedown" id="sensing_mousedown"></block>'+
     '<block type="sensing_mousex" id="sensing_mousex"></block>'+
     '<block type="sensing_mousey" id="sensing_mousey"></block>'+
+    '<block type="sensing_distanceto" id="sensing_distanceto">'+
+      '<value name="DISTANCETOMENU">'+
+        '<shadow type="sensing_distancetomenu"></shadow>'+
+      '</value>'+
+    '</block>'+
     '<block type="sensing_setdragmode" id="sensing_setdragmode"></block>' +
     '<block type="sensing_loudness" id="sensing_loudness"></block>'+
     '<block type="sensing_timer" id="sensing_timer"></block>'+

--- a/msg/messages.js
+++ b/msg/messages.js
@@ -68,8 +68,8 @@ Blockly.Msg.DATA_HIDELIST = "hide list %1";
 
 // Event blocks
 Blockly.Msg.EVENT_WHENFLAGCLICKED = "when %1 clicked";
-Blockly.Msg.EVENT_WHENTHISSPRITECLICKED = "when this sprite clicked";
-Blockly.Msg.EVENT_WHENSTAGECLICKED = "when stage clicked";
+Blockly.Msg.EVENT_WHENTHISSPRITECLICKED = "when this sprite tapped";
+Blockly.Msg.EVENT_WHENSTAGECLICKED = "when stage tapped";
 Blockly.Msg.EVENT_WHENBROADCASTRECEIVED = "when I receive %1";
 Blockly.Msg.EVENT_WHENBACKDROPSWITCHESTO = "when backdrop switches to %1";
 Blockly.Msg.EVENT_WHENGREATERTHAN = "when %1 > %2";
@@ -195,9 +195,9 @@ Blockly.Msg.SENSING_DISTANCETO_POINTER = "pointer";
 Blockly.Msg.SENSING_ASKANDWAIT = "ask %1 and wait";
 Blockly.Msg.SENSING_ANSWER = "answer";
 Blockly.Msg.SENSING_KEYPRESSED = "key %1 pressed?";
-Blockly.Msg.SENSING_MOUSEDOWN = "mouse down?";
-Blockly.Msg.SENSING_MOUSEX = "mouse x";
-Blockly.Msg.SENSING_MOUSEY = "mouse y";
+Blockly.Msg.SENSING_MOUSEDOWN = "pointer down?";
+Blockly.Msg.SENSING_MOUSEX = "pointer x";
+Blockly.Msg.SENSING_MOUSEY = "pointer y";
 Blockly.Msg.SENSING_SETDRAGMODE = "set drag mode %1";
 Blockly.Msg.SENSING_SETDRAGMODE_DRAGGABLE = "draggable";
 Blockly.Msg.SENSING_SETDRAGMODE_NOTDRAGGABLE = "not draggable";


### PR DESCRIPTION
### Resolves
Resolves GH-1472

### Proposed Changes
#### Move
- `go to (pointer)`
- `glide (1) secs to (pointer)`
- `point towards (pointer)`

#### Events
- `when this sprite tapped`
- `when stage tapped`

#### Sensing
- `<pointer down?>`
- `(pointer x)`
- `(pointer y)`
- `(distance to (pointer))`

### Reason for Changes
Scratch 3.0 will work on a wide variety of devices including Chromebooks, Windows Surface, iPads, and Android tablets. Many of these devices either exclusively support touch or support a mixture of touch and mouse interaction. Because of this, we would like to retire use of the terms "mouse-pointer" and "clicked" and use the more generic terms "pointer" and "tapped". This will impact a large number of blocks, but feels important in order to properly support touch platforms moving forward.

### Notes
- Some of these changes were made in https://github.com/LLK/scratch-blocks/pull/1469
- After this lands I'll create a small follow-up PR in the GUI to update the order of the `(distance to (pointer))` to fully close out this issue
- I've kept the opcode and message IDs the same for now as I'd like to make sure this "sticks" (testing and feedback from the community)
- I still have some hesitation around the term "tapped" (particularly as we aren't updating the `when "flag" clicked` block, but I'm happy to try this and test it out

### Reference
![image](https://user-images.githubusercontent.com/747641/39255256-13a3c004-487a-11e8-9b43-35fba37559fc.png)
![image](https://user-images.githubusercontent.com/747641/39255284-2299c202-487a-11e8-88e6-b44f494be10a.png)
![image](https://user-images.githubusercontent.com/747641/39255297-2bccc680-487a-11e8-89fb-d7be6e0b5265.png)
![image](https://user-images.githubusercontent.com/747641/39255308-350332c0-487a-11e8-8d76-3da8c2451809.png)


/cc @ntlrsk @SpeakkVisually @carljbowman 