### PR TITLE
Fix unclickable flyout buttons

### DIFF
--- a/core/css.js
+++ b/core/css.js
@@ -511,7 +511,7 @@ Blockly.Css.CONTENT = [
   '}',
 
   '.blocklyFlyoutButtonShadow {',
-    'fill: none;',
+    'fill: transparent;',
   '}',
 
   '.blocklyFlyoutButton:hover {',


### PR DESCRIPTION

### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-blocks/issues/941

### Proposed Changes

_Describe what this Pull Request does_

Change the `fill: none` to `fill: transparent`. Mouse up does not fire on the inside of a fill: none; path, but fill: transparent; does click

### Reason for Changes

_Explain why these changes should be made_

So you can click the buttons!

### Test Coverage

_Please show how you have added tests to cover your changes_

Try clicking the buttons.
