### PR TITLE
Add new indent rule to .eslintrc and increase the minimum version

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,7 +2,28 @@
     "rules": {
         "curly": ["error", "multi-line"],
         "eol-last": ["error"],
-        "indent": ["warn", 2, {"SwitchCase": 1}], # Blockly/Google use 2-space indents
+        "indent": [
+            "error", 2,  # Blockly/Google use 2-space indents
+            # Blockly/Google uses +4 space indents for line continuations.
+            {
+                "SwitchCase": 1,
+                "MemberExpression": 2,
+                "ObjectExpression": 1,
+                "FunctionDeclaration": {
+                    "body": 1,
+                    "parameters": 2
+                },
+                "FunctionExpression": {
+                    "body": 1,
+                    "parameters": 2
+                },
+                "CallExpression": {
+                    "arguments": 2
+                },
+                # Ignore default rules for ternary expressions.
+                "ignoredNodes": ["ConditionalExpression"]
+            }
+        ],
         "linebreak-style": ["error", "unix"],
         "max-len": ["error", 120, 4],
         "no-trailing-spaces": ["error", { "skipBlankLines": true }],

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "async": "2.6.0",
     "copy-webpack-plugin": "4.0.1",
-    "eslint": "2.9.0",
+    "eslint": "^4.16",
     "event-stream": "3.3.4",
     "exports-loader": "0.6.3",
     "gh-pages": "0.12.0",


### PR DESCRIPTION
### Resolves

None
### Proposed Changes

Use the [new indent rules](https://eslint.org/docs/user-guide/migrating-to-4.0.0#indent-rewrite) added in eslint 4.  Require a newer version of eslint, since the rules are not compatible across the migration.

### Reason for Changes

Automate linting, consistency between blockly and scratch-blocks.

### Test Coverage

I ran eslint . and got no errors or warnings.