### PR TITLE
Add padding to the bottom of the flyout

### DIFF
--- a/core/flyout_vertical.js
+++ b/core/flyout_vertical.js
@@ -205,10 +205,20 @@ Blockly.VerticalFlyout.prototype.getMetrics_ = function() {
   var viewHeight = this.height_ - 2 * this.SCROLLBAR_PADDING;
   var viewWidth = this.getWidth() - this.SCROLLBAR_PADDING;
 
+  // Add padding to the bottom of the flyout, so we can scroll to the top of
+  // the last category.
+  var contentHeight = optionBox.height * this.workspace_.scale;
+  this.recordCategoryScrollPositions_();
+  var lastLabel = this.categoryScrollPositions[
+      this.categoryScrollPositions.length - 1];
+  var lastPos = lastLabel.position * this.workspace_.scale;
+  var lastCategoryHeight = contentHeight - lastPos;
+  var bottomPadding = viewHeight - lastCategoryHeight;
+
   var metrics = {
     viewHeight: viewHeight,
     viewWidth: viewWidth,
-    contentHeight: optionBox.height * this.workspace_.scale + 2 * this.MARGIN,
+    contentHeight: contentHeight + bottomPadding,
     contentWidth: optionBox.width * this.workspace_.scale + 2 * this.MARGIN,
     viewTop: -this.workspace_.scrollY + optionBox.y,
     viewLeft: -this.workspace_.scrollX,

--- a/core/flyout_vertical.js
+++ b/core/flyout_vertical.js
@@ -213,7 +213,10 @@ Blockly.VerticalFlyout.prototype.getMetrics_ = function() {
       this.categoryScrollPositions.length - 1];
   var lastPos = lastLabel.position * this.workspace_.scale;
   var lastCategoryHeight = contentHeight - lastPos;
-  var bottomPadding = viewHeight - lastCategoryHeight;
+  var bottomPadding = this.MARGIN;
+  if (lastCategoryHeight < viewHeight) {
+    bottomPadding = viewHeight - lastCategoryHeight;
+  }
 
   var metrics = {
     viewHeight: viewHeight,


### PR DESCRIPTION
### Resolves

Resolves https://github.com/LLK/scratch-blocks/issues/1416
 
### Proposed Changes

In the vertical flyout's getMetrics function, increase contentHeight by adding padding to it to ensure that we can scroll to the top of the category.

The amount of padding is the view height of the flyout minus the height of the final blocks category. If the final blocks category is taller than the view (e.g. an extension with a large number of blocks), just add a small margin.  

### Reason for Changes

This change makes the category menu work better, so that each category button causes the scroll position to move, and each category can move to the top. 

### Test Coverage

No tests.