### PR TITLE
chore(webpack): update to webpack 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-- "4"
+- "8"
 - "stable"
 sudo: required
 addons:

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "async": "2.6.0",
-    "copy-webpack-plugin": "4.0.1",
+    "copy-webpack-plugin": "^4.5.1",
     "eslint": "^4.16",
     "event-stream": "3.3.4",
     "exports-loader": "0.6.3",
@@ -35,7 +35,9 @@
     "json": "9.0.4",
     "rimraf": "2.6.2",
     "travis-after-all": "1.4.4",
+    "uglifyjs-webpack-plugin": "^1.2.5",
     "webdriverio": "4.8.0",
-    "webpack": "1.13.2"
+    "webpack": "^4.8.0",
+    "webpack-cli": "^2.0.15"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "async": "2.6.0",
-    "copy-webpack-plugin": "^4.5.1",
+    "copy-webpack-plugin": "4.5.1",
     "eslint": "^4.16",
     "event-stream": "3.3.4",
     "exports-loader": "0.6.3",

--- a/shim/blockly_compressed_horizontal-blocks_compressed.js
+++ b/shim/blockly_compressed_horizontal-blocks_compressed.js
@@ -1,1 +1,1 @@
-module.exports = require('imports?Blockly=./shim/blockly_compressed_horizontal.Blockly!exports?Blockly!../blocks_compressed');
+module.exports = require('imports-loader?Blockly=./shim/blockly_compressed_horizontal.Blockly!exports-loader?Blockly!../blocks_compressed');

--- a/shim/blockly_compressed_horizontal.js
+++ b/shim/blockly_compressed_horizontal.js
@@ -1,1 +1,1 @@
-module.exports = require('imports?this=>window!exports?Blockly&goog!../blockly_compressed_horizontal');
+module.exports = require('imports-loader?this=>window!exports-loader?Blockly&goog!../blockly_compressed_horizontal');

--- a/shim/blockly_compressed_vertical-blocks_compressed.js
+++ b/shim/blockly_compressed_vertical-blocks_compressed.js
@@ -1,1 +1,1 @@
-module.exports = require('imports?Blockly=./shim/blockly_compressed_vertical.Blockly!exports?Blockly!../blocks_compressed');
+module.exports = require('imports-loader?Blockly=./shim/blockly_compressed_vertical.Blockly!exports-loader?Blockly!../blocks_compressed');

--- a/shim/blockly_compressed_vertical.js
+++ b/shim/blockly_compressed_vertical.js
@@ -1,1 +1,1 @@
-module.exports = require('imports?this=>window!exports?Blockly&goog!../blockly_compressed_vertical');
+module.exports = require('imports-loader?this=>window!exports-loader?Blockly&goog!../blockly_compressed_vertical');

--- a/shim/blocks_compressed_horizontal.js
+++ b/shim/blocks_compressed_horizontal.js
@@ -1,1 +1,1 @@
-module.exports = require('imports?Blockly=./shim/blockly_compressed_horizontal-blocks_compressed!exports?Blockly!../blocks_compressed_horizontal');
+module.exports = require('imports-loader?Blockly=./shim/blockly_compressed_horizontal-blocks_compressed!exports-loader?Blockly!../blocks_compressed_horizontal');

--- a/shim/blocks_compressed_vertical.js
+++ b/shim/blocks_compressed_vertical.js
@@ -1,1 +1,1 @@
-module.exports = require('imports?goog=./shim/blockly_compressed_vertical.goog,Blockly=./shim/blockly_compressed_vertical-blocks_compressed!exports?Blockly!../blocks_compressed_vertical');
+module.exports = require('imports-loader?goog=./shim/blockly_compressed_vertical.goog,Blockly=./shim/blockly_compressed_vertical-blocks_compressed!exports-loader?Blockly!../blocks_compressed_vertical');

--- a/shim/gh-pages.js
+++ b/shim/gh-pages.js
@@ -1,0 +1,1 @@
+// intentionally left empty

--- a/shim/horizontal.js
+++ b/shim/horizontal.js
@@ -1,1 +1,1 @@
-module.exports = require('imports?Blockly=../shim/blocks_compressed_horizontal,goog=../shim/blockly_compressed_horizontal.goog!exports?Blockly!../msg/messages');
+module.exports = require('imports-loader?Blockly=../shim/blocks_compressed_horizontal,goog=../shim/blockly_compressed_horizontal.goog!exports-loader?Blockly!../msg/messages');

--- a/shim/vertical.js
+++ b/shim/vertical.js
@@ -1,1 +1,1 @@
-module.exports = require('imports?Blockly=../shim/blocks_compressed_vertical,goog=../shim/blockly_compressed_vertical.goog!exports?Blockly!../msg/messages');
+module.exports = require('imports-loader?Blockly=../shim/blocks_compressed_vertical,goog=../shim/blockly_compressed_vertical.goog!exports-loader?Blockly!../msg/messages');

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,8 +5,10 @@ gracefulFs.gracefulify(realFs);
 
 var CopyWebpackPlugin = require('copy-webpack-plugin');
 var path = require('path');
+var UglifyJsPlugin = require('uglifyjs-webpack-plugin');
 
 module.exports = [{
+  mode: process.env.NODE_ENV === 'production' ? 'production' : 'development',
   entry: {
     horizontal: './shim/horizontal.js',
     vertical: './shim/vertical.js'
@@ -16,8 +18,15 @@ module.exports = [{
     libraryTarget: 'commonjs2',
     path: path.resolve(__dirname, 'dist'),
     filename: '[name].js'
+  },
+  optimization: {
+    minimize: false
+  },
+  performance: {
+    hints: false
   }
 }, {
+  mode: process.env.NODE_ENV === 'production' ? 'production' : 'development',
   entry: {
     horizontal: './shim/horizontal.js',
     vertical: './shim/vertical.js'
@@ -27,12 +36,30 @@ module.exports = [{
     libraryTarget: 'umd',
     path: path.resolve(__dirname, 'dist', 'web'),
     filename: '[name].js'
-  }
+  },
+  optimization: {
+    minimizer: [
+      new UglifyJsPlugin({
+        uglifyOptions: {
+          mangle: false
+        }
+      })
+    ]
+  },
+  plugins: []
 },
 {
+  mode: process.env.NODE_ENV === 'production' ? 'production' : 'development',
+  entry: './shim/gh-pages.js',
   output: {
     filename: '[name].js',
     path: path.resolve(__dirname, 'gh-pages')
+  },
+  optimization: {
+    minimize: false
+  },
+  performance: {
+    hints: false
   },
   plugins: [
       new CopyWebpackPlugin([{


### PR DESCRIPTION
### Proposed Changes

- Update from webpack 1 to webpack 4
- Use full loader (`imports` becomes `imports-loader`) names in `shim/`
- Add `shim/gh-pages.js` entry (versions of webpack after 1 do not allow entry to be empty)

### Reason for Changes

Sibling of https://github.com/LLK/scratch-vm/pull/1104
