### PR TITLE
Lint in block definitions

### DIFF
--- a/blocks_horizontal/event.js
+++ b/blocks_horizontal/event.js
@@ -66,24 +66,25 @@ Blockly.Blocks['dropdown_whenbroadcast'] = {
    */
   init: function() {
     this.appendDummyInput()
-        .appendField(new Blockly.FieldIconMenu([
-            {src: Blockly.mainWorkspace.options.pathToMedia + 'icons/event_when-broadcast-received_blue.svg',
-              value: 'blue', width: 48, height: 48, alt: 'Blue'},
-            {src: Blockly.mainWorkspace.options.pathToMedia + 'icons/event_when-broadcast-received_green.svg',
-              value: 'green', width: 48, height: 48, alt: 'Green'},
-            {src: Blockly.mainWorkspace.options.pathToMedia + 'icons/event_when-broadcast-received_coral.svg',
-              value: 'coral', width: 48, height: 48, alt: 'Coral'},
-            {src: Blockly.mainWorkspace.options.pathToMedia + 'icons/event_when-broadcast-received_magenta.svg',
-              value: 'magenta', width: 48, height: 48, alt: 'Magenta'},
-            {src: Blockly.mainWorkspace.options.pathToMedia + 'icons/event_when-broadcast-received_orange.svg',
-              value: 'orange', width: 48, height: 48, alt: 'Orange'},
-            {src: Blockly.mainWorkspace.options.pathToMedia + 'icons/event_when-broadcast-received_purple.svg',
-              value: 'purple', width: 48, height: 48, alt: 'Purple'}
-        ]), 'CHOICE');
+        .appendField(new Blockly.FieldIconMenu(
+            [
+              {src: Blockly.mainWorkspace.options.pathToMedia + 'icons/event_when-broadcast-received_blue.svg',
+                value: 'blue', width: 48, height: 48, alt: 'Blue'},
+              {src: Blockly.mainWorkspace.options.pathToMedia + 'icons/event_when-broadcast-received_green.svg',
+                value: 'green', width: 48, height: 48, alt: 'Green'},
+              {src: Blockly.mainWorkspace.options.pathToMedia + 'icons/event_when-broadcast-received_coral.svg',
+                value: 'coral', width: 48, height: 48, alt: 'Coral'},
+              {src: Blockly.mainWorkspace.options.pathToMedia + 'icons/event_when-broadcast-received_magenta.svg',
+                value: 'magenta', width: 48, height: 48, alt: 'Magenta'},
+              {src: Blockly.mainWorkspace.options.pathToMedia + 'icons/event_when-broadcast-received_orange.svg',
+                value: 'orange', width: 48, height: 48, alt: 'Orange'},
+              {src: Blockly.mainWorkspace.options.pathToMedia + 'icons/event_when-broadcast-received_purple.svg',
+                value: 'purple', width: 48, height: 48, alt: 'Purple'}
+            ]), 'CHOICE');
     this.setOutput(true);
     this.setColour(Blockly.Colours.event.primary,
-      Blockly.Colours.event.secondary,
-      Blockly.Colours.event.tertiary
+        Blockly.Colours.event.secondary,
+        Blockly.Colours.event.tertiary
     );
   }
 };
@@ -127,24 +128,25 @@ Blockly.Blocks['dropdown_broadcast'] = {
    */
   init: function() {
     this.appendDummyInput()
-        .appendField(new Blockly.FieldIconMenu([
-            {src: Blockly.mainWorkspace.options.pathToMedia + 'icons/event_broadcast_blue.svg',
-              value: 'blue', width: 48, height: 48, alt: 'Blue'},
-            {src: Blockly.mainWorkspace.options.pathToMedia + 'icons/event_broadcast_green.svg',
-              value: 'green', width: 48, height: 48, alt: 'Green'},
-            {src: Blockly.mainWorkspace.options.pathToMedia + 'icons/event_broadcast_coral.svg',
-              value: 'coral', width: 48, height: 48, alt: 'Coral'},
-            {src: Blockly.mainWorkspace.options.pathToMedia + 'icons/event_broadcast_magenta.svg',
-              value: 'magenta', width: 48, height: 48, alt: 'Magenta'},
-            {src: Blockly.mainWorkspace.options.pathToMedia + 'icons/event_broadcast_orange.svg',
-              value: 'orange', width: 48, height: 48, alt: 'Orange'},
-            {src: Blockly.mainWorkspace.options.pathToMedia + 'icons/event_broadcast_purple.svg',
-              value: 'purple', width: 48, height: 48, alt: 'Purple'}
-        ]), 'CHOICE');
+        .appendField(new Blockly.FieldIconMenu(
+            [
+              {src: Blockly.mainWorkspace.options.pathToMedia + 'icons/event_broadcast_blue.svg',
+                value: 'blue', width: 48, height: 48, alt: 'Blue'},
+              {src: Blockly.mainWorkspace.options.pathToMedia + 'icons/event_broadcast_green.svg',
+                value: 'green', width: 48, height: 48, alt: 'Green'},
+              {src: Blockly.mainWorkspace.options.pathToMedia + 'icons/event_broadcast_coral.svg',
+                value: 'coral', width: 48, height: 48, alt: 'Coral'},
+              {src: Blockly.mainWorkspace.options.pathToMedia + 'icons/event_broadcast_magenta.svg',
+                value: 'magenta', width: 48, height: 48, alt: 'Magenta'},
+              {src: Blockly.mainWorkspace.options.pathToMedia + 'icons/event_broadcast_orange.svg',
+                value: 'orange', width: 48, height: 48, alt: 'Orange'},
+              {src: Blockly.mainWorkspace.options.pathToMedia + 'icons/event_broadcast_purple.svg',
+                value: 'purple', width: 48, height: 48, alt: 'Purple'}
+            ]), 'CHOICE');
     this.setOutput(true);
     this.setColour(Blockly.Colours.event.primary,
-      Blockly.Colours.event.secondary,
-      Blockly.Colours.event.tertiary
+        Blockly.Colours.event.secondary,
+        Blockly.Colours.event.tertiary
     );
   }
 };

--- a/blocks_horizontal/wedo.js
+++ b/blocks_horizontal/wedo.js
@@ -37,30 +37,31 @@ Blockly.Blocks['dropdown_wedo_setcolor'] = {
    */
   init: function() {
     this.appendDummyInput()
-        .appendField(new Blockly.FieldIconMenu([
-          {src: Blockly.mainWorkspace.options.pathToMedia + 'icons/set-led_mystery.svg',
-              value: 'mystery', width: 48, height: 48, alt: 'Mystery'},
-          {src: Blockly.mainWorkspace.options.pathToMedia + 'icons/set-led_yellow.svg',
-              value: 'yellow', width: 48, height: 48, alt: 'Yellow'},
-          {src: Blockly.mainWorkspace.options.pathToMedia + 'icons/set-led_orange.svg',
-            value: 'orange', width: 48, height: 48, alt: 'Orange'},
-          {src: Blockly.mainWorkspace.options.pathToMedia + 'icons/set-led_coral.svg',
-            value: 'coral', width: 48, height: 48, alt: 'Coral'},
-          {src: Blockly.mainWorkspace.options.pathToMedia + 'icons/set-led_magenta.svg',
-            value: 'magenta', width: 48, height: 48, alt: 'Magenta'},
-          {src: Blockly.mainWorkspace.options.pathToMedia + 'icons/set-led_purple.svg',
-            value: 'purple', width: 48, height: 48, alt: 'Purple'},
-          {src: Blockly.mainWorkspace.options.pathToMedia + 'icons/set-led_blue.svg',
-            value: 'blue', width: 48, height: 48, alt: 'Blue'},
-          {src: Blockly.mainWorkspace.options.pathToMedia + 'icons/set-led_green.svg',
-            value: 'green', width: 48, height: 48, alt: 'Green'},
-          {src: Blockly.mainWorkspace.options.pathToMedia + 'icons/set-led_white.svg',
-              value: 'white', width: 48, height: 48, alt: 'White'}
-        ]), 'CHOICE');
+        .appendField(new Blockly.FieldIconMenu(
+            [
+              {src: Blockly.mainWorkspace.options.pathToMedia + 'icons/set-led_mystery.svg',
+                value: 'mystery', width: 48, height: 48, alt: 'Mystery'},
+              {src: Blockly.mainWorkspace.options.pathToMedia + 'icons/set-led_yellow.svg',
+                value: 'yellow', width: 48, height: 48, alt: 'Yellow'},
+              {src: Blockly.mainWorkspace.options.pathToMedia + 'icons/set-led_orange.svg',
+                value: 'orange', width: 48, height: 48, alt: 'Orange'},
+              {src: Blockly.mainWorkspace.options.pathToMedia + 'icons/set-led_coral.svg',
+                value: 'coral', width: 48, height: 48, alt: 'Coral'},
+              {src: Blockly.mainWorkspace.options.pathToMedia + 'icons/set-led_magenta.svg',
+                value: 'magenta', width: 48, height: 48, alt: 'Magenta'},
+              {src: Blockly.mainWorkspace.options.pathToMedia + 'icons/set-led_purple.svg',
+                value: 'purple', width: 48, height: 48, alt: 'Purple'},
+              {src: Blockly.mainWorkspace.options.pathToMedia + 'icons/set-led_blue.svg',
+                value: 'blue', width: 48, height: 48, alt: 'Blue'},
+              {src: Blockly.mainWorkspace.options.pathToMedia + 'icons/set-led_green.svg',
+                value: 'green', width: 48, height: 48, alt: 'Green'},
+              {src: Blockly.mainWorkspace.options.pathToMedia + 'icons/set-led_white.svg',
+                value: 'white', width: 48, height: 48, alt: 'White'}
+            ]), 'CHOICE');
     this.setOutput(true);
     this.setColour(Blockly.Colours.looks.primary,
-      Blockly.Colours.looks.secondary,
-      Blockly.Colours.looks.tertiary
+        Blockly.Colours.looks.secondary,
+        Blockly.Colours.looks.tertiary
     );
   }
 };
@@ -173,18 +174,19 @@ Blockly.Blocks['dropdown_wedo_motorspeed'] = {
    */
   init: function() {
     this.appendDummyInput()
-        .appendField(new Blockly.FieldIconMenu([
-            {src: Blockly.mainWorkspace.options.pathToMedia + 'icons/wedo_motor-speed_slow.svg',
-              value: 'slow', width: 48, height: 48, alt: 'Slow'},
-            {src: Blockly.mainWorkspace.options.pathToMedia + 'icons/wedo_motor-speed_med.svg',
-              value: 'medium', width: 48, height: 48, alt: 'Medium'},
-            {src: Blockly.mainWorkspace.options.pathToMedia + 'icons/wedo_motor-speed_fast.svg',
-              value: 'fast', width: 48, height: 48, alt: 'Fast'}
-        ]), 'CHOICE');
+        .appendField(new Blockly.FieldIconMenu(
+            [
+              {src: Blockly.mainWorkspace.options.pathToMedia + 'icons/wedo_motor-speed_slow.svg',
+                value: 'slow', width: 48, height: 48, alt: 'Slow'},
+              {src: Blockly.mainWorkspace.options.pathToMedia + 'icons/wedo_motor-speed_med.svg',
+                value: 'medium', width: 48, height: 48, alt: 'Medium'},
+              {src: Blockly.mainWorkspace.options.pathToMedia + 'icons/wedo_motor-speed_fast.svg',
+                value: 'fast', width: 48, height: 48, alt: 'Fast'}
+            ]), 'CHOICE');
     this.setOutput(true);
     this.setColour(Blockly.Colours.motion.primary,
-      Blockly.Colours.motion.secondary,
-      Blockly.Colours.motion.tertiary
+        Blockly.Colours.motion.secondary,
+        Blockly.Colours.motion.tertiary
     );
   }
 };
@@ -229,25 +231,26 @@ Blockly.Blocks['dropdown_wedo_whentilt'] = {
    */
   init: function() {
     this.appendDummyInput()
-        .appendField(new Blockly.FieldIconMenu([
-            {type: 'placeholder', width: 48, height: 48},
-            {src: Blockly.mainWorkspace.options.pathToMedia + 'icons/wedo_when-tilt-forward.svg',
-              value: 'forward', width: 48, height: 48, alt: 'Tilt forward'},
-            {type: 'placeholder', width: 48, height: 48},
-            {src: Blockly.mainWorkspace.options.pathToMedia + 'icons/wedo_when-tilt-left.svg',
-              value: 'left', width: 48, height: 48, alt: 'Tilt left'},
-            {src: Blockly.mainWorkspace.options.pathToMedia + 'icons/wedo_when-tilt.svg',
-              value: 'any', width: 48, height: 48, alt: 'Tilt any'},
-            {src: Blockly.mainWorkspace.options.pathToMedia + 'icons/wedo_when-tilt-right.svg',
+        .appendField(new Blockly.FieldIconMenu(
+            [
+              {type: 'placeholder', width: 48, height: 48},
+              {src: Blockly.mainWorkspace.options.pathToMedia + 'icons/wedo_when-tilt-forward.svg',
+                value: 'forward', width: 48, height: 48, alt: 'Tilt forward'},
+              {type: 'placeholder', width: 48, height: 48},
+              {src: Blockly.mainWorkspace.options.pathToMedia + 'icons/wedo_when-tilt-left.svg',
+                value: 'left', width: 48, height: 48, alt: 'Tilt left'},
+              {src: Blockly.mainWorkspace.options.pathToMedia + 'icons/wedo_when-tilt.svg',
+                value: 'any', width: 48, height: 48, alt: 'Tilt any'},
+              {src: Blockly.mainWorkspace.options.pathToMedia + 'icons/wedo_when-tilt-right.svg',
                 value: 'right', width: 48, height: 48, alt: 'Tilt right'},
-            {type: 'placeholder', width: 48, height: 48},
-            {src: Blockly.mainWorkspace.options.pathToMedia + 'icons/wedo_when-tilt-backward.svg',
+              {type: 'placeholder', width: 48, height: 48},
+              {src: Blockly.mainWorkspace.options.pathToMedia + 'icons/wedo_when-tilt-backward.svg',
                 value: 'backward', width: 48, height: 48, alt: 'Tilt backward'}
-        ]), 'CHOICE');
+            ]), 'CHOICE');
     this.setOutput(true);
     this.setColour(Blockly.Colours.event.primary,
-      Blockly.Colours.event.secondary,
-      Blockly.Colours.event.tertiary
+        Blockly.Colours.event.secondary,
+        Blockly.Colours.event.tertiary
     );
   }
 };

--- a/blocks_vertical/control.js
+++ b/blocks_vertical/control.js
@@ -208,8 +208,8 @@ Blockly.Blocks['control_stop'] = {
         .appendField(stopDropdown, 'STOP_OPTION');
     this.setCategory(Blockly.Categories.control);
     this.setColour(Blockly.Colours.control.primary,
-      Blockly.Colours.control.secondary,
-      Blockly.Colours.control.tertiary
+        Blockly.Colours.control.secondary,
+        Blockly.Colours.control.tertiary
     );
     this.setPreviousStatement(true);
   },
@@ -402,20 +402,19 @@ Blockly.Blocks['control_create_clone_of_menu'] = {
    * @this Blockly.Block
    */
   init: function() {
-    this.jsonInit(
-      {
-        "message0": "%1",
-        "args0": [
-          {
-            "type": "field_dropdown",
-            "name": "CLONE_OPTION",
-            "options": [
-              ['myself', '_myself_']
-            ]
-          }
-        ],
-        "extensions": ["colours_control", "output_string"]
-      });
+    this.jsonInit({
+      "message0": "%1",
+      "args0": [
+        {
+          "type": "field_dropdown",
+          "name": "CLONE_OPTION",
+          "options": [
+            ['myself', '_myself_']
+          ]
+        }
+      ],
+      "extensions": ["colours_control", "output_string"]
+    });
   }
 };
 

--- a/blocks_vertical/data.js
+++ b/blocks_vertical/data.js
@@ -478,7 +478,7 @@ Blockly.Constants.Data.CUSTOM_CONTEXT_MENU_GET_VARIABLE_MIXIN = {
 
         option.callback =
             Blockly.Constants.Data.VARIABLE_OPTION_CALLBACK_FACTORY(this,
-            option.text);
+                option.text);
         options.push(option);
       }
     } else {
@@ -500,7 +500,7 @@ Blockly.Constants.Data.CUSTOM_CONTEXT_MENU_GET_VARIABLE_MIXIN = {
 };
 
 Blockly.Extensions.registerMixin('contextMenu_getVariableBlock',
-  Blockly.Constants.Data.CUSTOM_CONTEXT_MENU_GET_VARIABLE_MIXIN);
+    Blockly.Constants.Data.CUSTOM_CONTEXT_MENU_GET_VARIABLE_MIXIN);
 
 /**
  * Callback factory for dropdown menu options associated with a variable getter

--- a/blocks_vertical/event.js
+++ b/blocks_vertical/event.js
@@ -117,7 +117,7 @@ Blockly.Blocks['event_whenbackdropswitchesto'] = {
           "type": "field_dropdown",
           "name": "BACKDROP",
           "options": [
-              ['backdrop1', 'BACKDROP1']
+            ['backdrop1', 'BACKDROP1']
           ]
         }
       ],
@@ -140,7 +140,7 @@ Blockly.Blocks['event_whengreaterthan'] = {
           "type": "field_dropdown",
           "name": "WHENGREATERTHANMENU",
           "options": [
-              ['timer', 'TIMER']
+            ['timer', 'TIMER']
           ]
         },
         {
@@ -160,22 +160,21 @@ Blockly.Blocks['event_broadcast_menu'] = {
    * @this Blockly.Block
    */
   init: function() {
-    this.jsonInit(
-      {
-        "message0": "%1",
-        "args0": [
-          {
-            "type": "field_variable",
-            "name": "BROADCAST_OPTION",
-            "variableTypes":[Blockly.BROADCAST_MESSAGE_VARIABLE_TYPE],
-            "variable": Blockly.Msg.DEFAULT_BROADCAST_MESSAGE_NAME
-          }
-        ],
-        "colour": Blockly.Colours.event.secondary,
-        "colourSecondary": Blockly.Colours.event.secondary,
-        "colourTertiary": Blockly.Colours.event.tertiary,
-        "extensions": ["output_string"]
-      });
+    this.jsonInit({
+      "message0": "%1",
+      "args0": [
+        {
+          "type": "field_variable",
+          "name": "BROADCAST_OPTION",
+          "variableTypes":[Blockly.BROADCAST_MESSAGE_VARIABLE_TYPE],
+          "variable": Blockly.Msg.DEFAULT_BROADCAST_MESSAGE_NAME
+        }
+      ],
+      "colour": Blockly.Colours.event.secondary,
+      "colourSecondary": Blockly.Colours.event.secondary,
+      "colourTertiary": Blockly.Colours.event.tertiary,
+      "extensions": ["output_string"]
+    });
   }
 };
 

--- a/blocks_vertical/extensions.js
+++ b/blocks_vertical/extensions.js
@@ -190,23 +190,22 @@ Blockly.Blocks['extension_wedo_tilt_menu'] = {
    * @this Blockly.Block
    */
   init: function() {
-    this.jsonInit(
-      {
-        "message0": "%1",
-        "args0": [
-          {
-            "type": "field_dropdown",
-            "name": "TILT",
-            "options": [
-              ['Any', 'Any'],
-              ['Whirl', 'Whirl'],
-              ['South', 'South'],
-              ['Back in time', 'Back in time']
-            ]
-          }
-        ],
-        "extensions": ["colours_more", "output_string"]
-      });
+    this.jsonInit({
+      "message0": "%1",
+      "args0": [
+        {
+          "type": "field_dropdown",
+          "name": "TILT",
+          "options": [
+            ['Any', 'Any'],
+            ['Whirl', 'Whirl'],
+            ['South', 'South'],
+            ['Back in time', 'Back in time']
+          ]
+        }
+      ],
+      "extensions": ["colours_more", "output_string"]
+    });
   }
 };
 

--- a/blocks_vertical/looks.js
+++ b/blocks_vertical/looks.js
@@ -122,12 +122,11 @@ Blockly.Blocks['looks_show'] = {
    * @this Blockly.Block
    */
   init: function() {
-    this.jsonInit(
-      {
-        "message0": Blockly.Msg.LOOKS_SHOW,
-        "category": Blockly.Categories.looks,
-        "extensions": ["colours_looks", "shape_statement"]
-      });
+    this.jsonInit({
+      "message0": Blockly.Msg.LOOKS_SHOW,
+      "category": Blockly.Categories.looks,
+      "extensions": ["colours_looks", "shape_statement"]
+    });
   }
 };
 
@@ -137,12 +136,11 @@ Blockly.Blocks['looks_hide'] = {
    * @this Blockly.Block
    */
   init: function() {
-    this.jsonInit(
-      {
-        "message0": Blockly.Msg.LOOKS_HIDE,
-        "category": Blockly.Categories.looks,
-        "extensions": ["colours_looks", "shape_statement"]
-      });
+    this.jsonInit({
+      "message0": Blockly.Msg.LOOKS_HIDE,
+      "category": Blockly.Categories.looks,
+      "extensions": ["colours_looks", "shape_statement"]
+    });
   }
 };
 
@@ -154,12 +152,11 @@ Blockly.Blocks['looks_hideallsprites'] = {
    * @this Blockly.Block
    */
   init: function() {
-    this.jsonInit(
-      {
-        "message0": Blockly.Msg.LOOKS_HIDEALLSPRITES,
-        "category": Blockly.Categories.looks,
-        "extensions": ["colours_looks", "shape_statement"]
-      });
+    this.jsonInit({
+      "message0": Blockly.Msg.LOOKS_HIDEALLSPRITES,
+      "category": Blockly.Categories.looks,
+      "extensions": ["colours_looks", "shape_statement"]
+    });
   }
 };
 
@@ -355,24 +352,23 @@ Blockly.Blocks['looks_costume'] = {
    * @this Blockly.Block
    */
   init: function() {
-    this.jsonInit(
-      {
-        "message0": "%1",
-        "args0": [
-          {
-            "type": "field_dropdown",
-            "name": "COSTUME",
-            "options": [
-              ['costume1', 'COSTUME1'],
-              ['costume2', 'COSTUME2']
-            ]
-          }
-        ],
-        "colour": Blockly.Colours.looks.secondary,
-        "colourSecondary": Blockly.Colours.looks.secondary,
-        "colourTertiary": Blockly.Colours.looks.tertiary,
-        "extensions": ["output_string"]
-      });
+    this.jsonInit({
+      "message0": "%1",
+      "args0": [
+        {
+          "type": "field_dropdown",
+          "name": "COSTUME",
+          "options": [
+            ['costume1', 'COSTUME1'],
+            ['costume2', 'COSTUME2']
+          ]
+        }
+      ],
+      "colour": Blockly.Colours.looks.secondary,
+      "colourSecondary": Blockly.Colours.looks.secondary,
+      "colourTertiary": Blockly.Colours.looks.tertiary,
+      "extensions": ["output_string"]
+    });
   }
 };
 
@@ -402,12 +398,11 @@ Blockly.Blocks['looks_nextcostume'] = {
    * @this Blockly.Block
    */
   init: function() {
-    this.jsonInit(
-      {
-        "message0": Blockly.Msg.LOOKS_NEXTCOSTUME,
-        "category": Blockly.Categories.looks,
-        "extensions": ["colours_looks", "shape_statement"]
-      });
+    this.jsonInit({
+      "message0": Blockly.Msg.LOOKS_NEXTCOSTUME,
+      "category": Blockly.Categories.looks,
+      "extensions": ["colours_looks", "shape_statement"]
+    });
   }
 };
 
@@ -445,7 +440,7 @@ Blockly.Blocks['looks_backdrops'] = {
           "type": "field_dropdown",
           "name": "BACKDROP",
           "options": [
-              ['backdrop1', 'BACKDROP1']
+            ['backdrop1', 'BACKDROP1']
           ]
         }
       ],
@@ -463,22 +458,21 @@ Blockly.Blocks['looks_gotofrontback'] = {
    * @this Blockly.Block
    */
   init: function() {
-    this.jsonInit(
-      {
-        "message0": Blockly.Msg.LOOKS_GOTOFRONTBACK,
-        "args0": [
-          {
-            "type": "field_dropdown",
-            "name": "FRONT_BACK",
-            "options": [
-              [Blockly.Msg.LOOKS_GOTOFRONTBACK_FRONT, 'front'],
-              [Blockly.Msg.LOOKS_GOTOFRONTBACK_BACK, 'back']
-            ]
-          }
-        ],
-        "category": Blockly.Categories.looks,
-        "extensions": ["colours_looks", "shape_statement"]
-      });
+    this.jsonInit({
+      "message0": Blockly.Msg.LOOKS_GOTOFRONTBACK,
+      "args0": [
+        {
+          "type": "field_dropdown",
+          "name": "FRONT_BACK",
+          "options": [
+            [Blockly.Msg.LOOKS_GOTOFRONTBACK_FRONT, 'front'],
+            [Blockly.Msg.LOOKS_GOTOFRONTBACK_BACK, 'back']
+          ]
+        }
+      ],
+      "category": Blockly.Categories.looks,
+      "extensions": ["colours_looks", "shape_statement"]
+    });
   }
 };
 
@@ -586,11 +580,10 @@ Blockly.Blocks['looks_nextbackdrop'] = {
    * @this Blockly.Block
    */
   init: function() {
-    this.jsonInit(
-      {
-        "message0": Blockly.Msg.LOOKS_NEXTBACKDROP,
-        "category": Blockly.Categories.looks,
-        "extensions": ["colours_looks", "shape_statement"]
-      });
+    this.jsonInit({
+      "message0": Blockly.Msg.LOOKS_NEXTBACKDROP,
+      "category": Blockly.Categories.looks,
+      "extensions": ["colours_looks", "shape_statement"]
+    });
   }
 };

--- a/blocks_vertical/motion.js
+++ b/blocks_vertical/motion.js
@@ -126,23 +126,22 @@ Blockly.Blocks['motion_pointtowards_menu'] = {
    * @this Blockly.Block
    */
   init: function() {
-    this.jsonInit(
-      {
-        "message0": "%1",
-        "args0": [
-          {
-            "type": "field_dropdown",
-            "name": "TOWARDS",
-            "options": [
-              [Blockly.Msg.MOTION_POINTTOWARDS_POINTER, '_mouse_']
-            ]
-          }
-        ],
-        "colour": Blockly.Colours.motion.secondary,
-        "colourSecondary": Blockly.Colours.motion.secondary,
-        "colourTertiary": Blockly.Colours.motion.tertiary,
-        "extensions": ["output_string"]
-      });
+    this.jsonInit({
+      "message0": "%1",
+      "args0": [
+        {
+          "type": "field_dropdown",
+          "name": "TOWARDS",
+          "options": [
+            [Blockly.Msg.MOTION_POINTTOWARDS_POINTER, '_mouse_']
+          ]
+        }
+      ],
+      "colour": Blockly.Colours.motion.secondary,
+      "colourSecondary": Blockly.Colours.motion.secondary,
+      "colourTertiary": Blockly.Colours.motion.tertiary,
+      "extensions": ["output_string"]
+    });
   }
 };
 
@@ -172,24 +171,23 @@ Blockly.Blocks['motion_goto_menu'] = {
    * @this Blockly.Block
    */
   init: function() {
-    this.jsonInit(
-      {
-        "message0": "%1",
-        "args0": [
-          {
-            "type": "field_dropdown",
-            "name": "TO",
-            "options": [
-              [Blockly.Msg.MOTION_GOTO_POINTER, '_mouse_'],
-              [Blockly.Msg.MOTION_GOTO_RANDOM, '_random_']
-            ]
-          }
-        ],
-        "colour": Blockly.Colours.motion.secondary,
-        "colourSecondary": Blockly.Colours.motion.secondary,
-        "colourTertiary": Blockly.Colours.motion.tertiary,
-        "extensions": ["output_string"]
-      });
+    this.jsonInit({
+      "message0": "%1",
+      "args0": [
+        {
+          "type": "field_dropdown",
+          "name": "TO",
+          "options": [
+            [Blockly.Msg.MOTION_GOTO_POINTER, '_mouse_'],
+            [Blockly.Msg.MOTION_GOTO_RANDOM, '_random_']
+          ]
+        }
+      ],
+      "colour": Blockly.Colours.motion.secondary,
+      "colourSecondary": Blockly.Colours.motion.secondary,
+      "colourTertiary": Blockly.Colours.motion.tertiary,
+      "extensions": ["output_string"]
+    });
   }
 };
 

--- a/blocks_vertical/operators.js
+++ b/blocks_vertical/operators.js
@@ -34,22 +34,21 @@ Blockly.Blocks['operator_add'] = {
    * @this Blockly.Block
    */
   init: function() {
-    this.jsonInit(
-      {
-        "message0": Blockly.Msg.OPERATORS_ADD,
-        "args0": [
-          {
-            "type": "input_value",
-            "name": "NUM1"
-          },
-          {
-            "type": "input_value",
-            "name": "NUM2"
-          }
-        ],
-        "category": Blockly.Categories.operators,
-        "extensions": ["colours_operators", "output_number"]
-      });
+    this.jsonInit({
+      "message0": Blockly.Msg.OPERATORS_ADD,
+      "args0": [
+        {
+          "type": "input_value",
+          "name": "NUM1"
+        },
+        {
+          "type": "input_value",
+          "name": "NUM2"
+        }
+      ],
+      "category": Blockly.Categories.operators,
+      "extensions": ["colours_operators", "output_number"]
+    });
   }
 };
 
@@ -59,22 +58,21 @@ Blockly.Blocks['operator_subtract'] = {
    * @this Blockly.Block
    */
   init: function() {
-    this.jsonInit(
-      {
-        "message0": Blockly.Msg.OPERATORS_SUBTRACT,
-        "args0": [
-          {
-            "type": "input_value",
-            "name": "NUM1"
-          },
-          {
-            "type": "input_value",
-            "name": "NUM2"
-          }
-        ],
-        "category": Blockly.Categories.operators,
-        "extensions": ["colours_operators", "output_number"]
-      });
+    this.jsonInit({
+      "message0": Blockly.Msg.OPERATORS_SUBTRACT,
+      "args0": [
+        {
+          "type": "input_value",
+          "name": "NUM1"
+        },
+        {
+          "type": "input_value",
+          "name": "NUM2"
+        }
+      ],
+      "category": Blockly.Categories.operators,
+      "extensions": ["colours_operators", "output_number"]
+    });
   }
 };
 
@@ -84,22 +82,21 @@ Blockly.Blocks['operator_multiply'] = {
    * @this Blockly.Block
    */
   init: function() {
-    this.jsonInit(
-      {
-        "message0": Blockly.Msg.OPERATORS_MULTIPLY,
-        "args0": [
-          {
-            "type": "input_value",
-            "name": "NUM1"
-          },
-          {
-            "type": "input_value",
-            "name": "NUM2"
-          }
-        ],
-        "category": Blockly.Categories.operators,
-        "extensions": ["colours_operators", "output_number"]
-      });
+    this.jsonInit({
+      "message0": Blockly.Msg.OPERATORS_MULTIPLY,
+      "args0": [
+        {
+          "type": "input_value",
+          "name": "NUM1"
+        },
+        {
+          "type": "input_value",
+          "name": "NUM2"
+        }
+      ],
+      "category": Blockly.Categories.operators,
+      "extensions": ["colours_operators", "output_number"]
+    });
   }
 };
 
@@ -109,22 +106,21 @@ Blockly.Blocks['operator_divide'] = {
    * @this Blockly.Block
    */
   init: function() {
-    this.jsonInit(
-      {
-        "message0": Blockly.Msg.OPERATORS_DIVIDE,
-        "args0": [
-          {
-            "type": "input_value",
-            "name": "NUM1"
-          },
-          {
-            "type": "input_value",
-            "name": "NUM2"
-          }
-        ],
-        "category": Blockly.Categories.operators,
-        "extensions": ["colours_operators", "output_number"]
-      });
+    this.jsonInit({
+      "message0": Blockly.Msg.OPERATORS_DIVIDE,
+      "args0": [
+        {
+          "type": "input_value",
+          "name": "NUM1"
+        },
+        {
+          "type": "input_value",
+          "name": "NUM2"
+        }
+      ],
+      "category": Blockly.Categories.operators,
+      "extensions": ["colours_operators", "output_number"]
+    });
   }
 };
 
@@ -134,22 +130,21 @@ Blockly.Blocks['operator_random'] = {
    * @this Blockly.Block
    */
   init: function() {
-    this.jsonInit(
-      {
-        "message0": Blockly.Msg.OPERATORS_RANDOM,
-        "args0": [
-          {
-            "type": "input_value",
-            "name": "FROM"
-          },
-          {
-            "type": "input_value",
-            "name": "TO"
-          }
-        ],
-        "category": Blockly.Categories.operators,
-        "extensions": ["colours_operators", "output_number"]
-      });
+    this.jsonInit({
+      "message0": Blockly.Msg.OPERATORS_RANDOM,
+      "args0": [
+        {
+          "type": "input_value",
+          "name": "FROM"
+        },
+        {
+          "type": "input_value",
+          "name": "TO"
+        }
+      ],
+      "category": Blockly.Categories.operators,
+      "extensions": ["colours_operators", "output_number"]
+    });
   }
 };
 
@@ -372,22 +367,21 @@ Blockly.Blocks['operator_contains'] = {
    * @this Blockly.Block
    */
   init: function() {
-    this.jsonInit(
-      {
-        "message0": Blockly.Msg.OPERATORS_CONTAINS,
-        "args0": [
-          {
-            "type": "input_value",
-            "name": "STRING1"
-          },
-          {
-            "type": "input_value",
-            "name": "STRING2"
-          }
-        ],
-        "category": Blockly.Categories.operators,
-        "extensions": ["colours_operators", "output_boolean"]
-      });
+    this.jsonInit({
+      "message0": Blockly.Msg.OPERATORS_CONTAINS,
+      "args0": [
+        {
+          "type": "input_value",
+          "name": "STRING1"
+        },
+        {
+          "type": "input_value",
+          "name": "STRING2"
+        }
+      ],
+      "category": Blockly.Categories.operators,
+      "extensions": ["colours_operators", "output_boolean"]
+    });
   }
 };
 
@@ -397,22 +391,21 @@ Blockly.Blocks['operator_mod'] = {
    * @this Blockly.Block
    */
   init: function() {
-    this.jsonInit(
-      {
-        "message0": Blockly.Msg.OPERATORS_MOD,
-        "args0": [
-          {
-            "type": "input_value",
-            "name": "NUM1"
-          },
-          {
-            "type": "input_value",
-            "name": "NUM2"
-          }
-        ],
-        "category": Blockly.Categories.operators,
-        "extensions": ["colours_operators", "output_number"]
-      });
+    this.jsonInit({
+      "message0": Blockly.Msg.OPERATORS_MOD,
+      "args0": [
+        {
+          "type": "input_value",
+          "name": "NUM1"
+        },
+        {
+          "type": "input_value",
+          "name": "NUM2"
+        }
+      ],
+      "category": Blockly.Categories.operators,
+      "extensions": ["colours_operators", "output_number"]
+    });
   }
 };
 
@@ -422,18 +415,17 @@ Blockly.Blocks['operator_round'] = {
    * @this Blockly.Block
    */
   init: function() {
-    this.jsonInit(
-      {
-        "message0": Blockly.Msg.OPERATORS_ROUND,
-        "args0": [
-          {
-            "type": "input_value",
-            "name": "NUM"
-          }
-        ],
-        "category": Blockly.Categories.operators,
-        "extensions": ["colours_operators", "output_number"]
-      });
+    this.jsonInit({
+      "message0": Blockly.Msg.OPERATORS_ROUND,
+      "args0": [
+        {
+          "type": "input_value",
+          "name": "NUM"
+        }
+      ],
+      "category": Blockly.Categories.operators,
+      "extensions": ["colours_operators", "output_number"]
+    });
   }
 };
 
@@ -443,37 +435,36 @@ Blockly.Blocks['operator_mathop'] = {
    * @this Blockly.Block
    */
   init: function() {
-    this.jsonInit(
-      {
-        "message0": Blockly.Msg.OPERATORS_MATHOP,
-        "args0": [
-          {
-            "type": "field_dropdown",
-            "name": "OPERATOR",
-            "options": [
-              [Blockly.Msg.OPERATORS_MATHOP_ABS, 'abs'],
-              [Blockly.Msg.OPERATORS_MATHOP_FLOOR, 'floor'],
-              [Blockly.Msg.OPERATORS_MATHOP_CEILING, 'ceiling'],
-              [Blockly.Msg.OPERATORS_MATHOP_SQRT, 'sqrt'],
-              [Blockly.Msg.OPERATORS_MATHOP_SIN, 'sin'],
-              [Blockly.Msg.OPERATORS_MATHOP_COS, 'cos'],
-              [Blockly.Msg.OPERATORS_MATHOP_TAN, 'tan'],
-              [Blockly.Msg.OPERATORS_MATHOP_ASIN, 'asin'],
-              [Blockly.Msg.OPERATORS_MATHOP_ACOS, 'acos'],
-              [Blockly.Msg.OPERATORS_MATHOP_ATAN, 'atan'],
-              [Blockly.Msg.OPERATORS_MATHOP_LN, 'ln'],
-              [Blockly.Msg.OPERATORS_MATHOP_LOG, 'log'],
-              [Blockly.Msg.OPERATORS_MATHOP_EEXP, 'e ^'],
-              [Blockly.Msg.OPERATORS_MATHOP_10EXP, '10 ^']
-            ]
-          },
-          {
-            "type": "input_value",
-            "name": "NUM"
-          }
-        ],
-        "category": Blockly.Categories.operators,
-        "extensions": ["colours_operators", "output_number"]
-      });
+    this.jsonInit({
+      "message0": Blockly.Msg.OPERATORS_MATHOP,
+      "args0": [
+        {
+          "type": "field_dropdown",
+          "name": "OPERATOR",
+          "options": [
+            [Blockly.Msg.OPERATORS_MATHOP_ABS, 'abs'],
+            [Blockly.Msg.OPERATORS_MATHOP_FLOOR, 'floor'],
+            [Blockly.Msg.OPERATORS_MATHOP_CEILING, 'ceiling'],
+            [Blockly.Msg.OPERATORS_MATHOP_SQRT, 'sqrt'],
+            [Blockly.Msg.OPERATORS_MATHOP_SIN, 'sin'],
+            [Blockly.Msg.OPERATORS_MATHOP_COS, 'cos'],
+            [Blockly.Msg.OPERATORS_MATHOP_TAN, 'tan'],
+            [Blockly.Msg.OPERATORS_MATHOP_ASIN, 'asin'],
+            [Blockly.Msg.OPERATORS_MATHOP_ACOS, 'acos'],
+            [Blockly.Msg.OPERATORS_MATHOP_ATAN, 'atan'],
+            [Blockly.Msg.OPERATORS_MATHOP_LN, 'ln'],
+            [Blockly.Msg.OPERATORS_MATHOP_LOG, 'log'],
+            [Blockly.Msg.OPERATORS_MATHOP_EEXP, 'e ^'],
+            [Blockly.Msg.OPERATORS_MATHOP_10EXP, '10 ^']
+          ]
+        },
+        {
+          "type": "input_value",
+          "name": "NUM"
+        }
+      ],
+      "category": Blockly.Categories.operators,
+      "extensions": ["colours_operators", "output_number"]
+    });
   }
 };

--- a/blocks_vertical/procedures.js
+++ b/blocks_vertical/procedures.js
@@ -200,7 +200,7 @@ Blockly.ScratchBlocks.ProcedureUtils.removeAllInputs_ = function() {
  */
 Blockly.ScratchBlocks.ProcedureUtils.createAllInputs_ = function(connectionMap) {
   // Split the proc into components, by %n, %b, and %s (ignoring escaped).
-  var procComponents = this.procCode_.split(/(?=[^\\]\%[nbs])/);
+  var procComponents = this.procCode_.split(/(?=[^\\]%[nbs])/);
   procComponents = procComponents.map(function(c) {
     return c.trim(); // Strip whitespace.
   });

--- a/blocks_vertical/sensing.js
+++ b/blocks_vertical/sensing.js
@@ -54,21 +54,20 @@ Blockly.Blocks['sensing_touchingobjectmenu'] = {
    * @this Blockly.Block
    */
   init: function() {
-    this.jsonInit(
-      {
-        "message0": "%1",
-        "args0": [
-          {
-            "type": "field_dropdown",
-            "name": "TOUCHINGOBJECTMENU",
-            "options": [
-              [Blockly.Msg.SENSING_TOUCHINGOBJECT_POINTER, '_mouse_'],
-              [Blockly.Msg.SENSING_TOUCHINGOBJECT_EDGE, '_edge_']
-            ]
-          }
-        ],
-        "extensions": ["colours_sensing", "output_string"]
-      });
+    this.jsonInit({
+      "message0": "%1",
+      "args0": [
+        {
+          "type": "field_dropdown",
+          "name": "TOUCHINGOBJECTMENU",
+          "options": [
+            [Blockly.Msg.SENSING_TOUCHINGOBJECT_POINTER, '_mouse_'],
+            [Blockly.Msg.SENSING_TOUCHINGOBJECT_EDGE, '_edge_']
+          ]
+        }
+      ],
+      "extensions": ["colours_sensing", "output_string"]
+    });
   }
 };
 
@@ -142,20 +141,19 @@ Blockly.Blocks['sensing_distancetomenu'] = {
    * @this Blockly.Block
    */
   init: function() {
-    this.jsonInit(
-      {
-        "message0": "%1",
-        "args0": [
-          {
-            "type": "field_dropdown",
-            "name": "DISTANCETOMENU",
-            "options": [
-              [Blockly.Msg.SENSING_DISTANCETO_POINTER, '_mouse_']
-            ]
-          }
-        ],
-        "extensions": ["colours_sensing", "output_string"]
-      });
+    this.jsonInit({
+      "message0": "%1",
+      "args0": [
+        {
+          "type": "field_dropdown",
+          "name": "DISTANCETOMENU",
+          "options": [
+            [Blockly.Msg.SENSING_DISTANCETO_POINTER, '_mouse_']
+          ]
+        }
+      ],
+      "extensions": ["colours_sensing", "output_string"]
+    });
   }
 };
 
@@ -409,21 +407,20 @@ Blockly.Blocks['sensing_of_object_menu'] = {
    * @this Blockly.Block
    */
   init: function() {
-    this.jsonInit(
-      {
-        "message0": "%1",
-        "args0": [
-          {
-            "type": "field_dropdown",
-            "name": "OBJECT",
-            "options": [
-              ['Sprite1', 'Sprite1'],
-              ['Stage', '_stage_']
-            ]
-          }
-        ],
-        "extensions": ["colours_sensing", "output_string"]
-      });
+    this.jsonInit({
+      "message0": "%1",
+      "args0": [
+        {
+          "type": "field_dropdown",
+          "name": "OBJECT",
+          "options": [
+            ['Sprite1', 'Sprite1'],
+            ['Stage', '_stage_']
+          ]
+        }
+      ],
+      "extensions": ["colours_sensing", "output_string"]
+    });
   }
 };
 

--- a/blocks_vertical/sound.js
+++ b/blocks_vertical/sound.js
@@ -33,32 +33,31 @@ Blockly.Blocks['sound_sounds_menu'] = {
    * @this Blockly.Block
    */
   init: function() {
-    this.jsonInit(
-      {
-        "message0": "%1",
-        "args0": [
-          {
-            "type": "field_dropdown",
-            "name": "SOUND_MENU",
-            "options": [
-              ['1', '0'],
-              ['2', '1'],
-              ['3', '2'],
-              ['4', '3'],
-              ['5', '4'],
-              ['6', '5'],
-              ['7', '6'],
-              ['8', '7'],
-              ['9', '8'],
-              ['10', '9']
-            ]
-          }
-        ],
-        "colour": Blockly.Colours.sounds.secondary,
-        "colourSecondary": Blockly.Colours.sounds.secondary,
-        "colourTertiary": Blockly.Colours.sounds.tertiary,
-        "extensions": ["output_string"]
-      });
+    this.jsonInit({
+      "message0": "%1",
+      "args0": [
+        {
+          "type": "field_dropdown",
+          "name": "SOUND_MENU",
+          "options": [
+            ['1', '0'],
+            ['2', '1'],
+            ['3', '2'],
+            ['4', '3'],
+            ['5', '4'],
+            ['6', '5'],
+            ['7', '6'],
+            ['8', '7'],
+            ['9', '8'],
+            ['10', '9']
+          ]
+        }
+      ],
+      "colour": Blockly.Colours.sounds.secondary,
+      "colourSecondary": Blockly.Colours.sounds.secondary,
+      "colourTertiary": Blockly.Colours.sounds.tertiary,
+      "extensions": ["output_string"]
+    });
   }
 };
 

--- a/blocks_vertical/vertical_extensions.js
+++ b/blocks_vertical/vertical_extensions.js
@@ -223,10 +223,10 @@ Blockly.ScratchBlocks.VerticalExtensions.SCRATCH_EXTENSION = function() {
 Blockly.ScratchBlocks.VerticalExtensions.registerAll = function() {
   var categoryNames =
       ['control', 'data', 'data_lists', 'sounds', 'motion', 'looks', 'event',
-      'sensing', 'pen', 'operators', 'more'];
+        'sensing', 'pen', 'operators', 'more'];
   // Register functions for all category colours.
   for (var i = 0; i < categoryNames.length; i++) {
-    name = categoryNames[i];
+    var name = categoryNames[i];
     Blockly.Extensions.register('colours_' + name,
         Blockly.ScratchBlocks.VerticalExtensions.colourHelper(name));
   }
@@ -259,7 +259,7 @@ Blockly.ScratchBlocks.VerticalExtensions.registerAll = function() {
 
   // Extension blocks have slightly different block rendering.
   Blockly.Extensions.register('scratch_extension',
-    Blockly.ScratchBlocks.VerticalExtensions.SCRATCH_EXTENSION);
+      Blockly.ScratchBlocks.VerticalExtensions.SCRATCH_EXTENSION);
 };
 
 Blockly.ScratchBlocks.VerticalExtensions.registerAll();


### PR DESCRIPTION
### Resolves

:notes: 
Dashing through the code
In an endless format fight
O'er the files I go
Tabbing all the way
Bells in terminals ring
For every broken sprite
What fun it is to code and sing
A linting song tonight

Jingle bells, jingle bells,
Jingle all the way
Oh what fun it is to lint
On a sunny mid-spring day, hey
Jingle bells, jingle bells,
Jingle all the way
Oh what fun it is to lint
On a sunny mid-spring day
 :notes:

### Proposed Changes

Resolves all lint in block definitions.

There is one change that is not just indentation.  In blocks_vertical/procedures.js I removed a backslash to comply with no-useless-escape.

### Reason for Changes

This plus #1493 should unblock upgrading to eslint 4, which has a new indentation rule (hence all the hassle)