### PR TITLE
Add "loud?" block

### DIFF
--- a/blocks_vertical/sensing.js
+++ b/blocks_vertical/sensing.js
@@ -358,6 +358,22 @@ Blockly.Blocks['sensing_loudness'] = {
   }
 };
 
+Blockly.Blocks['sensing_loud'] = {
+  /**
+   * Block to report if the loudness is "loud" (greater than 10). This is an
+   * obsolete block that is implemented for compatibility with Scratch 2.0 and
+   * 1.4 projects.
+   * @this Blockly.Block
+   */
+  init: function() {
+    this.jsonInit({
+      "message0": Blockly.Msg.SENSING_LOUD,
+      "category": Blockly.Categories.sensing,
+      "extensions": ["colours_sensing", "output_boolean"]
+    });
+  }
+};
+
 Blockly.Blocks['sensing_timer'] = {
   /**
    * Block to report timer

--- a/msg/messages.js
+++ b/msg/messages.js
@@ -202,6 +202,7 @@ Blockly.Msg.SENSING_SETDRAGMODE = "set drag mode %1";
 Blockly.Msg.SENSING_SETDRAGMODE_DRAGGABLE = "draggable";
 Blockly.Msg.SENSING_SETDRAGMODE_NOTDRAGGABLE = "not draggable";
 Blockly.Msg.SENSING_LOUDNESS = "loudness";
+Blockly.Msg.SENSING_LOUD = "loud?";
 Blockly.Msg.SENSING_TIMER = "timer";
 Blockly.Msg.SENSING_RESETTIMER = "reset timer";
 Blockly.Msg.SENSING_OF = "%1 of %2";


### PR DESCRIPTION
### Resolves

Towards LLK/scratch-vm#355 (adds "loud?" block). Should be merged alongside LLK/scratch-vm#1101.

### Proposed Changes

Adds a new block: `sensing_loud`. (This is a hacked block, so it's not added to the block palette. It's functionally equivalent to `loudness > 1`.)

![The new block, a sensing boolean reporter labeled "loud?".](https://user-images.githubusercontent.com/9948030/39454485-e8392d5a-4cb1-11e8-8d38-5581c9d820a0.png)

### Reason for Changes

Compatibility with Scratch 2.0 and 1.4 projects. This is a hacked block. I don't have a stat on how often it was used, but this block was a "normal" (not hacked) block in Scratch 1.4. (If I recall correctly, 1.4 projects opened in 2.0 would automatically have "loud?" converted to "loudness > 10" -- however, [some projects](https://scratch.mit.edu/projects/56391904/) still managed to get access to the block, and since it still functions correctly, it's worth being implemented.

### Test Coverage

No new tests in scratch-blocks, but tested manually.
