### PR TITLE
Add when touching hat

### DIFF
--- a/blocks_vertical/event.js
+++ b/blocks_vertical/event.js
@@ -29,12 +29,12 @@ goog.require('Blockly.ScratchBlocks.VerticalExtensions');
 
 Blockly.Blocks['event_whentouchingobject'] = {
   /**
-   * Block to when a sprite is touching an object.
+   * Block for when a sprite is touching an object.
    * @this Blockly.Block
    */
   init: function() {
     this.jsonInit({
-      "message0": "when this sprite touches %1",
+      "message0": Blockly.Msg.EVENT_WHENTOUCHINGOBJECT,
       "args0": [
         {
           "type": "input_value",

--- a/blocks_vertical/event.js
+++ b/blocks_vertical/event.js
@@ -27,6 +27,48 @@ goog.require('Blockly.Colours');
 goog.require('Blockly.constants');
 goog.require('Blockly.ScratchBlocks.VerticalExtensions');
 
+Blockly.Blocks['event_whentouchingobject'] = {
+  /**
+   * Block to when a sprite is touching an object.
+   * @this Blockly.Block
+   */
+  init: function() {
+    this.jsonInit({
+      "message0": "when this sprite touches %1",
+      "args0": [
+        {
+          "type": "input_value",
+          "name": "TOUCHINGOBJECTMENU"
+        }
+      ],
+      "category": Blockly.Categories.event,
+      "extensions": ["colours_event", "shape_hat"]
+    });
+  }
+};
+
+Blockly.Blocks['event_touchingobjectmenu'] = {
+  /**
+   * "Touching [Object]" Block Menu.
+   * @this Blockly.Block
+   */
+  init: function() {
+    this.jsonInit({
+      "message0": "%1",
+      "args0": [
+        {
+          "type": "field_dropdown",
+          "name": "TOUCHINGOBJECTMENU",
+          "options": [
+            [Blockly.Msg.SENSING_TOUCHINGOBJECT_POINTER, '_mouse_'],
+            [Blockly.Msg.SENSING_TOUCHINGOBJECT_EDGE, '_edge_']
+          ]
+        }
+      ],
+      "extensions": ["colours_event", "output_string"]
+    });
+  }
+};
 
 Blockly.Blocks['event_whenflagclicked'] = {
   /**

--- a/msg/messages.js
+++ b/msg/messages.js
@@ -75,6 +75,7 @@ Blockly.Msg.DATA_INDEX_RANDOM = "random";
 Blockly.Msg.EVENT_WHENFLAGCLICKED = "when %1 clicked";
 Blockly.Msg.EVENT_WHENTHISSPRITECLICKED = "when this sprite clicked";
 Blockly.Msg.EVENT_WHENSTAGECLICKED = "when stage clicked";
+Blockly.Msg.EVENT_WHENTOUCHINGOBJECT = "when this sprite touches %1";
 Blockly.Msg.EVENT_WHENBROADCASTRECEIVED = "when I receive %1";
 Blockly.Msg.EVENT_WHENBACKDROPSWITCHESTO = "when backdrop switches to %1";
 Blockly.Msg.EVENT_WHENGREATERTHAN = "when %1 > %2";


### PR DESCRIPTION
### Resolves

Part of https://github.com/LLK/scratch-gui/issues/607

### Proposed Changes

Add a hat block for when a sprite is touching the mouse pointer, edge of the stage, or another sprite.

### Reason for Changes

This is a "low floor" feature, making it easier to make simple projects where you want a sprite to do something when it touches e.g. another sprite. 