### PR TITLE
Mark CTM dirty instead of forcing a reflow/recalc

### DIFF
--- a/core/constants.js
+++ b/core/constants.js
@@ -366,3 +366,9 @@ Blockly.PROCEDURES_PROTOTYPE_BLOCK_TYPE = 'procedures_prototype';
  * @const {string}
  */
 Blockly.PROCEDURES_CALL_BLOCK_TYPE = 'procedures_call';
+
+/**
+ * A constant value that we can use to mark calculated properties as dirty.
+ * @const {string}
+ */
+Blockly.DIRTY = 'dirty';

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -55,12 +55,6 @@ goog.require('goog.userAgent');
 goog.require('goog.math.Rect');
 
 /**
- * This is a unique object that only we have access to.  It is used
- * to mark some properties as dirty so we can recalculate.
- */
-var DIRTY = {};
-
-/**
  * Class for a workspace.  This is an onscreen area with optional trashcan,
  * scrollbars, bubbles, and dragging.
  * @param {!Blockly.Options} options Dictionary of options.
@@ -291,20 +285,21 @@ Blockly.WorkspaceSvg.prototype.toolboxCategoryCallbacks_ = {};
  * @type {SVGMatrix}
  * @private
  */
-Blockly.WorkspaceSvg.prototype.inverseScreenCTM_ = DIRTY;
+Blockly.WorkspaceSvg.prototype.inverseScreenCTM_ = false;
 
 /**
  * Getter for the inverted screen CTM.
  * @return {SVGMatrix} The matrix to use in mouseToSvg
  */
 Blockly.WorkspaceSvg.prototype.getInverseScreenCTM = function() {
-  if (this.inverseScreenCTM_ == DIRTY) {
+  // We use `false` to mark dirty, `null` is a valid value.
+  if (this.inverseScreenCTM_ == false) {
     var ctm = this.getParentSvg().getScreenCTM();
     if (ctm) {
       this.inverseScreenCTM_ = ctm.inverse();
     } else {
-      // When DIRTY, and we can't get a CTM - we are null.
-      return null;
+      // When dirty, and we can't get a CTM, set it to null.
+      this.inverseScreenCTM_ = null;
     }
   }
 
@@ -315,7 +310,7 @@ Blockly.WorkspaceSvg.prototype.getInverseScreenCTM = function() {
  * Mark the inverse screen CTM as dirty.
  */
 Blockly.WorkspaceSvg.prototype.updateInverseScreenCTM = function() {
-  this.inverseScreenCTM_ = DIRTY;
+  this.inverseScreenCTM_ = false;
 };
 
 /**

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -285,7 +285,7 @@ Blockly.WorkspaceSvg.prototype.toolboxCategoryCallbacks_ = {};
  * @type {SVGMatrix}
  * @private
  */
-Blockly.WorkspaceSvg.prototype.inverseScreenCTM_ = "dirty";
+Blockly.WorkspaceSvg.prototype.inverseScreenCTM_ = Blockly.DIRTY;
 
 /**
  * Getter for the inverted screen CTM.
@@ -295,7 +295,7 @@ Blockly.WorkspaceSvg.prototype.getInverseScreenCTM = function() {
 
   // Defer getting the screen CTM until we actually need it, this should
   // avoid forced reflows from any calls to updateInverseScreenCTM.
-  if (this.inverseScreenCTM_ == "dirty") {
+  if (this.inverseScreenCTM_ == Blockly.DIRTY) {
     var ctm = this.getParentSvg().getScreenCTM();
     if (ctm) {
       this.inverseScreenCTM_ = ctm.inverse();
@@ -312,7 +312,7 @@ Blockly.WorkspaceSvg.prototype.getInverseScreenCTM = function() {
  * Mark the inverse screen CTM as dirty.
  */
 Blockly.WorkspaceSvg.prototype.updateInverseScreenCTM = function() {
-  this.inverseScreenCTM_ = "dirty";
+  this.inverseScreenCTM_ = Blockly.DIRTY;
 };
 
 /**

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -54,6 +54,11 @@ goog.require('goog.math.Coordinate');
 goog.require('goog.userAgent');
 goog.require('goog.math.Rect');
 
+/**
+ * This is a unique object that only we have access to.  It is used
+ * to mark some properties as dirty so we can recalculate.
+ */
+var DIRTY = {};
 
 /**
  * Class for a workspace.  This is an onscreen area with optional trashcan,
@@ -286,24 +291,31 @@ Blockly.WorkspaceSvg.prototype.toolboxCategoryCallbacks_ = {};
  * @type {SVGMatrix}
  * @private
  */
-Blockly.WorkspaceSvg.prototype.inverseScreenCTM_ = null;
+Blockly.WorkspaceSvg.prototype.inverseScreenCTM_ = DIRTY;
 
 /**
  * Getter for the inverted screen CTM.
  * @return {SVGMatrix} The matrix to use in mouseToSvg
  */
 Blockly.WorkspaceSvg.prototype.getInverseScreenCTM = function() {
+  if (this.inverseScreenCTM_ == DIRTY) {
+    var ctm = this.getParentSvg().getScreenCTM();
+    if (ctm) {
+      this.inverseScreenCTM_ = ctm.inverse();
+    } else {
+      // When DIRTY, and we can't get a CTM - we are null.
+      return null;
+    }
+  }
+
   return this.inverseScreenCTM_;
 };
 
 /**
- * Update the inverted screen CTM.
+ * Mark the inverse screen CTM as dirty.
  */
 Blockly.WorkspaceSvg.prototype.updateInverseScreenCTM = function() {
-  var ctm = this.getParentSvg().getScreenCTM();
-  if (ctm) {
-    this.inverseScreenCTM_ = ctm.inverse();
-  }
+  this.inverseScreenCTM_ = DIRTY;
 };
 
 /**

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -285,15 +285,17 @@ Blockly.WorkspaceSvg.prototype.toolboxCategoryCallbacks_ = {};
  * @type {SVGMatrix}
  * @private
  */
-Blockly.WorkspaceSvg.prototype.inverseScreenCTM_ = false;
+Blockly.WorkspaceSvg.prototype.inverseScreenCTM_ = "dirty";
 
 /**
  * Getter for the inverted screen CTM.
  * @return {SVGMatrix} The matrix to use in mouseToSvg
  */
 Blockly.WorkspaceSvg.prototype.getInverseScreenCTM = function() {
-  // We use `false` to mark dirty, `null` is a valid value.
-  if (this.inverseScreenCTM_ == false) {
+
+  // Defer getting the screen CTM until we actually need it, this should
+  // avoid forced reflows from any calls to updateInverseScreenCTM.
+  if (this.inverseScreenCTM_ == "dirty") {
     var ctm = this.getParentSvg().getScreenCTM();
     if (ctm) {
       this.inverseScreenCTM_ = ctm.inverse();
@@ -310,7 +312,7 @@ Blockly.WorkspaceSvg.prototype.getInverseScreenCTM = function() {
  * Mark the inverse screen CTM as dirty.
  */
 Blockly.WorkspaceSvg.prototype.updateInverseScreenCTM = function() {
-  this.inverseScreenCTM_ = false;
+  this.inverseScreenCTM_ = "dirty";
 };
 
 /**


### PR DESCRIPTION
### Proposed Changes

* Wait until we are asked for this inverse screen CTM instead of immediately requesting the CTM from the browser right after we've mutated it, causing a forced layout / recalc styles.

### Reason for Changes

* to quote Chrome Debugger - "Forced reflow is a likely performance bottleneck"
* This forced reflow happens 2-3x per workspace update
* Nothing seems to read this value until drag events/other events are processed

`grep -C10 nverseScreen core/*`
<details>

```
core/scrollbar.js-  this.workspace_.markFocused();
core/scrollbar.js-  Blockly.Touch.clearTouchIdentifier();  // This is really a click.
core/scrollbar.js-  this.cleanUp_();
core/scrollbar.js-  if (Blockly.utils.isRightButton(e)) {
core/scrollbar.js-    // Right-click.
core/scrollbar.js-    // Scrollbars have no context menu.
core/scrollbar.js-    e.stopPropagation();
core/scrollbar.js-    return;
core/scrollbar.js-  }
core/scrollbar.js-  var mouseXY = Blockly.utils.mouseToSvg(e, this.workspace_.getParentSvg(),
core/scrollbar.js:      this.workspace_.getInverseScreenCTM());
core/scrollbar.js-  var mouseLocation = this.horizontal_ ? mouseXY.x : mouseXY.y;
core/scrollbar.js-
core/scrollbar.js-  var handleXY = Blockly.utils.getInjectionDivXY_(this.svgHandle_);
core/scrollbar.js-  var handleStart = this.horizontal_ ? handleXY.x : handleXY.y;
core/scrollbar.js-  var handlePosition = this.handlePosition_;
core/scrollbar.js-
core/scrollbar.js-  var pageLength = this.handleLength_ * 0.95;
core/scrollbar.js-  if (mouseLocation <= handleStart) {
core/scrollbar.js-    // Decrease the scrollbar's value by a page.
core/scrollbar.js-    handlePosition -= pageLength;
--
--
core/workspace_svg.js- * @type {!Object.<string, function(!Blockly.Workspace):!Array.<!Element>>}
core/workspace_svg.js- * @private
core/workspace_svg.js- */
core/workspace_svg.js-Blockly.WorkspaceSvg.prototype.toolboxCategoryCallbacks_ = {};
core/workspace_svg.js-
core/workspace_svg.js-/**
core/workspace_svg.js- * Inverted screen CTM, for use in mouseToSvg.
core/workspace_svg.js- * @type {SVGMatrix}
core/workspace_svg.js- * @private
core/workspace_svg.js- */
core/workspace_svg.js:Blockly.WorkspaceSvg.prototype.inverseScreenCTM_ = DIRTY;
core/workspace_svg.js-
core/workspace_svg.js-/**
core/workspace_svg.js- * Getter for the inverted screen CTM.
core/workspace_svg.js- * @return {SVGMatrix} The matrix to use in mouseToSvg
core/workspace_svg.js- */
--
core/workspace_svg.js-
core/workspace_svg.js-/**
core/workspace_svg.js- * Getter for the inverted screen CTM.
core/workspace_svg.js- * @return {SVGMatrix} The matrix to use in mouseToSvg
core/workspace_svg.js- */
core/workspace_svg.js:Blockly.WorkspaceSvg.prototype.getInverseScreenCTM = function() {
core/workspace_svg.js:  if (this.inverseScreenCTM_ == DIRTY) {
core/workspace_svg.js-    var ctm = this.getParentSvg().getScreenCTM();
core/workspace_svg.js-    if (ctm) {
--
core/workspace_svg.js-    var ctm = this.getParentSvg().getScreenCTM();
core/workspace_svg.js-    if (ctm) {
core/workspace_svg.js:      this.inverseScreenCTM_ = ctm.inverse();
core/workspace_svg.js-    } else {
core/workspace_svg.js-      // When DIRTY, and we can't get a CTM - we are null.
core/workspace_svg.js-      return null;
core/workspace_svg.js-    }
core/workspace_svg.js-  }
core/workspace_svg.js-
--
core/workspace_svg.js-    } else {
core/workspace_svg.js-      // When DIRTY, and we can't get a CTM - we are null.
core/workspace_svg.js-      return null;
core/workspace_svg.js-    }
core/workspace_svg.js-  }
core/workspace_svg.js-
core/workspace_svg.js:  return this.inverseScreenCTM_;
core/workspace_svg.js-};
core/workspace_svg.js-
core/workspace_svg.js-/**
core/workspace_svg.js- * Mark the inverse screen CTM as dirty.
core/workspace_svg.js- */
--
core/workspace_svg.js-};
core/workspace_svg.js-
core/workspace_svg.js-/**
core/workspace_svg.js- * Mark the inverse screen CTM as dirty.
core/workspace_svg.js- */
core/workspace_svg.js:Blockly.WorkspaceSvg.prototype.updateInverseScreenCTM = function() {
core/workspace_svg.js:  this.inverseScreenCTM_ = DIRTY;
core/workspace_svg.js-};
core/workspace_svg.js-
core/workspace_svg.js-/**
core/workspace_svg.js- * Return the absolute coordinates of the top-left corner of this element,
core/workspace_svg.js- * scales that after canvas SVG element, if it's a descendant.
core/workspace_svg.js- * The origin (0,0) is the top-left corner of the Blockly SVG.
core/workspace_svg.js- * @param {!Element} element Element to find the coordinates of.
core/workspace_svg.js- * @return {!goog.math.Coordinate} Object with .x and .y properties.
core/workspace_svg.js- * @private
core/workspace_svg.js- */
--
--
core/workspace_svg.js-  }
core/workspace_svg.js-  return null;
core/workspace_svg.js-};
core/workspace_svg.js-
core/workspace_svg.js-/**
core/workspace_svg.js- * Update items that use screen coordinate calculations
core/workspace_svg.js- * because something has changed (e.g. scroll position, window size).
core/workspace_svg.js- * @private
core/workspace_svg.js- */
core/workspace_svg.js-Blockly.WorkspaceSvg.prototype.updateScreenCalculations_ = function() {
core/workspace_svg.js:  this.updateInverseScreenCTM();
core/workspace_svg.js-  this.recordCachedAreas();
core/workspace_svg.js-};
core/workspace_svg.js-
core/workspace_svg.js-/**
core/workspace_svg.js- * If enabled, resize the parts of the workspace that change when the workspace
core/workspace_svg.js- * contents (e.g. block positions) change.  This will also scroll the
core/workspace_svg.js- * workspace contents if needed.
core/workspace_svg.js- * @package
core/workspace_svg.js- */
core/workspace_svg.js-Blockly.WorkspaceSvg.prototype.resizeContents = function() {
--
--
core/workspace_svg.js-Blockly.WorkspaceSvg.prototype.resizeContents = function() {
core/workspace_svg.js-  if (!this.resizesEnabled_ || !this.rendered) {
core/workspace_svg.js-    return;
core/workspace_svg.js-  }
core/workspace_svg.js-  if (this.scrollbar) {
core/workspace_svg.js-    // TODO(picklesrus): Once rachel-fenichel's scrollbar refactoring
core/workspace_svg.js-    // is complete, call the method that only resizes scrollbar
core/workspace_svg.js-    // based on contents.
core/workspace_svg.js-    this.scrollbar.resize();
core/workspace_svg.js-  }
core/workspace_svg.js:  this.updateInverseScreenCTM();
core/workspace_svg.js-};
core/workspace_svg.js-
core/workspace_svg.js-/**
core/workspace_svg.js- * Resize and reposition all of the workspace chrome (toolbox,
core/workspace_svg.js- * trash, scrollbars etc.)
core/workspace_svg.js- * This should be called when something changes that
core/workspace_svg.js- * requires recalculating dimensions and positions of the
core/workspace_svg.js- * trash, zoom, toolbox, etc. (e.g. window resize).
core/workspace_svg.js- */
core/workspace_svg.js-Blockly.WorkspaceSvg.prototype.resize = function() {
--
--
core/workspace_svg.js-};
core/workspace_svg.js-
core/workspace_svg.js-/**
core/workspace_svg.js- * Start tracking a drag of an object on this workspace.
core/workspace_svg.js- * @param {!Event} e Mouse down event.
core/workspace_svg.js- * @param {!goog.math.Coordinate} xy Starting location of object.
core/workspace_svg.js- */
core/workspace_svg.js-Blockly.WorkspaceSvg.prototype.startDrag = function(e, xy) {
core/workspace_svg.js-  // Record the starting offset between the bubble's location and the mouse.
core/workspace_svg.js-  var point = Blockly.utils.mouseToSvg(e, this.getParentSvg(),
core/workspace_svg.js:      this.getInverseScreenCTM());
core/workspace_svg.js-  // Fix scale of mouse event.
core/workspace_svg.js-  point.x /= this.scale;
core/workspace_svg.js-  point.y /= this.scale;
core/workspace_svg.js-  this.dragDeltaXY_ = goog.math.Coordinate.difference(xy, point);
core/workspace_svg.js-};
core/workspace_svg.js-
core/workspace_svg.js-/**
core/workspace_svg.js- * Track a drag of an object on this workspace.
core/workspace_svg.js- * @param {!Event} e Mouse move event.
core/workspace_svg.js- * @return {!goog.math.Coordinate} New location of object.
--
--
core/workspace_svg.js-  this.dragDeltaXY_ = goog.math.Coordinate.difference(xy, point);
core/workspace_svg.js-};
core/workspace_svg.js-
core/workspace_svg.js-/**
core/workspace_svg.js- * Track a drag of an object on this workspace.
core/workspace_svg.js- * @param {!Event} e Mouse move event.
core/workspace_svg.js- * @return {!goog.math.Coordinate} New location of object.
core/workspace_svg.js- */
core/workspace_svg.js-Blockly.WorkspaceSvg.prototype.moveDrag = function(e) {
core/workspace_svg.js-  var point = Blockly.utils.mouseToSvg(e, this.getParentSvg(),
core/workspace_svg.js:      this.getInverseScreenCTM());
core/workspace_svg.js-  // Fix scale of mouse event.
core/workspace_svg.js-  point.x /= this.scale;
core/workspace_svg.js-  point.y /= this.scale;
core/workspace_svg.js-  return goog.math.Coordinate.sum(this.dragDeltaXY_, point);
core/workspace_svg.js-};
core/workspace_svg.js-
core/workspace_svg.js-/**
core/workspace_svg.js- * Is the user currently dragging a block or scrolling the flyout/workspace?
core/workspace_svg.js- * @return {boolean} True if currently dragging or scrolling.
core/workspace_svg.js- */
--
--
core/workspace_svg.js-  // TODO: Remove gesture cancellation and compensate for coordinate skew during
core/workspace_svg.js-  // zoom.
core/workspace_svg.js-  if (this.currentGesture_) {
core/workspace_svg.js-    this.currentGesture_.cancel();
core/workspace_svg.js-  }
core/workspace_svg.js-  if (e.ctrlKey) {
core/workspace_svg.js-    // The vertical scroll distance that corresponds to a click of a zoom button.
core/workspace_svg.js-    var PIXELS_PER_ZOOM_STEP = 50;
core/workspace_svg.js-    var delta = -e.deltaY / PIXELS_PER_ZOOM_STEP;
core/workspace_svg.js-    var position = Blockly.utils.mouseToSvg(e, this.getParentSvg(),
core/workspace_svg.js:        this.getInverseScreenCTM());
core/workspace_svg.js-    this.zoom(position.x, position.y, delta);
core/workspace_svg.js-  } else {
core/workspace_svg.js-    // This is a regular mouse wheel event - scroll the workspace
core/workspace_svg.js-    // First hide the WidgetDiv without animation
core/workspace_svg.js-    // (mouse scroll makes field out of place with div)
core/workspace_svg.js-    Blockly.WidgetDiv.hide(true);
core/workspace_svg.js-    Blockly.DropDownDiv.hideWithoutAnimation();
core/workspace_svg.js-    var x = this.scrollX - e.deltaX;
core/workspace_svg.js-    var y = this.scrollY - e.deltaY;
core/workspace_svg.js-    this.startDragMetrics = this.getMetrics();
```
</details>