### PR TITLE
Pass stack glow filter to the toolbox

### DIFF
--- a/core/toolbox.js
+++ b/core/toolbox.js
@@ -161,7 +161,8 @@ Blockly.Toolbox.prototype.createFlyout_ = function() {
     RTL: workspace.RTL,
     oneBasedIndex: workspace.options.oneBasedIndex,
     horizontalLayout: workspace.horizontalLayout,
-    toolboxPosition: workspace.options.toolboxPosition
+    toolboxPosition: workspace.options.toolboxPosition,
+    stackGlowFilterId: workspace.options.stackGlowFilterId
   };
 
   if (workspace.horizontalLayout) {

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -589,7 +589,8 @@ Blockly.WorkspaceSvg.prototype.addFlyout_ = function(tagName) {
     RTL: this.RTL,
     oneBasedIndex: this.options.oneBasedIndex,
     horizontalLayout: this.horizontalLayout,
-    toolboxPosition: this.options.toolboxPosition
+    toolboxPosition: this.options.toolboxPosition,
+    stackGlowFilterId: this.options.stackGlowFilterId
   };
   if (this.horizontalLayout) {
     this.flyout_ = new Blockly.HorizontalFlyout(workspaceOptions);


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes an issue caused by #1551 that wasn't caught at the time, that the toolbox can stack glow and so needs to be passed the parents stack glow filter id when it is initialized.

### Proposed Changes

_Describe what this Pull Request does_

Pass down the stack glow filter ID when creating a flyout, or use the workspaces stack glow filter when creating a toolbox.

Note this is required in two places, because you can create a palette of blocks either by creating just a flyout ("simple" mode in the playground) or by creating a toolbox ("categories" mode) which then creates a flyout.
