### PR TITLE
Update the chromedriver version

### DIFF
--- a/tests/scripts/get_chromedriver.sh
+++ b/tests/scripts/get_chromedriver.sh
@@ -8,10 +8,10 @@ fi
 echo "downloading chromedriver"
 
 if [[ $os_name == 'Linux' && ! -f $chromedriver_dir/chromedriver ]]; then
-  cd chromedriver  && curl -L https://chromedriver.storage.googleapis.com/2.29/chromedriver_linux64.zip > tmp.zip &&  unzip -o tmp.zip && rm tmp.zip
+  cd chromedriver  && curl -L https://chromedriver.storage.googleapis.com/2.39/chromedriver_linux64.zip > tmp.zip &&  unzip -o tmp.zip && rm tmp.zip
   # wait until download finish
   sleep 5
 elif [[ $os_name == 'Darwin' && ! -f $chromedriver_dir/chromedriver ]]; then
-  cd chromedriver  &&  curl -L https://chromedriver.storage.googleapis.com/2.29/chromedriver_mac64.zip  | tar xz
+  cd chromedriver  &&  curl -L https://chromedriver.storage.googleapis.com/2.39/chromedriver_mac64.zip  | tar xz
   sleep 5
 fi


### PR DESCRIPTION
Update the chromedriver version requested by the test setup scripts, version 2.29 does not work with the newest version of chrome released recently and automatically included by Travis, causing the build to fail.

I'll open a follow up issue, but we should really move away from those custom scripts and just use the `chromedriver` and `selenium-webdriver` npm packages, which handle the selenium server and chromedriver path stuff for you.

Fixes https://github.com/LLK/scratch-blocks/issues/1567

If the build passes, this is good to go.