### PR TITLE
Only use Blockly.Msg inside the init functions, since it doesn't exist yet in dist

### DIFF
--- a/blocks_vertical/looks.js
+++ b/blocks_vertical/looks.js
@@ -146,16 +146,6 @@ Blockly.Blocks['looks_hide'] = {
   }
 };
 
-Blockly.Blocks['looks_effect_menu_options'] = [
-  [Blockly.Msg.LOOKS_EFFECT_COLOR, 'COLOR'],
-  [Blockly.Msg.LOOKS_EFFECT_FISHEYE, 'FISHEYE'],
-  [Blockly.Msg.LOOKS_EFFECT_WHIRL, 'WHIRL'],
-  [Blockly.Msg.LOOKS_EFFECT_PIXELATE, 'PIXELATE'],
-  [Blockly.Msg.LOOKS_EFFECT_MOSAIC, 'MOSAIC'],
-  [Blockly.Msg.LOOKS_EFFECT_BRIGHTNESS, 'BRIGHTNESS'],
-  [Blockly.Msg.LOOKS_EFFECT_GHOST, 'GHOST']
-];
-
 Blockly.Blocks['looks_changeeffectby'] = {
   /**
    * Block to change graphic effect.
@@ -168,7 +158,15 @@ Blockly.Blocks['looks_changeeffectby'] = {
         {
           "type": "field_dropdown",
           "name": "EFFECT",
-          "options": Blockly.Blocks['looks_effect_menu_options']
+          "options": [
+            [Blockly.Msg.LOOKS_EFFECT_COLOR, 'COLOR'],
+            [Blockly.Msg.LOOKS_EFFECT_FISHEYE, 'FISHEYE'],
+            [Blockly.Msg.LOOKS_EFFECT_WHIRL, 'WHIRL'],
+            [Blockly.Msg.LOOKS_EFFECT_PIXELATE, 'PIXELATE'],
+            [Blockly.Msg.LOOKS_EFFECT_MOSAIC, 'MOSAIC'],
+            [Blockly.Msg.LOOKS_EFFECT_BRIGHTNESS, 'BRIGHTNESS'],
+            [Blockly.Msg.LOOKS_EFFECT_GHOST, 'GHOST']
+          ]
         },
         {
           "type": "input_value",
@@ -193,7 +191,15 @@ Blockly.Blocks['looks_seteffectto'] = {
         {
           "type": "field_dropdown",
           "name": "EFFECT",
-          "options": Blockly.Blocks['looks_effect_menu_options']
+          "options": [
+            [Blockly.Msg.LOOKS_EFFECT_COLOR, 'COLOR'],
+            [Blockly.Msg.LOOKS_EFFECT_FISHEYE, 'FISHEYE'],
+            [Blockly.Msg.LOOKS_EFFECT_WHIRL, 'WHIRL'],
+            [Blockly.Msg.LOOKS_EFFECT_PIXELATE, 'PIXELATE'],
+            [Blockly.Msg.LOOKS_EFFECT_MOSAIC, 'MOSAIC'],
+            [Blockly.Msg.LOOKS_EFFECT_BRIGHTNESS, 'BRIGHTNESS'],
+            [Blockly.Msg.LOOKS_EFFECT_GHOST, 'GHOST']
+          ]
         },
         {
           "type": "input_value",

--- a/blocks_vertical/sound.js
+++ b/blocks_vertical/sound.js
@@ -115,11 +115,6 @@ Blockly.Blocks['sound_stopallsounds'] = {
   }
 };
 
-Blockly.Blocks['sound_effects_menu_options'] = [
-  [Blockly.Msg.SOUND_EFFECTS_PITCH, 'PITCH'],
-  [Blockly.Msg.SOUND_EFFECTS_PAN, 'PAN']
-];
-
 Blockly.Blocks['sound_seteffectto'] = {
   /**
    * Block to set the audio effect
@@ -132,7 +127,10 @@ Blockly.Blocks['sound_seteffectto'] = {
         {
           "type": "field_dropdown",
           "name": "EFFECT",
-          "options": Blockly.Blocks['sound_effects_menu_options']
+          "options": [
+            [Blockly.Msg.SOUND_EFFECTS_PITCH, 'PITCH'],
+            [Blockly.Msg.SOUND_EFFECTS_PAN, 'PAN']
+          ]
         },
         {
           "type": "input_value",
@@ -157,7 +155,10 @@ Blockly.Blocks['sound_changeeffectby'] = {
         {
           "type": "field_dropdown",
           "name": "EFFECT",
-          "options": Blockly.Blocks['sound_effects_menu_options']
+          "options": [
+            [Blockly.Msg.SOUND_EFFECTS_PITCH, 'PITCH'],
+            [Blockly.Msg.SOUND_EFFECTS_PAN, 'PAN']
+          ]
         },
         {
           "type": "input_value",


### PR DESCRIPTION
Basically, our load order in the final webpack step that bundles together messages/blockly/blocks_vertical is putting messages at the end instead of in the middle. This fixes that while we wait on a real fix to the load order stuff.