### PR TITLE
Clear selected block before executing undo/redo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,5 +31,3 @@ common.pyc
 /gh-pages/_site
 /*compiler*.jar
 /local_blockly_compressed_vertical.js
-
-\.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ common.pyc
 /gh-pages/_site
 /*compiler*.jar
 /local_blockly_compressed_vertical.js
+
+\.idea/

--- a/core/workspace.js
+++ b/core/workspace.js
@@ -488,6 +488,14 @@ Blockly.Workspace.prototype.undo = function(redo) {
   }
   events = Blockly.Events.filter(events, redo);
   Blockly.Events.recordUndo = false;
+  if (Blockly.selected) {
+    Blockly.Events.disable();
+    try {
+      Blockly.selected.unselect();
+    } finally {
+      Blockly.Events.enable();
+    }
+  }
   try {
     for (var i = 0, event; event = events[i]; i++) {
       event.run(redo);


### PR DESCRIPTION
### Resolves

Resolves #773 

### Proposed Changes

Clear any selected block before executing an undo/redo.

### Reason for Changes

When attempting to call undo and then redo on a currently selected block, the call to `block.setParent(null)` isn't complete as it does not properly append the block to the workspace and instead it stays attached to its current block. (see https://github.com/LLK/scratch-blocks/blob/f7be0a9ac7742f80c421b1b894f856b31cca47ea/core/block_svg.js#L315). This means when the redo process attempts to reconnect the block, it throws the error `"Failed to execute 'appendChild' on 'Node': The new child element contains the parent."`

### Test Coverage

Tested by following the steps to reproduce in #773.
