### PR TITLE
Use localeCompare for variable and procedure name comparison

### DIFF
--- a/core/blockly.js
+++ b/core/blockly.js
@@ -528,6 +528,19 @@ Blockly.isNumber = function(str) {
   return !!str.match(/^\s*-?\d+(\.\d+)?\s*$/);
 };
 
+/**
+ * Compare strings with natural number sorting.
+ * @param {string} str1 First input.
+ * @param {string} str2 Second input.
+ * @return {number} -1, 0, or 1 to signify greater than, equality, or less than.
+ */
+Blockly.compareStrings = function(str1, str2) {
+  return str1.localeCompare(str2, undefined, {
+    sensitivity: 'base',
+    numeric: true
+  })
+}
+
 // IE9 does not have a console.  Create a stub to stop errors.
 if (!goog.global['console']) {
   goog.global['console'] = {

--- a/core/blockly.js
+++ b/core/blockly.js
@@ -528,19 +528,6 @@ Blockly.isNumber = function(str) {
   return !!str.match(/^\s*-?\d+(\.\d+)?\s*$/);
 };
 
-/**
- * Compare strings with natural number sorting.
- * @param {string} str1 First input.
- * @param {string} str2 Second input.
- * @return {number} -1, 0, or 1 to signify greater than, equality, or less than.
- */
-Blockly.compareStrings = function(str1, str2) {
-  return str1.localeCompare(str2, undefined, {
-    sensitivity: 'base',
-    numeric: true
-  });
-};
-
 // IE9 does not have a console.  Create a stub to stop errors.
 if (!goog.global['console']) {
   goog.global['console'] = {

--- a/core/blockly.js
+++ b/core/blockly.js
@@ -538,8 +538,8 @@ Blockly.compareStrings = function(str1, str2) {
   return str1.localeCompare(str2, undefined, {
     sensitivity: 'base',
     numeric: true
-  })
-}
+  });
+};
 
 // IE9 does not have a console.  Create a stub to stop errors.
 if (!goog.global['console']) {

--- a/core/procedures.js
+++ b/core/procedures.js
@@ -108,7 +108,7 @@ Blockly.Procedures.sortProcedureMutations_ = function(mutations) {
     var procCodeA = a.getAttribute('proccode');
     var procCodeB = b.getAttribute('proccode');
 
-    return Blockly.compareStrings(procCodeA, procCodeB);
+    return Blockly.scratchBlocksUtils.compareStrings(procCodeA, procCodeB);
   });
 
   return newMutations;
@@ -123,7 +123,7 @@ Blockly.Procedures.sortProcedureMutations_ = function(mutations) {
  * @private
  */
 Blockly.Procedures.procTupleComparator_ = function(ta, tb) {
-  return Blockly.compareStrings(ta[0], tb[0]);
+  return Blockly.scratchBlocksUtils.compareStrings(ta[0], tb[0]);
 };
 
 /**

--- a/core/procedures.js
+++ b/core/procedures.js
@@ -108,13 +108,10 @@ Blockly.Procedures.sortProcedureMutations_ = function(mutations) {
     var procCodeA = a.getAttribute('proccode');
     var procCodeB = b.getAttribute('proccode');
 
-    if (procCodeA < procCodeB) {
-      return -1;
-    } else if (procCodeA > procCodeB) {
-      return 1;
-    } else {
-      return 0;
-    }
+    return procCodeA.localeCompare(procCodeB, undefined, {
+      sensitivity: 'base',
+      numeric: true
+    });
   });
 
   return newMutations;
@@ -129,7 +126,10 @@ Blockly.Procedures.sortProcedureMutations_ = function(mutations) {
  * @private
  */
 Blockly.Procedures.procTupleComparator_ = function(ta, tb) {
-  return ta[0].toLowerCase().localeCompare(tb[0].toLowerCase());
+  return ta[0].localeCompare(tb[0], undefined, {
+    sensitivity: 'base',
+    numeric: true
+  });
 };
 
 /**

--- a/core/procedures.js
+++ b/core/procedures.js
@@ -108,7 +108,7 @@ Blockly.Procedures.sortProcedureMutations_ = function(mutations) {
     var procCodeA = a.getAttribute('proccode');
     var procCodeB = b.getAttribute('proccode');
 
-    return Blockly.compareStrings(procCodeA, procCodeB)
+    return Blockly.compareStrings(procCodeA, procCodeB);
   });
 
   return newMutations;
@@ -123,7 +123,7 @@ Blockly.Procedures.sortProcedureMutations_ = function(mutations) {
  * @private
  */
 Blockly.Procedures.procTupleComparator_ = function(ta, tb) {
-  return Blockly.compareStrings(ta[0], tb[0])
+  return Blockly.compareStrings(ta[0], tb[0]);
 };
 
 /**

--- a/core/procedures.js
+++ b/core/procedures.js
@@ -108,10 +108,7 @@ Blockly.Procedures.sortProcedureMutations_ = function(mutations) {
     var procCodeA = a.getAttribute('proccode');
     var procCodeB = b.getAttribute('proccode');
 
-    return procCodeA.localeCompare(procCodeB, undefined, {
-      sensitivity: 'base',
-      numeric: true
-    });
+    return Blockly.compareStrings(procCodeA, procCodeB)
   });
 
   return newMutations;
@@ -126,10 +123,7 @@ Blockly.Procedures.sortProcedureMutations_ = function(mutations) {
  * @private
  */
 Blockly.Procedures.procTupleComparator_ = function(ta, tb) {
-  return ta[0].localeCompare(tb[0], undefined, {
-    sensitivity: 'base',
-    numeric: true
-  });
+  return Blockly.compareStrings(ta[0], tb[0])
 };
 
 /**

--- a/core/scratch_blocks_utils.js
+++ b/core/scratch_blocks_utils.js
@@ -109,7 +109,7 @@ Blockly.scratchBlocksUtils.isShadowArgumentReporter = function(block) {
  * @return {number} -1, 0, or 1 to signify greater than, equality, or less than.
  */
 Blockly.scratchBlocksUtils.compareStrings = function(str1, str2) {
-  return str1.localeCompare(str2, undefined, {
+  return str1.localeCompare(str2, [], {
     sensitivity: 'base',
     numeric: true
   });

--- a/core/scratch_blocks_utils.js
+++ b/core/scratch_blocks_utils.js
@@ -101,3 +101,16 @@ Blockly.scratchBlocksUtils.isShadowArgumentReporter = function(block) {
   return (block.isShadow() && (block.type == 'argument_reporter_boolean' ||
       block.type == 'argument_reporter_string_number'));
 };
+
+/**
+ * Compare strings with natural number sorting.
+ * @param {string} str1 First input.
+ * @param {string} str2 Second input.
+ * @return {number} -1, 0, or 1 to signify greater than, equality, or less than.
+ */
+Blockly.scratchBlocksUtils.compareStrings = function(str1, str2) {
+  return str1.localeCompare(str2, undefined, {
+    sensitivity: 'base',
+    numeric: true
+  });
+};

--- a/core/variable_model.js
+++ b/core/variable_model.js
@@ -97,5 +97,5 @@ Blockly.VariableModel.prototype.getId = function() {
  * @package
  */
 Blockly.VariableModel.compareByName = function(var1, var2) {
-  return Blockly.compareStrings(var1.name, var2.name);
+  return Blockly.scratchBlocksUtils.compareStrings(var1.name, var2.name);
 };

--- a/core/variable_model.js
+++ b/core/variable_model.js
@@ -97,5 +97,8 @@ Blockly.VariableModel.prototype.getId = function() {
  * @package
  */
 Blockly.VariableModel.compareByName = function(var1, var2) {
-  return goog.string.caseInsensitiveCompare(var1.name, var2.name);
+  return var1.name.localeCompare(var2.name, undefined, {
+    sensitivity: 'base',
+    numeric: true
+  });
 };

--- a/core/variable_model.js
+++ b/core/variable_model.js
@@ -97,5 +97,5 @@ Blockly.VariableModel.prototype.getId = function() {
  * @package
  */
 Blockly.VariableModel.compareByName = function(var1, var2) {
-  return Blockly.compareStrings(var1.name, var2.name)
+  return Blockly.compareStrings(var1.name, var2.name);
 };

--- a/core/variable_model.js
+++ b/core/variable_model.js
@@ -97,8 +97,5 @@ Blockly.VariableModel.prototype.getId = function() {
  * @package
  */
 Blockly.VariableModel.compareByName = function(var1, var2) {
-  return var1.name.localeCompare(var2.name, undefined, {
-    sensitivity: 'base',
-    numeric: true
-  });
+  return Blockly.compareStrings(var1.name, var2.name)
 };


### PR DESCRIPTION
Fixes #1504 by using `localeCompare` with the numeric option enabled.