### PR TITLE
Don't check for the selected block in setParent

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -310,12 +310,8 @@ Blockly.BlockSvg.prototype.setParent = function(newParent) {
   // If we are losing a parent, we want to move our DOM element to the
   // root of the workspace.
   else if (oldParent) {
-    // Avoid moving a block up the DOM if it's currently selected/dragging,
-    // so as to avoid taking things off the drag surface.
-    if (Blockly.selected != this) {
-      this.workspace.getCanvas().appendChild(svgRoot);
-      this.translate(oldXY.x, oldXY.y);
-    }
+    this.workspace.getCanvas().appendChild(svgRoot);
+    this.translate(oldXY.x, oldXY.y);
   }
 
 };


### PR DESCRIPTION
The check for the selected block claims to be a check against moving the dragging block, but it doesn't check for that and it *does* mean that dragged blocks don't end up on the correct element.