### PR TITLE
Add scroll blocks

### DIFF
--- a/blocks_vertical/motion.js
+++ b/blocks_vertical/motion.js
@@ -478,3 +478,110 @@ Blockly.Blocks['motion_direction'] = {
     });
   }
 };
+
+Blockly.Blocks['motion_scroll_right'] = {
+  /**
+   * Block to scroll the stage right. Does not actually do anything. This is
+   * an obsolete block that is implemented for compatibility with Scratch 2.0
+   * projects.
+   * @this Blockly.Block
+   */
+  init: function() {
+    this.jsonInit({
+      "message0": Blockly.Msg.MOTION_SCROLLRIGHT,
+      "args0": [
+        {
+          "type": "input_value",
+          "name": "DISTANCE"
+        }
+      ],
+      "category": Blockly.Categories.motion,
+      "extensions": ["colours_motion", "shape_statement"]
+    });
+  }
+};
+
+Blockly.Blocks['motion_scroll_up'] = {
+  /**
+   * Block to scroll the stage up. Does not actually do anything. This is an
+   * obsolete block that is implemented for compatibility with Scratch 2.0
+   * projects.
+   * @this Blockly.Block
+   */
+  init: function() {
+    this.jsonInit({
+      "message0": Blockly.Msg.MOTION_SCROLLUP,
+      "args0": [
+        {
+          "type": "input_value",
+          "name": "DISTANCE"
+        }
+      ],
+      "category": Blockly.Categories.motion,
+      "extensions": ["colours_motion", "shape_statement"]
+    });
+  }
+};
+
+Blockly.Blocks['motion_align_scene'] = {
+  /**
+   * Block to change the stage's scrolling alignment. Does not actually do
+   * anything. This is an obsolete block that is implemented for compatibility
+   * with Scratch 2.0 projects.
+   * @this Blockly.Block
+   */
+  init: function() {
+    this.jsonInit({
+      "message0": Blockly.Msg.MOTION_ALIGNSCENE,
+      "args0": [
+        {
+          "type": "field_dropdown",
+          "name": "ALIGNMENT",
+          "options": [
+            [Blockly.Msg.MOTION_ALIGNSCENE_BOTTOMLEFT, 'bottom-left'],
+            [Blockly.Msg.MOTION_ALIGNSCENE_BOTTOMRIGHT, 'bottom-right'],
+            [Blockly.Msg.MOTION_ALIGNSCENE_MIDDLE, 'middle'],
+            [Blockly.Msg.MOTION_ALIGNSCENE_TOPLEFT, 'top-left'],
+            [Blockly.Msg.MOTION_ALIGNSCENE_TOPRIGHT, 'top-right']
+          ]
+        }
+      ],
+      "category": Blockly.Categories.motion,
+      "extensions": ["colours_motion", "shape_statement"]
+    });
+  }
+};
+
+Blockly.Blocks['motion_xscroll'] = {
+  /**
+   * Block to report the stage's scroll position's X value. Does not actually
+   * do anything. This is an obsolete block that is implemented for
+   * compatibility with Scratch 2.0 projects.
+   * @this Blockly.Block
+   */
+  init: function() {
+    this.jsonInit({
+      "message0": Blockly.Msg.MOTION_XSCROLL,
+      "category": Blockly.Categories.motion,
+      "checkboxInFlyout": true,
+      "extensions": ["colours_motion", "output_number"]
+    });
+  }
+};
+
+Blockly.Blocks['motion_yscroll'] = {
+  /**
+   * Block to report the stage's scroll position's Y value. Does not actually
+   * do anything. This is an obsolete block that is implemented for
+   * compatibility with Scratch 2.0 projects.
+   * @this Blockly.Block
+   */
+  init: function() {
+    this.jsonInit({
+      "message0": Blockly.Msg.MOTION_YSCROLL,
+      "category": Blockly.Categories.motion,
+      "checkboxInFlyout": true,
+      "extensions": ["colours_motion", "output_number"]
+    });
+  }
+};

--- a/blocks_vertical/motion.js
+++ b/blocks_vertical/motion.js
@@ -563,7 +563,6 @@ Blockly.Blocks['motion_xscroll'] = {
     this.jsonInit({
       "message0": Blockly.Msg.MOTION_XSCROLL,
       "category": Blockly.Categories.motion,
-      "checkboxInFlyout": true,
       "extensions": ["colours_motion", "output_number"]
     });
   }
@@ -580,7 +579,6 @@ Blockly.Blocks['motion_yscroll'] = {
     this.jsonInit({
       "message0": Blockly.Msg.MOTION_YSCROLL,
       "category": Blockly.Categories.motion,
-      "checkboxInFlyout": true,
       "extensions": ["colours_motion", "output_number"]
     });
   }

--- a/msg/messages.js
+++ b/msg/messages.js
@@ -146,6 +146,16 @@ Blockly.Msg.MOTION_SETROTATIONSTYLE_ALLAROUND = "all around";
 Blockly.Msg.MOTION_XPOSITION = "x position";
 Blockly.Msg.MOTION_YPOSITION = "y position";
 Blockly.Msg.MOTION_DIRECTION = "direction";
+Blockly.Msg.MOTION_SCROLLRIGHT = "scroll right %1";
+Blockly.Msg.MOTION_SCROLLUP = "scroll up %1";
+Blockly.Msg.MOTION_ALIGNSCENE = "align scene %1";
+Blockly.Msg.MOTION_ALIGNSCENE_BOTTOMLEFT = "bottom-left";
+Blockly.Msg.MOTION_ALIGNSCENE_BOTTOMRIGHT = "bottom-right";
+Blockly.Msg.MOTION_ALIGNSCENE_MIDDLE = "middle";
+Blockly.Msg.MOTION_ALIGNSCENE_TOPLEFT = "top-left";
+Blockly.Msg.MOTION_ALIGNSCENE_TOPRIGHT = "top-right";
+Blockly.Msg.MOTION_XSCROLL = "x scroll";
+Blockly.Msg.MOTION_YSCROLL = "y scroll";
 
 // Operators blocks
 Blockly.Msg.OPERATORS_ADD = "%1 + %2";


### PR DESCRIPTION
### Resolves

Towards LLK/scratch-vm#355 (adds scrolling-related blocks). Should be merged alongside LLK/scratch-vm#1099.

### Proposed Changes

Adds five new blocks: `motion_scroll_right`, `motion_scroll_up`, `motion_align_scene`, `motion_xscroll`, and `motion_yscroll`.

![The five new blocks: "scroll right (10)", "scroll up (10)", "x scroll", "y scroll", "align scene (middle)". The "align scene" block's dropdown menu is open, showing its options: "bottom-left", "bottom-right", "middle", "top-left", and "top-right".](https://user-images.githubusercontent.com/9948030/39449922-d781c862-4c9f-11e8-93cf-e41c94532818.png)

### Reason for Changes

Compatibility with Scratch 2.0 projects. These are hacked blocks; in total, [around 130 projects use scroll blocks](https://github.com/LLK/scratch-vm/issues/355#issuecomment-379418752).

### Test Coverage

No new tests, but tested manually.
