### PR TITLE
Change local compiler script name

### DIFF
--- a/build.py
+++ b/build.py
@@ -49,9 +49,9 @@ CLOSURE_LIBRARY = "closure-library"
 CLOSURE_COMPILER = REMOTE_COMPILER
 
 CLOSURE_DIR_NPM = "node_modules"
-CLOSURE_ROOT_NPM = os.path.join("node_modules")
+CLOSURE_ROOT_NPM = "node_modules"
 CLOSURE_LIBRARY_NPM = "google-closure-library"
-CLOSURE_COMPILER_NPM = "google-closure-compiler"
+CLOSURE_COMPILER_NPM = os.path.join(CLOSURE_ROOT_NPM, "google-closure-compiler", "cli.js")
 
 def import_path(fullpath):
   """Import a file with full path specification.
@@ -346,7 +346,7 @@ class Gen_compressed(threading.Thread):
       # Build the final args array by prepending google-closure-compiler to
       # dash_args and dropping any falsy members
       args = []
-      for group in [["google-closure-compiler"], dash_args]:
+      for group in [[self.closure_env["closure_compiler"]], dash_args]:
         args.extend(filter(lambda item: item, group))
 
       proc = subprocess.Popen(args, stdin=subprocess.PIPE, stdout=subprocess.PIPE)


### PR DESCRIPTION
### Proposed Changes

Use a path to the local compiler's startup script under node_modules instead of assuming the developer will have node_modules/.bin in there executable PATH.

### Reason for Changes

This removes an assumption about how the local compiler runs so it should work for more developers with less (unexplained setup). The remaining bit for local builds would be need for a JDK. This is mentioned as an error by the startup script before build.py starts trying to use the remote compiler but could possibly be better explained.
