### PR TITLE
Add "all at once" block

### DIFF
--- a/blocks_vertical/control.js
+++ b/blocks_vertical/control.js
@@ -500,3 +500,33 @@ Blockly.Blocks['control_clear_counter'] = {
     });
   }
 };
+
+Blockly.Blocks['control_all_at_once'] = {
+  /**
+   * Block to run the contained script. This is an obsolete block that is
+   * implemented for compatibility with Scratch 2.0 projects. Note that
+   * this was originally designed to run all of the contained blocks
+   * (sequentially, like normal) within a single frame, but this feature
+   * was removed in place of custom blocks marked "run without screen
+   * refresh". The "all at once" block was changed to run the contained
+   * blocks ordinarily, functioning the same way as an "if" block with a
+   * reporter that is always true (e.g. "if 1 = 1"). Also note that the
+   * Scratch 2.0 spec for this block is "warpSpeed", but the label shows
+   * "all at once".
+   * @this Blockly.Block
+   */
+  init: function() {
+    this.jsonInit({
+      "message0": Blockly.Msg.CONTROL_ALLATONCE,
+      "message1": "%1", // Statement
+      "args1": [
+        {
+          "type": "input_statement",
+          "name": "SUBSTACK"
+        }
+      ],
+      "category": Blockly.Categories.control,
+      "extensions": ["colours_control", "shape_statement"]
+    });
+  }
+};

--- a/msg/messages.js
+++ b/msg/messages.js
@@ -50,6 +50,7 @@ Blockly.Msg.CONTROL_DELETETHISCLONE = "delete this clone";
 Blockly.Msg.CONTROL_COUNTER = "counter";
 Blockly.Msg.CONTROL_INCRCOUNTER = "increment counter";
 Blockly.Msg.CONTROL_CLEARCOUNTER = "clear counter";
+Blockly.Msg.CONTROL_ALLATONCE = "all at once";
 
 // Data blocks
 Blockly.Msg.DATA_SETVARIABLETO = "set %1 to %2";


### PR DESCRIPTION
### Resolves

Towards LLK/scratch-vm#355 (adds "all at once" block). Should be merged alongside LLK/scratch-vm#1096.

### Proposed Changes

Adds a new block: `control_all_at_once`. (As with the other hacked blocks, this isn't added to the block palette; it's workaroundable by simply not using the block at all, since it's functionally equivalent to `if 1 = 1`.)

![The new block, the C-shaped "all at once"](https://user-images.githubusercontent.com/9948030/39435312-6d5ab17a-4c71-11e8-882c-47d983cd91fd.png)

### Reason for Changes

Compatibility with Scratch 2.0 projects. This is a hacked block; in total, [around 1800 projects use the "all at once" block](https://github.com/LLK/scratch-vm/issues/355#issuecomment-379418752). (Its opcode is `warpSpeed` in 2.0.)

### Test Coverage

No new tests, but tested manually.