### PR TITLE
Add referencesVariables function to fields

### DIFF
--- a/core/block.js
+++ b/core/block.js
@@ -853,8 +853,7 @@ Blockly.Block.prototype.getVars = function() {
   var vars = [];
   for (var i = 0, input; input = this.inputList[i]; i++) {
     for (var j = 0, field; field = input.fieldRow[j]; j++) {
-      if (field instanceof Blockly.FieldVariable ||
-          field instanceof Blockly.FieldVariableGetter) {
+      if (field.referencesVariables()) {
         vars.push(field.getValue());
       }
     }
@@ -871,8 +870,7 @@ Blockly.Block.prototype.getVarModels = function() {
   var vars = [];
   for (var i = 0, input; input = this.inputList[i]; i++) {
     for (var j = 0, field; field = input.fieldRow[j]; j++) {
-      if (field instanceof Blockly.FieldVariable ||
-          field instanceof Blockly.FieldVariableGetter) {
+      if (field.referencesVariables()) {
         var model = this.workspace.getVariableById(field.getValue());
         // Check if the variable actually exists (and isn't just a potential
         // variable).
@@ -894,8 +892,7 @@ Blockly.Block.prototype.getVarModels = function() {
 Blockly.Block.prototype.updateVarName = function(variable) {
   for (var i = 0, input; input = this.inputList[i]; i++) {
     for (var j = 0, field; field = input.fieldRow[j]; j++) {
-      if ((field instanceof Blockly.FieldVariable ||
-          field instanceof Blockly.FieldVariableGetter) &&
+      if (field.referencesVariables() &&
           variable.getId() == field.getValue()) {
         field.setText(variable.name);
       }
@@ -913,8 +910,7 @@ Blockly.Block.prototype.updateVarName = function(variable) {
 Blockly.Block.prototype.renameVarById = function(oldId, newId) {
   for (var i = 0, input; input = this.inputList[i]; i++) {
     for (var j = 0, field; field = input.fieldRow[j]; j++) {
-      if ((field instanceof Blockly.FieldVariable ||
-          field instanceof Blockly.FieldVariableGetter) &&
+      if (field.referencesVariables() &&
           oldId == field.getValue()) {
         field.setValue(newId);
       }

--- a/core/field.js
+++ b/core/field.js
@@ -777,3 +777,14 @@ Blockly.Field.prototype.getClickTarget_ = function() {
 Blockly.Field.prototype.getAbsoluteXY_ = function() {
   return goog.style.getPageOffset(this.getClickTarget_());
 };
+
+/**
+ * Whether this field references any Blockly variables.  If true it may need to
+ * be handled differently during serialization and deserialization.  Subclasses
+ * may override this.
+ * @return {boolean} True if this field has any variable references.
+ * @package
+ */
+Blockly.Field.prototype.referencesVariables = function() {
+  return false;
+};

--- a/core/field_variable.js
+++ b/core/field_variable.js
@@ -358,4 +358,15 @@ Blockly.FieldVariable.prototype.onItemSelected = function(menu, menuItem) {
   this.setValue(id);
 };
 
+/**
+ * Whether this field references any Blockly variables.  If true it may need to
+ * be handled differently during serialization and deserialization.  Subclasses
+ * may override this.
+ * @return {boolean} True if this field has any variable references.
+ * @package
+ */
+Blockly.FieldVariable.prototype.referencesVariables = function() {
+  return true;
+};
+
 Blockly.Field.register('field_variable', Blockly.FieldVariable);

--- a/core/field_variable_getter.js
+++ b/core/field_variable_getter.js
@@ -171,4 +171,15 @@ Blockly.FieldVariableGetter.prototype.updateEditable = function() {
   // nop.
 };
 
+/**
+ * Whether this field references any Blockly variables.  If true it may need to
+ * be handled differently during serialization and deserialization.  Subclasses
+ * may override this.
+ * @return {boolean} True if this field has any variable references.
+ * @package
+ */
+Blockly.FieldVariableGetter.prototype.referencesVariables = function() {
+  return true;
+};
+
 Blockly.Field.register('field_variable_getter', Blockly.FieldVariableGetter);

--- a/core/xml.js
+++ b/core/xml.js
@@ -131,8 +131,7 @@ Blockly.Xml.fieldToDomVariable_ = function(field) {
  */
 Blockly.Xml.fieldToDom_ = function(field) {
   if (field.name && field.SERIALIZABLE) {
-    if (field instanceof Blockly.FieldVariable ||
-        field instanceof Blockly.FieldVariableGetter) {
+    if (field.referencesVariables()) {
       return Blockly.Xml.fieldToDomVariable_(field);
     } else {
       var container = goog.dom.createDom('field', null, field.getValue());
@@ -819,8 +818,7 @@ Blockly.Xml.domToField_ = function(block, fieldName, xml) {
 
   var workspace = block.workspace;
   var text = xml.textContent;
-  if (field instanceof Blockly.FieldVariable ||
-      field instanceof Blockly.FieldVariableGetter) {
+  if (field.referencesVariables()) {
     Blockly.Xml.domToFieldVariable_(workspace, xml, text, field);
   } else {
     field.setValue(text);


### PR DESCRIPTION
Scratch-blocks version of https://github.com/google/blockly/pull/1827

### Resolves

Merge conflicts/ergonomics.

### Proposed Changes

Add a `referencesVariables` function to field, and use it instead of `field instanceof Blockly.FieldVariable`.

### Reason for Changes

Scratch blocks has more types of fields that references variables, and we have merge conflicts every place where Blockly does one instanceof check and Scratch Blocks does two.

### Test Coverage

_Please show how you have added tests to cover your changes_
