### PR TITLE
python build script fixed

### DIFF
--- a/build.py
+++ b/build.py
@@ -322,7 +322,7 @@ class Gen_compressed(threading.Thread):
     self.do_compile(params, target_filename, filenames, remove)
 
   def do_compile(self, params, target_filename, filenames, remove):
-    do_compile = self.do_compile_remote if self.closure_env == REMOTE_COMPILER else self.do_compile_local
+    do_compile = self.do_compile_remote if self.closure_env["closure_compiler"] == REMOTE_COMPILER else self.do_compile_local
     json_data = do_compile(params, target_filename)
 
     if self.report_errors(target_filename, filenames, json_data):
@@ -349,7 +349,7 @@ class Gen_compressed(threading.Thread):
       for group in [["google-closure-compiler"], dash_args]:
         args.extend(filter(lambda item: item, group))
 
-      proc = subprocess.Popen(args, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+      proc = subprocess.Popen(args, stdin=subprocess.PIPE, stdout=subprocess.PIPE,shell=True)
       (stdout, stderr) = proc.communicate()
 
       # Build the JSON response.
@@ -592,7 +592,7 @@ if __name__ == "__main__":
 
     # Sanity check the local compiler
     test_args = [closure_compiler, os.path.join("build", "test_input.js")]
-    test_proc = subprocess.Popen(test_args, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+    test_proc = subprocess.Popen(test_args, stdin=subprocess.PIPE, stdout=subprocess.PIPE,shell=True)
     (stdout, _) = test_proc.communicate()
     assert stdout == read(os.path.join("build", "test_expect.js"))
 


### PR DESCRIPTION
### Resolves

Resolves issue [#2119](https://github.com/LLK/scratch-gui/issues/2119) in scratch-gui

### Proposed Changes

While checking for remote compiler in do_compile, compare self.closure_env["closure_compiler"] with REMOTE_COMPILER instead of self.closure_env

### Reason for Changes

Error running build script

### Test Coverage

Run the file to test for it's correctness