### PR TITLE
Add a file for scratch-blocks-specific util functions

### DIFF
--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -27,6 +27,7 @@
 goog.provide('Blockly.BlockSvg.render');
 
 goog.require('Blockly.BlockSvg');
+goog.require('Blockly.scratchBlocksUtils');
 goog.require('Blockly.utils');
 
 
@@ -502,8 +503,8 @@ Blockly.BlockSvg.DEFINE_BLOCK_PADDING_RIGHT = 2 * Blockly.BlockSvg.GRID_UNIT;
  */
 Blockly.BlockSvg.prototype.updateColour = function() {
   var strokeColour = this.getColourTertiary();
-  var renderShadowed =
-      this.isShadow() && !Blockly.utils.isShadowArgumentReporter(this);
+  var renderShadowed = this.isShadow() &&
+      !Blockly.scratchBlocksUtils.isShadowArgumentReporter(this);
 
   if (renderShadowed && this.parentBlock_) {
     // Pull shadow block stroke colour from parent block's tertiary if possible.
@@ -924,7 +925,8 @@ Blockly.BlockSvg.prototype.computeInputWidth_ = function(input) {
 Blockly.BlockSvg.prototype.computeInputHeight_ = function(input, row,
     previousRow) {
   if (this.inputList.length === 1 && this.outputConnection &&
-      (this.isShadow() &&  !Blockly.utils.isShadowArgumentReporter(this))) {
+      (this.isShadow() &&
+      !Blockly.scratchBlocksUtils.isShadowArgumentReporter(this))) {
     // "Lone" field blocks are smaller.
     return Blockly.BlockSvg.MIN_BLOCK_Y_SINGLE_FIELD_OUTPUT;
   } else if (this.outputConnection) {
@@ -983,7 +985,8 @@ Blockly.BlockSvg.prototype.computeRightEdge_ = function(curEdge, hasStatement) {
     // Blocks with notches
     edge = Math.max(edge, Blockly.BlockSvg.MIN_BLOCK_X);
   } else if (this.outputConnection) {
-    if (this.isShadow() && !Blockly.utils.isShadowArgumentReporter(this)) {
+    if (this.isShadow() &&
+        !Blockly.scratchBlocksUtils.isShadowArgumentReporter(this)) {
       // Single-fields
       edge = Math.max(edge, Blockly.BlockSvg.MIN_BLOCK_X_SHADOW_OUTPUT);
     } else {
@@ -1013,7 +1016,8 @@ Blockly.BlockSvg.prototype.computeRightEdge_ = function(curEdge, hasStatement) {
 Blockly.BlockSvg.prototype.computeOutputPadding_ = function(inputRows) {
   // Only apply to blocks with outputs and not single fields (shadows).
   if (!this.getOutputShape() || !this.outputConnection ||
-      (this.isShadow() && !Blockly.utils.isShadowArgumentReporter(this))) {
+      (this.isShadow() &&
+      !Blockly.scratchBlocksUtils.isShadowArgumentReporter(this))) {
     return;
   }
   // Blocks with outputs must have single row to be padded.

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -31,9 +31,11 @@ goog.require('Blockly.BlockAnimations');
 goog.require('Blockly.ContextMenu');
 goog.require('Blockly.Grid');
 goog.require('Blockly.RenderedConnection');
+goog.require('Blockly.scratchBlocksUtils');
 goog.require('Blockly.Tooltip');
 goog.require('Blockly.Touch');
 goog.require('Blockly.utils');
+
 goog.require('goog.Timer');
 goog.require('goog.asserts');
 goog.require('goog.dom');
@@ -682,7 +684,7 @@ Blockly.BlockSvg.prototype.duplicateAndDragCallback_ = function() {
         var newBlock = Blockly.Xml.domToBlock(xml, ws);
 
         // Scratch-specific: Give shadow dom new IDs to prevent duplicating on paste
-        Blockly.utils.changeObscuredShadowIds(newBlock);
+        Blockly.scratchBlocksUtils.changeObscuredShadowIds(newBlock);
 
         var svgRootNew = newBlock.getSvgRoot();
         if (!svgRootNew) {

--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -30,7 +30,9 @@ goog.require('Blockly.BlockSvg.render');
 goog.require('Blockly.Colours');
 goog.require('Blockly.Field');
 goog.require('Blockly.Msg');
+goog.require('Blockly.scratchBlocksUtils');
 goog.require('Blockly.utils');
+
 goog.require('goog.asserts');
 goog.require('goog.dom');
 goog.require('goog.dom.TagName');
@@ -124,13 +126,15 @@ Blockly.FieldTextInput.prototype.init = function() {
 
   // If not in a shadow block, draw a box.
   if (notInShadow) {
-    this.box_ = Blockly.utils.createSvgElement('rect', {
-      'x': 0,
-      'y': 0,
-      'width': this.size_.width,
-      'height': this.size_.height,
-      'fill': this.sourceBlock_.getColourTertiary()
-    });
+    this.box_ = Blockly.utils.createSvgElement('rect',
+        {
+          'x': 0,
+          'y': 0,
+          'width': this.size_.width,
+          'height': this.size_.height,
+          'fill': this.sourceBlock_.getColourTertiary()
+        }
+    );
     this.fieldGroup_.insertBefore(this.box_, this.textElement_);
   }
 };
@@ -455,7 +459,7 @@ Blockly.FieldTextInput.prototype.resizeEditor_ = function() {
   var width;
   if (Blockly.BlockSvg.FIELD_TEXTINPUT_EXPAND_PAST_TRUNCATION) {
     // Resize the box based on the measured width of the text, pre-truncation
-    var textWidth = Blockly.utils.measureText(
+    var textWidth = Blockly.scratchBlocksUtils.measureText(
       Blockly.FieldTextInput.htmlInput_.style.fontSize,
       Blockly.FieldTextInput.htmlInput_.style.fontFamily,
       Blockly.FieldTextInput.htmlInput_.style.fontWeight,

--- a/core/gesture.js
+++ b/core/gesture.js
@@ -32,6 +32,7 @@ goog.require('Blockly.BlockDragger');
 goog.require('Blockly.constants');
 goog.require('Blockly.Events');
 goog.require('Blockly.FlyoutDragger');
+goog.require('Blockly.scratchBlocksUtils');
 goog.require('Blockly.Tooltip');
 goog.require('Blockly.Touch');
 goog.require('Blockly.WorkspaceDragger');
@@ -699,7 +700,8 @@ Blockly.Gesture.prototype.setStartField = function(field) {
 Blockly.Gesture.prototype.setStartBlock = function(block) {
   if (!this.startBlock_) {
     this.startBlock_ = block;
-    this.shouldDuplicateOnDrag_ = Blockly.utils.isShadowArgumentReporter(block);
+    this.shouldDuplicateOnDrag_ =
+        Blockly.scratchBlocksUtils.isShadowArgumentReporter(block);
     if (block.isInFlyout && block != block.getRootBlock()) {
       this.setTargetBlock_(block.getRootBlock());
     } else {

--- a/core/scratch_blocks_utils.js
+++ b/core/scratch_blocks_utils.js
@@ -1,0 +1,103 @@
+/**
+ * @license
+ * Visual Blocks Editor
+ *
+ * Copyright 2018 Google Inc.
+ * https://developers.google.com/blockly/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Utility methods for Scratch Blocks but not Blockly.
+ * @author fenichel@google.com (Rachel Fenichel)
+ */
+'use strict';
+
+/**
+ * @name Blockly.scratchBlocksUtils
+ * @namespace
+ **/
+goog.provide('Blockly.scratchBlocksUtils');
+
+
+/**
+ * Measure some text using a canvas in-memory.
+ * Does not exist in Blockly, but needed in scratch-blocks
+ * @param {string} fontSize E.g., '10pt'
+ * @param {string} fontFamily E.g., 'Arial'
+ * @param {string} fontWeight E.g., '600'
+ * @param {string} text The actual text to measure
+ * @return {number} Width of the text in px.
+ * @package
+ */
+Blockly.scratchBlocksUtils.measureText = function(fontSize, fontFamily,
+    fontWeight, text) {
+  var canvas = document.createElement('canvas');
+  var context = canvas.getContext('2d');
+  context.font = fontWeight + ' ' + fontSize + ' ' + fontFamily;
+  return context.measureText(text).width;
+};
+
+/**
+ * Encode a string's HTML entities.
+ * E.g., <a> -> &lt;a&gt;
+ * Does not exist in Blockly, but needed in scratch-blocks
+ * @param {string} rawStr Unencoded raw string to encode.
+ * @return {string} String with HTML entities encoded.
+ * @package
+ */
+Blockly.scratchBlocksUtils.encodeEntities = function(rawStr) {
+  // CC-BY-SA https://stackoverflow.com/questions/18749591/encode-html-entities-in-javascript
+  return rawStr.replace(/[\u00A0-\u9999<>\&]/gim, function(i) {
+    return '&#' + i.charCodeAt(0) + ';';
+  });
+};
+
+/**
+ * Re-assign obscured shadow blocks new IDs to prevent collisions
+ * Scratch specific to help the VM handle deleting obscured shadows.
+ * @param {Blockly.Block} block the root block to be processed.
+ * @package
+ */
+Blockly.scratchBlocksUtils.changeObscuredShadowIds = function(block) {
+  var blocks = block.getDescendants();
+  for (var i = blocks.length - 1; i >= 0; i--) {
+    var descendant = blocks[i];
+    for (var j = 0; j < descendant.inputList.length; j++) {
+      var connection = descendant.inputList[j].connection;
+      if (connection) {
+        var shadowDom = connection.getShadowDom();
+        if (shadowDom) {
+          shadowDom.setAttribute('id', Blockly.utils.genUid());
+          connection.setShadowDom(shadowDom);
+        }
+      }
+    }
+  }
+};
+
+/**
+ * Whether a block is both a shadow block and an argument reporter.  These
+ * blocks have special behaviour in scratch-blocks: they're duplicated when
+ * dragged, and they are rendered slightly differently from normal shadow
+ * blocks.
+ * @param {!Blockly.BlockSvg} block The block that should be used to make this
+ *     decision.
+ * @return {boolean} True if the block should be duplicated on drag.
+ * @package
+ */
+Blockly.scratchBlocksUtils.isShadowArgumentReporter = function(block) {
+  return (block.isShadow() && (block.type == 'argument_reporter_boolean' ||
+      block.type == 'argument_reporter_string_number'));
+};

--- a/core/utils.js
+++ b/core/utils.js
@@ -812,36 +812,6 @@ Blockly.utils.wrapToText_ = function(words, wordBreaks) {
 };
 
 /**
- * Measure some text using a canvas in-memory.
- * Does not exist in Blockly, but needed in scratch-blocks
- * @param {string} fontSize E.g., '10pt'
- * @param {string} fontFamily E.g., 'Arial'
- * @param {string} fontWeight E.g., '600'
- * @param {string} text The actual text to measure
- * @return {number} Width of the text in px.
- */
-Blockly.utils.measureText = function(fontSize, fontFamily, fontWeight, text) {
-  var canvas = document.createElement('canvas');
-  var context = canvas.getContext('2d');
-  context.font = fontWeight + ' ' + fontSize + ' ' + fontFamily;
-  return context.measureText(text).width;
-};
-
-/**
- * Encode a string's HTML entities.
- * E.g., <a> -> &lt;a&gt;
- * Does not exist in Blockly, but needed in scratch-blocks
- * @param {string} rawStr Unencoded raw string to encode.
- * @return {string} String with HTML entities encoded.
- */
-Blockly.utils.encodeEntities = function(rawStr) {
-  // CC-BY-SA https://stackoverflow.com/questions/18749591/encode-html-entities-in-javascript
-  return rawStr.replace(/[\u00A0-\u9999<>\&]/gim, function(i) {
-    return '&#' + i.charCodeAt(0) + ';';
-  });
-};
-
-/**
  * Check if 3D transforms are supported by adding an element
  * and attempting to set the property.
  * @return {boolean} true if 3D transforms are supported.
@@ -943,43 +913,6 @@ Blockly.utils.runAfterPageLoad = function(fn) {
 Blockly.utils.setCssTransform = function(node, transform) {
   node.style['transform'] = transform;
   node.style['-webkit-transform'] = transform;
-};
-
-/**
- * Re-assign obscured shadow blocks new IDs to prevent collisions
- * Scratch specific to help the VM handle deleting obscured shadows.
- * @param {Blockly.Block} block the root block to be processed.
- */
-Blockly.utils.changeObscuredShadowIds = function(block) {
-  var blocks = block.getDescendants();
-  for (var i = blocks.length - 1; i >= 0; i--) {
-    var descendant = blocks[i];
-    for (var j = 0; j < descendant.inputList.length; j++) {
-      var connection = descendant.inputList[j].connection;
-      if (connection) {
-        var shadowDom = connection.getShadowDom();
-        if (shadowDom) {
-          shadowDom.setAttribute('id', Blockly.utils.genUid());
-          connection.setShadowDom(shadowDom);
-        }
-      }
-    }
-  }
-};
-
-/**
- * Whether a block is both a shadow block and an argument reporter.  These
- * blocks have special behaviour in scratch-blocks: they're duplicated when
- * dragged, and they are rendered slightly differently from normal shadow
- * blocks.
- * @param {!Blockly.BlockSvg} block The block that should be used to make this
- *     decision.
- * @return {boolean} True if the block should be duplicated on drag.
- * @package
- */
-Blockly.utils.isShadowArgumentReporter = function(block) {
-  return (block.isShadow() && (block.type == 'argument_reporter_boolean' ||
-      block.type == 'argument_reporter_string_number'));
 };
 
 /**

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -37,6 +37,7 @@ goog.require('Blockly.Events');
 goog.require('Blockly.Gesture');
 goog.require('Blockly.Grid');
 goog.require('Blockly.Options');
+goog.require('Blockly.scratchBlocksUtils');
 goog.require('Blockly.ScrollbarPair');
 goog.require('Blockly.Touch');
 goog.require('Blockly.Trashcan');
@@ -931,7 +932,7 @@ Blockly.WorkspaceSvg.prototype.reportValue = function(id, value) {
   var contentDiv = Blockly.DropDownDiv.getContentDiv();
   var valueReportBox = goog.dom.createElement('div');
   valueReportBox.setAttribute('class', 'valueReportBox');
-  valueReportBox.innerHTML = Blockly.utils.encodeEntities(value);
+  valueReportBox.innerHTML = Blockly.scratchBlocksUtils.encodeEntities(value);
   contentDiv.appendChild(valueReportBox);
   Blockly.DropDownDiv.setColour(
     Blockly.Colours.valueReportBackground,
@@ -955,7 +956,7 @@ Blockly.WorkspaceSvg.prototype.paste = function(xmlBlock) {
   try {
     var block = Blockly.Xml.domToBlock(xmlBlock, this);
     // Scratch-specific: Give shadow dom new IDs to prevent duplicating on paste
-    Blockly.utils.changeObscuredShadowIds(block);
+    Blockly.scratchBlocksUtils.changeObscuredShadowIds(block);
     // Move the duplicate to original position.
     var blockX = parseInt(xmlBlock.getAttribute('x'), 10);
     var blockY = parseInt(xmlBlock.getAttribute('y'), 10);


### PR DESCRIPTION
### Resolves

None
### Proposed Changes

Moves four functions into a new file + namespace, Blockly.scratchBlocksUtils.  The functions were previously in Blockly.utils.

### Reason for Changes

There are some utility functions that Blockly doesn't need but Scratch Blocks does.  This formalizes where they go, removes some potential merge conflicts, and makes it clearer when code is implementing scratch-blocks-specific behaviour.

### Test Coverage

Rebuilt and played around in the vertical playground.