### PR TITLE
Scroll to category by id

### DIFF
--- a/blocks_vertical/default_toolbox.js
+++ b/blocks_vertical/default_toolbox.js
@@ -29,7 +29,7 @@ goog.require('Blockly.Blocks');
  */
 
 Blockly.Blocks.defaultToolbox = '<xml id="toolbox-categories" style="display: none">'+
-  '<category name="Motion" colour="#4C97FF" secondaryColour="#3373CC">'+
+  '<category name="Motion" id="motion" colour="#4C97FF" secondaryColour="#3373CC">'+
     '<block type="motion_movesteps" id="motion_movesteps">'+
       '<value name="STEPS">'+
         '<shadow type="math_number">'+
@@ -144,7 +144,7 @@ Blockly.Blocks.defaultToolbox = '<xml id="toolbox-categories" style="display: no
     '<block type="motion_yposition" id="motion_yposition"></block>'+
     '<block type="motion_direction" id="motion_direction"></block>'+
   '</category>'+
-  '<category name="Looks" colour="#9966FF" secondaryColour="#774DCB">'+
+  '<category name="Looks" id="looks" colour="#9966FF" secondaryColour="#774DCB">'+
     '<block type="looks_show" id="looks_show"></block>'+
     '<block type="looks_hide" id="looks_hide"></block>'+
     '<block type="looks_switchcostumeto" id="looks_switchcostumeto">'+
@@ -205,7 +205,7 @@ Blockly.Blocks.defaultToolbox = '<xml id="toolbox-categories" style="display: no
     '<block type="looks_backdropnumbername" id="looks_backdropnumbername"></block>'+
     '<block type="looks_size" id="looks_size"></block>'+
   '</category>'+
-  '<category name="Sound" colour="#D65CD6" secondaryColour="#BD42BD">'+
+  '<category name="Sound" id="sound" colour="#D65CD6" secondaryColour="#BD42BD">'+
     '<block type="sound_play" id="sound_play">'+
       '<value name="SOUND_MENU">'+
         '<shadow type="sound_sounds_menu"></shadow>'+
@@ -248,7 +248,7 @@ Blockly.Blocks.defaultToolbox = '<xml id="toolbox-categories" style="display: no
     '</block>'+
     '<block type="sound_volume" id="sound_volume"></block>'+
   '</category>'+
-  '<category name="Events" colour="#FFD500" secondaryColour="#CC9900">'+
+  '<category name="Events" id="events" colour="#FFD500" secondaryColour="#CC9900">'+
     '<block type="event_whenflagclicked" id="event_whenflagclicked"></block>'+
     '<block type="event_whenkeypressed" id="event_whenkeypressed">'+
     '</block>'+
@@ -275,7 +275,7 @@ Blockly.Blocks.defaultToolbox = '<xml id="toolbox-categories" style="display: no
       '</value>'+
     '</block>'+
   '</category>'+
-  '<category name="Control" colour="#FFAB19" secondaryColour="#CF8B17">'+
+  '<category name="Control" id="control" colour="#FFAB19" secondaryColour="#CF8B17">'+
     '<block type="control_wait" id="control_wait">'+
       '<value name="DURATION">'+
         '<shadow type="math_positive_number">'+
@@ -304,7 +304,7 @@ Blockly.Blocks.defaultToolbox = '<xml id="toolbox-categories" style="display: no
     '</block>'+
     '<block type="control_delete_this_clone" id="control_delete_this_clone"></block>'+
   '</category>'+
-  '<category name="Sensing" colour="#4CBFE6" secondaryColour="#2E8EB8">'+
+  '<category name="Sensing" id="sensing" colour="#4CBFE6" secondaryColour="#2E8EB8">'+
     '<block type="sensing_touchingobject" id="sensing_touchingobject">'+
       '<value name="TOUCHINGOBJECTMENU">'+
         '<shadow type="sensing_touchingobjectmenu"></shadow>'+
@@ -348,7 +348,7 @@ Blockly.Blocks.defaultToolbox = '<xml id="toolbox-categories" style="display: no
     '<block type="sensing_current" id="sensing_current"></block>'+
     '<block type="sensing_dayssince2000" id="sensing_dayssince2000"></block>'+
   '</category>'+
-  '<category name="Operators" colour="#40BF4A" secondaryColour="#389438">'+
+  '<category name="Operators" id="operators" colour="#40BF4A" secondaryColour="#389438">'+
     '<block type="operator_add" id="operator_add">'+
       '<value name="NUM1">'+
         '<shadow type="math_number">'+
@@ -518,11 +518,11 @@ Blockly.Blocks.defaultToolbox = '<xml id="toolbox-categories" style="display: no
       '</value>'+
     '</block>'+
   '</category>'+
-  '<category name="Data" colour="#FF8C1A" secondaryColour="#DB6E00" custom="VARIABLE">' +
+  '<category name="Data" id="data" colour="#FF8C1A" secondaryColour="#DB6E00" custom="VARIABLE">' +
   '</category>' +
-  '<category name="More" colour="#FF6680" secondaryColour="#FF4D6A" custom="PROCEDURE">' +
+  '<category name="More" id="more" colour="#FF6680" secondaryColour="#FF4D6A" custom="PROCEDURE">' +
   '</category>' +
-  '<category name="Extensions" colour="#FF6680" secondaryColour="#FF4D6A" '+
+  '<category name="Extensions" id="extensions" colour="#FF6680" secondaryColour="#FF4D6A" '+
     'iconURI="../media/extensions/wedo2-block-icon.svg">'+
     '<block type="extension_pen_down" id="extension_pen_down"></block>'+
     '<block type="extension_music_drum" id="extension_music_drum">'+

--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -579,12 +579,13 @@ Blockly.Flyout.prototype.emptyRecycleBlocks_ = function() {
 };
 
 /**
- * Store an array of category names, scrollbar positions, and category lengths.
+ * Store an array of category names, ids, scrollbar positions, and category lengths.
  * This is used when scrolling the flyout to cause a category to be selected.
  * @private
  */
 Blockly.Flyout.prototype.recordCategoryScrollPositions_ = function() {
   this.categoryScrollPositions = [];
+  // Record category names and positions using the text label at the top of each one.
   for (var i = 0; i < this.buttons_.length; i++) {
     if (this.buttons_[i].getIsCategoryLabel()) {
       var categoryLabel = this.buttons_[i];
@@ -595,6 +596,7 @@ Blockly.Flyout.prototype.recordCategoryScrollPositions_ = function() {
       });
     }
   }
+  // Record the length of each category, setting the final one to 0.
   var numCategories = this.categoryScrollPositions.length;
   for (var i = 0; i < numCategories - 1; i++) {
     var currentPos = this.categoryScrollPositions[i].position;
@@ -603,6 +605,13 @@ Blockly.Flyout.prototype.recordCategoryScrollPositions_ = function() {
     this.categoryScrollPositions[i].length = length;
   }
   this.categoryScrollPositions[numCategories - 1].length = 0;
+  // Record the id of each category.
+  for (var i = 0; i < numCategories; i++) {
+    var category = this.parentToolbox_.getCategoryByIndex(i);
+    if (category && category.id_) {
+      this.categoryScrollPositions[i].categoryId = category.id_;
+    }
+  }
 };
 
 /**
@@ -621,7 +630,7 @@ Blockly.Flyout.prototype.selectCategoryByScrollPosition = function(pos) {
   // category that the scroll position is beyond.
   for (var i = this.categoryScrollPositions.length - 1; i >= 0; i--) {
     if (workspacePos >= this.categoryScrollPositions[i].position) {
-      this.parentToolbox_.selectCategoryByName(this.categoryScrollPositions[i].categoryName);
+      this.parentToolbox_.selectCategoryById(this.categoryScrollPositions[i].categoryId);
       return;
     }
   }

--- a/core/toolbox.js
+++ b/core/toolbox.js
@@ -502,10 +502,10 @@ Blockly.Toolbox.prototype.scrollToCategoryById = function(id) {
 /**
  * Get a category by its index.
  * @param  {number} index The index of the category.
- * @return {Blockly.Toolbox.Category} the category.
+ * @return {Blockly.Toolbox.Category} the category, or null if there are no categories.
  */
 Blockly.Toolbox.prototype.getCategoryByIndex = function(index) {
-  if (!this.categoryMenu_.categories_) return;
+  if (!this.categoryMenu_.categories_) return null;
   return this.categoryMenu_.categories_[index];
 };
 

--- a/core/toolbox.js
+++ b/core/toolbox.js
@@ -345,11 +345,18 @@ Blockly.Toolbox.prototype.getSelectedCategoryName = function() {
 };
 
 /**
+ * @return {string} The id of the currently selected category.
+ */
+Blockly.Toolbox.prototype.getSelectedCategoryId = function() {
+  return this.selectedItem_.id_;
+};
+
+/**
  * @return {number} The distance flyout is scrolled below the top of the currently
  * selected category.
  */
 Blockly.Toolbox.prototype.getCategoryScrollOffset = function() {
-  var categoryPos = this.getCategoryPositionByName(this.getSelectedCategoryName());
+  var categoryPos = this.getCategoryPositionById(this.getSelectedCategoryId());
   return this.flyout_.getScrollPos() - categoryPos;
 };
 
@@ -368,6 +375,20 @@ Blockly.Toolbox.prototype.getCategoryPositionByName = function(name) {
 };
 
 /**
+ * Get the position of a category by id.
+ * @param  {string} id The id of the category.
+ * @return {number} The position of the category.
+ */
+Blockly.Toolbox.prototype.getCategoryPositionById = function(id) {
+  var scrollPositions = this.flyout_.categoryScrollPositions;
+  for (var i = 0; i < scrollPositions.length; i++) {
+    if (id === scrollPositions[i].categoryId) {
+      return scrollPositions[i].position;
+    }
+  }
+};
+
+/**
  * Get the length of a category by name.
  * @param  {string} name The name of the category.
  * @return {number} The length of the category.
@@ -376,6 +397,20 @@ Blockly.Toolbox.prototype.getCategoryLengthByName = function(name) {
   var scrollPositions = this.flyout_.categoryScrollPositions;
   for (var i = 0; i < scrollPositions.length; i++) {
     if (name === scrollPositions[i].categoryName) {
+      return scrollPositions[i].length;
+    }
+  }
+};
+
+/**
+ * Get the length of a category by id.
+ * @param  {string} id The id of the category.
+ * @return {number} The length of the category.
+ */
+Blockly.Toolbox.prototype.getCategoryLengthById = function(id) {
+  var scrollPositions = this.flyout_.categoryScrollPositions;
+  for (var i = 0; i < scrollPositions.length; i++) {
+    if (id === scrollPositions[i].categoryId) {
       return scrollPositions[i].length;
     }
   }
@@ -407,9 +442,9 @@ Blockly.Toolbox.prototype.setSelectedItem = function(item, opt_shouldScroll) {
   if (this.selectedItem_ != null) {
     this.selectedItem_.setSelected(true);
     // Scroll flyout to the top of the selected category
-    var categoryName = item.name_;
+    var categoryId = item.id_;
     if (opt_shouldScroll) {
-      this.scrollToCategoryByName(categoryName);
+      this.scrollToCategoryById(categoryId);
     }
   }
 };
@@ -421,6 +456,15 @@ Blockly.Toolbox.prototype.setSelectedItem = function(item, opt_shouldScroll) {
 Blockly.Toolbox.prototype.setSelectedCategoryByName = function(name) {
   this.selectCategoryByName(name);
   this.scrollToCategoryByName(name);
+};
+
+/**
+ * Select and scroll to a category by id.
+ * @param {string} id The id of the category to select and scroll to.
+ */
+Blockly.Toolbox.prototype.setSelectedCategoryById = function(id) {
+  this.selectCategoryById(id);
+  this.scrollToCategoryById(id);
 };
 
 /**
@@ -440,6 +484,32 @@ Blockly.Toolbox.prototype.scrollToCategoryByName = function(name) {
 };
 
 /**
+ * Scroll to a category by id.
+ * @param {string} id The id of the category to scroll to.
+ * @package
+ */
+Blockly.Toolbox.prototype.scrollToCategoryById = function(id) {
+  var scrollPositions = this.flyout_.categoryScrollPositions;
+  for (var i = 0; i < scrollPositions.length; i++) {
+    if (id === scrollPositions[i].categoryId) {
+      this.flyout_.setVisible(true);
+      this.flyout_.scrollTo(scrollPositions[i].position);
+      return;
+    }
+  }
+};
+
+/**
+ * Get a category by its index.
+ * @param  {number} index The index of the category.
+ * @return {Blockly.Toolbox.Category} the category.
+ */
+Blockly.Toolbox.prototype.getCategoryByIndex = function(index) {
+  if (!this.categoryMenu_.categories_) return;
+  return this.categoryMenu_.categories_[index];
+};
+
+/**
  * Select a category by name.
  * @param {string} name The name of the category to select.
  * @package
@@ -448,6 +518,22 @@ Blockly.Toolbox.prototype.selectCategoryByName = function(name) {
   for (var i = 0; i < this.categoryMenu_.categories_.length; i++) {
     var category = this.categoryMenu_.categories_[i];
     if (name === category.name_) {
+      this.selectedItem_.setSelected(false);
+      this.selectedItem_ = category;
+      this.selectedItem_.setSelected(true);
+    }
+  }
+};
+
+/**
+ * Select a category by id.
+ * @param {string} id The id of the category to select.
+ * @package
+ */
+Blockly.Toolbox.prototype.selectCategoryById = function(id) {
+  for (var i = 0; i < this.categoryMenu_.categories_.length; i++) {
+    var category = this.categoryMenu_.categories_[i];
+    if (id === category.id_) {
       this.selectedItem_.setSelected(false);
       this.selectedItem_ = category;
       this.selectedItem_.setSelected(true);
@@ -563,6 +649,7 @@ Blockly.Toolbox.Category = function(parent, parentHtml, domTree) {
   this.parent_ = parent;
   this.parentHtml_ = parentHtml;
   this.name_ = domTree.getAttribute('name');
+  this.id_ = domTree.getAttribute('id');
   this.setColour(domTree);
   this.custom_ = domTree.getAttribute('custom');
   this.iconURI_ = domTree.getAttribute('iconURI');

--- a/core/toolbox.js
+++ b/core/toolbox.js
@@ -346,6 +346,7 @@ Blockly.Toolbox.prototype.getSelectedCategoryName = function() {
 
 /**
  * @return {string} The id of the currently selected category.
+ * @public
  */
 Blockly.Toolbox.prototype.getSelectedCategoryId = function() {
   return this.selectedItem_.id_;
@@ -378,6 +379,7 @@ Blockly.Toolbox.prototype.getCategoryPositionByName = function(name) {
  * Get the position of a category by id.
  * @param  {string} id The id of the category.
  * @return {number} The position of the category.
+ * @public
  */
 Blockly.Toolbox.prototype.getCategoryPositionById = function(id) {
   var scrollPositions = this.flyout_.categoryScrollPositions;
@@ -406,6 +408,7 @@ Blockly.Toolbox.prototype.getCategoryLengthByName = function(name) {
  * Get the length of a category by id.
  * @param  {string} id The id of the category.
  * @return {number} The length of the category.
+ * @public
  */
 Blockly.Toolbox.prototype.getCategoryLengthById = function(id) {
   var scrollPositions = this.flyout_.categoryScrollPositions;
@@ -461,6 +464,7 @@ Blockly.Toolbox.prototype.setSelectedCategoryByName = function(name) {
 /**
  * Select and scroll to a category by id.
  * @param {string} id The id of the category to select and scroll to.
+ * @public
  */
 Blockly.Toolbox.prototype.setSelectedCategoryById = function(id) {
   this.selectCategoryById(id);
@@ -486,7 +490,7 @@ Blockly.Toolbox.prototype.scrollToCategoryByName = function(name) {
 /**
  * Scroll to a category by id.
  * @param {string} id The id of the category to scroll to.
- * @package
+ * @public
  */
 Blockly.Toolbox.prototype.scrollToCategoryById = function(id) {
   var scrollPositions = this.flyout_.categoryScrollPositions;
@@ -503,6 +507,7 @@ Blockly.Toolbox.prototype.scrollToCategoryById = function(id) {
  * Get a category by its index.
  * @param  {number} index The index of the category.
  * @return {Blockly.Toolbox.Category} the category, or null if there are no categories.
+ * @package
  */
 Blockly.Toolbox.prototype.getCategoryByIndex = function(index) {
   if (!this.categoryMenu_.categories_) return null;


### PR DESCRIPTION
### Resolves

Support for https://github.com/LLK/scratch-blocks/issues/1429
GUI blocks menu will be broken after this change until https://github.com/LLK/scratch-gui/pull/2041 is merged.
  
### Proposed Changes

- Add an id to each category in the default toolbox
- Store the category ids in the object recording category scroll positions, which required adding `getCategoryByIndex`
- Add several functions to access categories by id, to replace the ones that accessed categories by name

### Reason for Changes

This change is necessary because the category names will change due to localization, so we need to use stable ids. 

It also provides support for auto-scrolling to an extension category (on adding it) even if the extension name shown in the library does not match the name shown in the category menu.

### Question

I've left in the functions that access categories by name. Should we:

A) Leave them in (messy, but fewer things break)?
B) Leave them in but stubbed out, or with a deprecation warning?
C) Remove them entirely?

(If it's B or C I can do that in another PR)