### PR TITLE
Fix remote builds with build.py

### DIFF
--- a/build.py
+++ b/build.py
@@ -134,11 +134,7 @@ window.BLOCKLY_BOOT = function() {
       alert('Error: Closure not found.  Read this:\\n' +
             'developers.google.com/blockly/guides/modify/web/closure');
     }
-    if (window.BLOCKLY_DIR.search(/node_modules/)) {
-      dir = '..';
-    } else {
-      dir = window.BLOCKLY_DIR.match(/[^\\/]+$/)[0];
-    }
+    dir = window.BLOCKLY_DIR.match(/[^\\/]+$/)[0];
   }
 """))
     add_dependency = []
@@ -322,7 +318,10 @@ class Gen_compressed(threading.Thread):
     self.do_compile(params, target_filename, filenames, remove)
 
   def do_compile(self, params, target_filename, filenames, remove):
-    do_compile = self.do_compile_remote if self.closure_env == REMOTE_COMPILER else self.do_compile_local
+    if self.closure_env["closure_compiler"] == REMOTE_COMPILER:
+      do_compile = self.do_compile_remote
+    else:
+      do_compile = self.do_compile_local
     json_data = do_compile(params, target_filename)
 
     if self.report_errors(target_filename, filenames, json_data):


### PR DESCRIPTION
This has two changes to make building and using the uncompressed version of scratch blocks work, when doing a remote build:
- get rid of a check for `node_modules` that was unnecessary and always set `dir` wrong
- correctly check for the remote compiler

The second one is the same as #1512 with a long line broken apart.

I need this so that I can add workspace comments, because I need to be able to build and test them as I add new classes.