### PR TITLE
Randomized id for svg filters

### DIFF
--- a/core/block_render_svg_horizontal.js
+++ b/core/block_render_svg_horizontal.js
@@ -335,7 +335,9 @@ Blockly.BlockSvg.prototype.updateColour = function() {
  */
 Blockly.BlockSvg.prototype.highlightForReplacement = function(add) {
   if (add) {
-    this.svgPath_.setAttribute('filter', 'url(#blocklyReplacementGlowFilter)');
+    var replacementGlowFilterId = this.workspace.options.replacementGlowFilterId
+      || 'blocklyReplacementGlowFilter';
+    this.svgPath_.setAttribute('filter', 'url(#' + replacementGlowFilterId + ')');
     Blockly.utils.addClass(/** @type {!Element} */ (this.svgGroup_),
         'blocklyReplaceable');
   } else {

--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -560,7 +560,9 @@ Blockly.BlockSvg.prototype.updateColour = function() {
  */
 Blockly.BlockSvg.prototype.highlightForReplacement = function(add) {
   if (add) {
-    this.svgPath_.setAttribute('filter', 'url(#blocklyReplacementGlowFilter)');
+    var replacementGlowFilterId = this.workspace.options.replacementGlowFilterId
+      || 'blocklyReplacementGlowFilter';
+    this.svgPath_.setAttribute('filter', 'url(#' + replacementGlowFilterId + ')');
     Blockly.utils.addClass(/** @type {!Element} */ (this.svgGroup_),
         'blocklyReplaceable');
   } else {
@@ -585,8 +587,10 @@ Blockly.BlockSvg.prototype.highlightShapeForInput = function(conn, add) {
     return;
   }
   if (add) {
+    var replacementGlowFilterId = this.workspace.options.replacementGlowFilterId
+      || 'blocklyReplacementGlowFilter';
     input.outlinePath.setAttribute('filter',
-        'url(#blocklyReplacementGlowFilter)');
+        'url(#' + replacementGlowFilterId + ')');
     Blockly.utils.addClass(/** @type {!Element} */ (this.svgGroup_),
         'blocklyReplaceable');
   } else {

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -231,7 +231,8 @@ Blockly.BlockSvg.prototype.setGlowStack = function(isGlowingStack) {
   // Update the applied SVG filter if the property has changed
   var svg = this.getSvgRoot();
   if (this.isGlowingStack_ && !svg.hasAttribute('filter')) {
-    svg.setAttribute('filter', 'url(#blocklyStackGlowFilter)');
+    var stackGlowFilterId = this.workspace.options.stackGlowFilterId || 'blocklyStackGlowFilter';
+    svg.setAttribute('filter', 'url(#' + stackGlowFilterId + ')');
   } else if (!this.isGlowingStack_ && svg.hasAttribute('filter')) {
     svg.removeAttribute('filter');
   }

--- a/core/inject.js
+++ b/core/inject.js
@@ -132,7 +132,7 @@ Blockly.createDom_ = function(container, options) {
   // Instead use a gaussian blur, and then set all alpha to 1 with a transfer.
   var stackGlowFilter = Blockly.utils.createSvgElement('filter',
       {
-        'id': 'blocklyStackGlowFilter',
+        'id': 'blocklyStackGlowFilter' + rnd,
         'height': '160%',
         'width': '180%',
         y: '-30%',
@@ -180,7 +180,7 @@ Blockly.createDom_ = function(container, options) {
   // Filter for replacement marker
   var replacementGlowFilter = Blockly.utils.createSvgElement('filter',
       {
-        'id': 'blocklyReplacementGlowFilter',
+        'id': 'blocklyReplacementGlowFilter' + rnd,
         'height': '160%',
         'width': '180%',
         y: '-30%',
@@ -253,6 +253,8 @@ Blockly.createDom_ = function(container, options) {
         'stroke': '#cc0'
       },
       disabledPattern);
+  options.stackGlowFilterId = stackGlowFilter.id;
+  options.replacementGlowFilterId = replacementGlowFilter.id;
   options.disabledPatternId = disabledPattern.id;
 
   options.gridPattern = Blockly.Grid.createDom(rnd, options.gridOptions, defs);


### PR DESCRIPTION
### Resolves

Resolves #1549 
Resolves #889 

### Proposed Changes

Randomly generate the id for the stack glow filter and replacement glow filter

### Reason for Changes

When `inject` is called for an embedded workspace (ie. when displaying the custom procedures modal), the stack and replacement glow filters are generated again with the same ID as the original instances.  This is an issue in Safari and iOS browsers which then stop displaying the filters when the embedded workspace is destroyed.  By randomly generating the filter IDs, we prevent collisions.

### Test Coverage

Tested by instantiating an embedded workspace and verifying the fix.
