### PR TITLE
Decompose functions in core/zoom_controls.js

### DIFF
--- a/core/zoom_controls.js
+++ b/core/zoom_controls.js
@@ -121,104 +121,11 @@ Blockly.ZoomControls.prototype.top_ = 0;
  * @return {!Element} The zoom controls SVG group.
  */
 Blockly.ZoomControls.prototype.createDom = function() {
-  var workspace = this.workspace_;
-  /* Here's the markup that will be generated:
-  <g class="blocklyZoom" transform="translate(822,594)">
-    <image width="36" height="36" y="0" xlink:href="../media/zoom-in.svg">
-    </image>
-    <image width="36" height="36" y="44" xlink:href="../media/zoom-out.svg">
-    </image>
-    <image width="36" height="36" y="88" xlink:href="../media/zoom-reset.svg">
-    </image>
-  </g>
-  */
-  this.svgGroup_ = Blockly.utils.createSvgElement(
-    'g',
-    {'class': 'blocklyZoom'},
-    null
-  );
-
-  /**
-   * Zoom in control.
-   * @type {SVGElement}
-   */
-  var zoominSvg = Blockly.utils.createSvgElement(
-    'image',
-    {
-      'width': this.WIDTH_,
-      'height': this.WIDTH_,
-      'y': 0
-    },
-    this.svgGroup_
-  );
-  zoominSvg.setAttributeNS(
-    'http://www.w3.org/1999/xlink',
-    'xlink:href',
-    workspace.options.pathToMedia + this.ZOOM_IN_PATH_
-  );
-
-  /**
-   * Zoom out control.
-   * @type {SVGElement}
-   */
-  var zoomoutSvg = Blockly.utils.createSvgElement(
-    'image',
-    {
-      'width': this.WIDTH_,
-      'height': this.WIDTH_,
-      'y': (this.WIDTH_ * 1) + (this.MARGIN_BETWEEN_ * 1)
-    },
-    this.svgGroup_
-  );
-  zoomoutSvg.setAttributeNS(
-    'http://www.w3.org/1999/xlink',
-    'xlink:href',
-    workspace.options.pathToMedia + this.ZOOM_OUT_PATH_
-  );
-
-  /**
-   * Zoom reset control.
-   * @type {SVGElement}
-   */
-  var zoomresetSvg = Blockly.utils.createSvgElement(
-    'image',
-    {
-      'width': this.WIDTH_,
-      'height': this.WIDTH_,
-      'y': (this.WIDTH_ * 2) + (this.MARGIN_BETWEEN_ * 2)
-    },
-    this.svgGroup_
-  );
-  zoomresetSvg.setAttributeNS(
-    'http://www.w3.org/1999/xlink',
-    'xlink:href',
-    workspace.options.pathToMedia + this.ZOOM_RESET_PATH_
-  );
-
-  // Attach event listeners.
-  Blockly.bindEventWithChecks_(zoomresetSvg, 'mousedown', null, function(e) {
-    workspace.markFocused();
-    workspace.setScale(workspace.options.zoomOptions.startScale);
-    workspace.scrollCenter();
-    Blockly.Touch.clearTouchIdentifier();  // Don't block future drags.
-    e.stopPropagation();  // Don't start a workspace scroll.
-    e.preventDefault();  // Stop double-clicking from selecting text.
-  });
-  Blockly.bindEventWithChecks_(zoominSvg, 'mousedown', null, function(e) {
-    workspace.markFocused();
-    workspace.zoomCenter(1);
-    Blockly.Touch.clearTouchIdentifier();  // Don't block future drags.
-    e.stopPropagation();  // Don't start a workspace scroll.
-    e.preventDefault();  // Stop double-clicking from selecting text.
-  });
-  Blockly.bindEventWithChecks_(zoomoutSvg, 'mousedown', null, function(e) {
-    workspace.markFocused();
-    workspace.zoomCenter(-1);
-    Blockly.Touch.clearTouchIdentifier();  // Don't block future drags.
-    e.stopPropagation();  // Don't start a workspace scroll.
-    e.preventDefault();  // Stop double-clicking from selecting text.
-  });
-
+  this.svgGroup_ =
+      Blockly.utils.createSvgElement('g', {'class': 'blocklyZoom'}, null);
+  this.createZoomOutSvg_();
+  this.createZoomInSvg_();
+  this.createZoomResetSvg_();
   return this.svgGroup_;
 };
 
@@ -276,4 +183,119 @@ Blockly.ZoomControls.prototype.position = function() {
   }
   this.svgGroup_.setAttribute('transform',
       'translate(' + this.left_ + ',' + this.top_ + ')');
+};
+
+/**
+ * Create the zoom in icon and its event handler.
+ * The Scratch Blocks implementation of this function is different from the
+ * Blockly implementation.
+ * @private
+ */
+Blockly.ZoomControls.prototype.createZoomOutSvg_ = function() {
+  /* This markup will be generated and added to the "blocklyZoom" group:
+    <image width="36" height="36" y="44" xlink:href="../media/zoom-out.svg">
+    </image>
+  */
+  var ws = this.workspace_;
+  /**
+   * Zoom out control.
+   * @type {SVGElement}
+   */
+  var zoomoutSvg = Blockly.utils.createSvgElement(
+      'image',
+      {
+        'width': this.WIDTH_,
+        'height': this.WIDTH_,
+        'y': (this.WIDTH_ * 1) + (this.MARGIN_BETWEEN_ * 1)
+      },
+      this.svgGroup_
+  );
+  zoomoutSvg.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href',
+      ws.options.pathToMedia + this.ZOOM_OUT_PATH_);
+  // Attach listener.
+  Blockly.bindEventWithChecks_(zoomoutSvg, 'mousedown', null, function(e) {
+    ws.markFocused();
+    ws.zoomCenter(-1);
+    Blockly.Touch.clearTouchIdentifier();  // Don't block future drags.
+    e.stopPropagation();  // Don't start a workspace scroll.
+    e.preventDefault();  // Stop double-clicking from selecting text.
+  });
+};
+
+/**
+ * Create the zoom out icon and its event handler.
+ * The Scratch Blocks implementation of this function is different from the
+ * Blockly implementation.
+ * @private
+ */
+Blockly.ZoomControls.prototype.createZoomInSvg_ = function() {
+  /* This markup will be generated and added to the "blocklyZoom" group:
+    <image width="36" height="36" y="0" xlink:href="../media/zoom-in.svg">
+    </image>
+  */
+  var ws = this.workspace_;
+  /**
+   * Zoom in control.
+   * @type {SVGElement}
+   */
+  var zoominSvg = Blockly.utils.createSvgElement(
+      'image',
+      {
+        'width': this.WIDTH_,
+        'height': this.WIDTH_,
+        'y': 0
+      },
+      this.svgGroup_
+  );
+  zoominSvg.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href',
+      ws.options.pathToMedia + this.ZOOM_IN_PATH_);
+
+  // Attach listener.
+  Blockly.bindEventWithChecks_(zoominSvg, 'mousedown', null, function(e) {
+    ws.markFocused();
+    ws.zoomCenter(1);
+    Blockly.Touch.clearTouchIdentifier();  // Don't block future drags.
+    e.stopPropagation();  // Don't start a workspace scroll.
+    e.preventDefault();  // Stop double-clicking from selecting text.
+  });
+};
+
+/**
+ * Create the zoom reset icon and its event handler.
+ * The Scratch Blocks implementation of this function is different from the
+ * Blockly implementation.
+ * @private
+ */
+Blockly.ZoomControls.prototype.createZoomResetSvg_ = function() {
+  /* This markup will be generated and added to the "blocklyZoom" group:
+    <image width="36" height="36" y="88" xlink:href="../media/zoom-reset.svg">
+    </image>
+  */
+  var ws = this.workspace_;
+
+  /**
+   * Zoom reset control.
+   * @type {SVGElement}
+   */
+  var zoomresetSvg = Blockly.utils.createSvgElement(
+      'image',
+      {
+        'width': this.WIDTH_,
+        'height': this.WIDTH_,
+        'y': (this.WIDTH_ * 2) + (this.MARGIN_BETWEEN_ * 2)
+      },
+      this.svgGroup_
+  );
+  zoomresetSvg.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href',
+      ws.options.pathToMedia + this.ZOOM_RESET_PATH_);
+
+  // Attach event listeners.
+  Blockly.bindEventWithChecks_(zoomresetSvg, 'mousedown', null, function(e) {
+    ws.markFocused();
+    ws.setScale(ws.options.zoomOptions.startScale);
+    ws.scrollCenter();
+    Blockly.Touch.clearTouchIdentifier();  // Don't block future drags.
+    e.stopPropagation();  // Don't start a workspace scroll.
+    e.preventDefault();  // Stop double-clicking from selecting text.
+  });
 };


### PR DESCRIPTION
### Resolves

Scratch blocks version of https://github.com/google/blockly/pull/1828

### Proposed Changes

Make some helper functions to create the zoom controls.

### Reason for Changes

More work for easing merges.   Makes it easier to mark which code is deliberately different in scratch blocks and blockly.

### Test Coverage

_Please show how you have added tests to cover your changes_
