### PR TITLE
Publish only dist, TRADEMARK, README.md, package.json, and LICENSE to npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,14 @@
+# Development files
+.eslintrc
+/.editorconfig
+/.eslintignore
+/.gitattributes
+/.github
+/.travis.yml
+/.tx
+/tests
+/webpack.config.js
+
 # Localization / I18N
 common.pyc
 .settings
@@ -7,3 +18,9 @@ common.pyc
 /nbproject/private/
 
 /accessible/*
+
+# Build created files
+/gh-pages
+
+# Exclude already built packages from testing with npm pack
+/scratch-blocks-*.{tar,tgz}


### PR DESCRIPTION
### Proposed Changes

- Publish only `dist`, `TRADEMARK`, `README.md`, `package.json`, and `LICENSE` to npm

### Reason for Changes

Other packages that depend on scratch-blocks need to download it and locally install a copy to require into. As scratch-blocks is, it's publishing `gh-pages` and `tests`. These folders are not used by scratch-blocks dependents. They take up a relatively large amount of space in the download file and once extracted on disk. Importantly this extra space means that CI servers along with the developers working on another scratch-* package need to spend more time downloading and for CI, more time storing and retrieving the node_modules cache to perform CI work quicker.

Specifying the files published with this change, reduces the download from **8.4MB** to **920K**, and space used once extracted from **45MB** to **4.1MB**. Most of the savings is from omitting `gh-pages`.

-----

`README.md`, `package.json` and `LICENSE` are automatically included in the files published to npm whether they are stated in `package.json` or not. I can add those if the explicit nature of stating them that way would be preferred.

-----

If you want to check locally what files will be published, one way to do so is to make the package npm will publish with the `npm pack` command. It'll make a gzip'd tar file with the content that would be published. You can then use a tool to see the contents (like `tar -tf scratch-blocks-0.1.0.tgz` on a command line) or extract the contents and look at the extracted directory.
