### PR TITLE
Updated message key that was missed when original key was changed

### DIFF
--- a/blocks_vertical/vertical_extensions.js
+++ b/blocks_vertical/vertical_extensions.js
@@ -184,7 +184,7 @@ Blockly.ScratchBlocks.VerticalExtensions.PROCEDURE_DEF_CONTEXTMENU = {
     }
     // Find and remove the duplicate option
     for (var i = 0, option; option = menuOptions[i]; i++) {
-      if (option.text == Blockly.Msg.DUPLICATE_BLOCK) {
+      if (option.text == Blockly.Msg.DUPLICATE) {
         menuOptions.splice(i, 1);
         break;
       }


### PR DESCRIPTION
### Resolves

No issue filed that I'm aware of.

### Proposed Changes

The key for the "duplicate" string was recently changed (here: https://github.com/LLK/scratch-blocks/commit/e38969831eb53b19a380ae8faec4ca43e0904404) but one case was not updated.

### Reason for Changes

This was causing the user to be able to duplicate a custom procedure definition block because the key check was failing.

### Test Coverage

Verified that custom procedure definition blocks cannot be duplicated after updating the key reference.
