### PR TITLE
Use shim/vertical as browser entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "url": "https://github.com/LLK/scratch-blocks.git"
   },
   "main": "./dist/vertical.js",
+  "browser": "./shim/vertical.js",
   "scripts": {
     "deploy": "rimraf gh-pages/closure-library/scripts/ci/CloseAdobeDialog.exe && gh-pages -t -d gh-pages -m \"Build for $(git log --pretty=format:%H -n1)\"",
     "prepublish": "python build.py && webpack",
@@ -20,18 +21,20 @@
     "version": "json -f package.json -I -e \"this.repository.sha = '$(git log -n1 --pretty=format:%H)'\"",
     "translate": "node i18n/js_to_json.js && node i18n/json_to_js.js"
   },
+  "dependencies": {
+    "exports-loader": "0.6.3",
+    "imports-loader": "0.6.5"
+  },
   "devDependencies": {
     "async": "2.6.0",
     "copy-webpack-plugin": "4.5.1",
     "eslint": "^4.16",
     "event-stream": "3.3.4",
-    "exports-loader": "0.6.3",
     "gh-pages": "0.12.0",
     "glob": "7.1.2",
     "google-closure-compiler": "20180402.0.0",
     "google-closure-library": "20180204.0.0",
     "graceful-fs": "4.1.11",
-    "imports-loader": "0.6.5",
     "json": "9.0.4",
     "rimraf": "2.6.2",
     "travis-after-all": "1.4.4",


### PR DESCRIPTION
### Proposed Changes

- Use shim/vertical for browser entry point instead of webpack build library
- Depend on dependencies used in `src` as non-dev dependencies
- Build node version with non-dev dependencies as external modules

### Reason for Changes

Sibling of https://github.com/LLK/scratch-vm/pull/1106
