### PR TITLE
Fixed lack of category identifiers

### DIFF
--- a/blocks_vertical/sound.js
+++ b/blocks_vertical/sound.js
@@ -95,6 +95,7 @@ Blockly.Blocks['sound_playuntildone'] = {
           "name": "SOUND_MENU"
         }
       ],
+      "category": Blockly.Categories.sound,
       "extensions": ["colours_sounds", "shape_statement"]
     });
   }
@@ -136,6 +137,7 @@ Blockly.Blocks['sound_seteffectto'] = {
           "name": "VALUE"
         }
       ],
+      "category": Blockly.Categories.sound,
       "extensions": ["colours_sounds", "shape_statement"]
     });
   }
@@ -164,6 +166,7 @@ Blockly.Blocks['sound_changeeffectby'] = {
           "name": "VALUE"
         }
       ],
+      "category": Blockly.Categories.sound,
       "extensions": ["colours_sounds", "shape_statement"]
     });
   }
@@ -177,6 +180,7 @@ Blockly.Blocks['sound_cleareffects'] = {
   init: function() {
     this.jsonInit({
       "message0": Blockly.Msg.SOUND_CLEAREFFECTS,
+      "category": Blockly.Categories.sound,
       "extensions": ["colours_sounds", "shape_statement"]
     });
   }


### PR DESCRIPTION
When I was changing CSS via a userscript, I noticed that a few blocks were not being affected.  Looking at the code I noticed that those specific blocks did not have the `"category": Blockly.Categories.sound,` property.  This simple change should fix the problem.  (There is one more block with this issue, and that is the "When backdrop switches to" block.  However, looking at it, it appears that this block does have a category definition, making that cause unknown)

Resolves #1509 