### PR TITLE
Store and get category length

### DIFF
--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -544,7 +544,7 @@ Blockly.Flyout.prototype.recordCategoryScrollPositions_ = function() {
     }
   }
   var numCategories = this.categoryScrollPositions.length;
-  for (var i=0; i<numCategories - 1; i++) {
+  for (var i = 0; i < numCategories - 1; i++) {
     var currentPos = this.categoryScrollPositions[i].position;
     var nextPos = this.categoryScrollPositions[i+1].position;
     var length = nextPos - currentPos;

--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -527,7 +527,7 @@ Blockly.Flyout.prototype.show = function(xmlList) {
 };
 
 /**
- * Store an array of category names and scrollbar positions.
+ * Store an array of category names, scrollbar positions, and category lengths.
  * This is used when scrolling the flyout to cause a category to be selected.
  * @private
  */
@@ -543,6 +543,14 @@ Blockly.Flyout.prototype.recordCategoryScrollPositions_ = function() {
       });
     }
   }
+  var numCategories = this.categoryScrollPositions.length;
+  for (var i=0; i<numCategories - 1; i++) {
+    var currentPos = this.categoryScrollPositions[i].position;
+    var nextPos = this.categoryScrollPositions[i+1].position;
+    var length = nextPos - currentPos;
+    this.categoryScrollPositions[i].length = length;
+  }
+  this.categoryScrollPositions[numCategories - 1].length = 0;
 };
 
 /**

--- a/core/toolbox.js
+++ b/core/toolbox.js
@@ -368,6 +368,20 @@ Blockly.Toolbox.prototype.getCategoryPositionByName = function(name) {
 };
 
 /**
+ * Get the length of a category by name.
+ * @param  {string} name The name of the category.
+ * @return {number} The length of the category.
+ */
+Blockly.Toolbox.prototype.getCategoryLengthByName = function(name) {
+  var scrollPositions = this.flyout_.categoryScrollPositions;
+  for (var i = 0; i < scrollPositions.length; i++) {
+    if (name === scrollPositions[i].categoryName) {
+      return scrollPositions[i].length;
+    }
+  }
+};
+
+/**
  * Set the scroll position of the flyout.
  * @param {number} pos The position to set.
  */


### PR DESCRIPTION
### Resolves

Support for https://github.com/LLK/scratch-gui/issues/1638

### Proposed Changes

- When recording the scroll position of the top of each blocks category, also store the length of the category.
- Add a function to get the length of a category by name.

### Reason for Changes

The GUI will use the category length to prevent a problem where the scroll position jumps when switching sprites between a sprite and the stage, while in a category that changes length (such as motion).
