### PR TITLE
Add ability to overwrite default block colours

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ common.pyc
 *.komodoproject
 /nbproject/private/
 
+# Editor
+.vscode
+
 /accessible/*
 /dist
 /msg/json/synonyms.json
@@ -31,3 +34,4 @@ common.pyc
 /gh-pages/_site
 /*compiler*.jar
 /local_blockly_compressed_vertical.js
+

--- a/.gitignore
+++ b/.gitignore
@@ -34,4 +34,3 @@ common.pyc
 /gh-pages/_site
 /*compiler*.jar
 /local_blockly_compressed_vertical.js
-

--- a/core/options.js
+++ b/core/options.js
@@ -127,7 +127,13 @@ Blockly.Options = function(options) {
           Blockly.Colours.hasOwnProperty(colourProperty)) {
         // If a property is in both colours option and Blockly.Colours,
         // set the Blockly.Colours value to the override.
-        Blockly.Colours[colourProperty] = colours[colourProperty];
+        // Ensure references are kept by extending a property when it's an object
+        var colourPropertyValue = colours[colourProperty];
+        if (goog.isObject(colourPropertyValue)) {
+          goog.object.extend(Blockly.Colours[colourProperty], colourPropertyValue);
+        } else {
+          Blockly.Colours[colourProperty] = colourPropertyValue;
+        }
       }
     }
   }

--- a/core/options.js
+++ b/core/options.js
@@ -127,8 +127,8 @@ Blockly.Options = function(options) {
           Blockly.Colours.hasOwnProperty(colourProperty)) {
         // If a property is in both colours option and Blockly.Colours,
         // set the Blockly.Colours value to the override.
-        // Ensure to override old Blockly category colours by reference instead
-        // of overriding them, as theya re used by reference elsewhere.
+        // Override Blockly category color object properties with those
+        // provided.
         var colourPropertyValue = colours[colourProperty];
         if (goog.isObject(colourPropertyValue)) {
           for (var colourSequence in colourPropertyValue) {

--- a/core/options.js
+++ b/core/options.js
@@ -127,10 +127,16 @@ Blockly.Options = function(options) {
           Blockly.Colours.hasOwnProperty(colourProperty)) {
         // If a property is in both colours option and Blockly.Colours,
         // set the Blockly.Colours value to the override.
-        // Ensure references are kept by extending a property when it's an object
+        // Ensure to override old Blockly category colours by reference instead
+        // of overriding them, as theya re used by reference elsewhere.
         var colourPropertyValue = colours[colourProperty];
         if (goog.isObject(colourPropertyValue)) {
-          goog.object.extend(Blockly.Colours[colourProperty], colourPropertyValue);
+          for (var colourSequence in colourPropertyValue) {
+            if (colourPropertyValue.hasOwnProperty(colourSequence) &&
+              Blockly.Colours[colourProperty].hasOwnProperty(colourSequence)) {
+              Blockly.Colours[colourProperty][colourSequence] = colourPropertyValue[colourSequence];
+            }
+          }
         } else {
           Blockly.Colours[colourProperty] = colourPropertyValue;
         }


### PR DESCRIPTION
### Resolves

fixes #1535

### Proposed Changes

This pull request adds the ability to parametrize the core scratch block colours from the `Blockly.inject` call

### Reason for Changes

scratch-blocks already has the ability to change the colours of each category, this further allows the customization of block primary, secondary and tertiary colours, should other projects using scratch-blocks wish to have their own colour scheme

### Test Coverage

_Please show how you have added tests to cover your changes_
