### PR TITLE
Add the require for WorkspaceCommentSvg.render

### DIFF
--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -46,6 +46,7 @@ goog.require('Blockly.Workspace');
 goog.require('Blockly.WorkspaceAudio');
 goog.require('Blockly.WorkspaceComment');
 goog.require('Blockly.WorkspaceCommentSvg');
+goog.require('Blockly.WorkspaceCommentSvg.render');
 goog.require('Blockly.WorkspaceDragSurfaceSvg');
 goog.require('Blockly.Xml');
 goog.require('Blockly.ZoomControls');


### PR DESCRIPTION
### Proposed Changes

Make workspace comments work with compressed scratch-blocks.
