### PR TITLE
Add workspace comment tests and other event tests

### DIFF
--- a/tests/jsunit/event_test.js
+++ b/tests/jsunit/event_test.js
@@ -29,15 +29,6 @@ goog.require('goog.testing.MockControl');
 
 var mockControl_;
 var workspace;
-var savedFireFunc = Blockly.Events.fire;
-
-function temporary_fireEvent(event) {
-  if (!Blockly.Events.isEnabled()) {
-    return;
-  }
-  Blockly.Events.FIRE_QUEUE_.push(event);
-  Blockly.Events.fireNow_();
-}
 
 function eventTest_setUp() {
   workspace = new Blockly.Workspace();

--- a/tests/jsunit/test_utilities.js
+++ b/tests/jsunit/test_utilities.js
@@ -28,6 +28,23 @@ goog.require('goog.testing');
 
 
 /**
+ * The normal blockly event fire function.  We sometimes override this.  This
+ * handle lets us reset after an override.
+ */
+var savedFireFunc = Blockly.Events.fire;
+
+/**
+ * A helper function to replace Blockly.Events.fire in tests.
+ */
+function temporary_fireEvent(event) {
+  if (!Blockly.Events.isEnabled()) {
+    return;
+  }
+  Blockly.Events.FIRE_QUEUE_.push(event);
+  Blockly.Events.fireNow_();
+}
+
+/**
  * Check that two arrays have the same content.
  * @param {!Array.<string>} array1 The first array.
  * @param {!Array.<string>} array2 The second array.

--- a/tests/jsunit/vertical_tests.html
+++ b/tests/jsunit/vertical_tests.html
@@ -11,6 +11,7 @@
     <script src="block_test.js"></script>
     <script src="connection_db_test.js"></script>
     <script src="connection_test.js"></script>
+    <script src="event_test.js"></script>
     <script src="extensions_test.js"></script>
     <script src="field_test.js"></script>
     <script src="field_angle_test.js"></script>

--- a/tests/jsunit/workspace_comment_test.js
+++ b/tests/jsunit/workspace_comment_test.js
@@ -84,3 +84,75 @@ function test_disposeWsCommentTwice() {
     workspaceCommentTest_tearDown();
   }
 }
+
+function test_wsCommentHeightWidth() {
+  workspaceCommentTest_setUp();
+  try {
+    var comment =
+        new Blockly.WorkspaceComment(workspace, 'comment text', 10, 20, 'comment id');
+    assertEquals('Initial width', 20, comment.getWidth());
+    assertEquals('Initial height', 10, comment.getHeight());
+
+    comment.setWidth(30);
+    assertEquals('New width should be different', 30, comment.getWidth());
+    assertEquals('New height should not be different', 10, comment.getHeight());
+
+    comment.setHeight(40);
+    assertEquals('New width should not be different', 30, comment.getWidth());
+    assertEquals('New height should be different', 40, comment.getHeight());
+    comment.dispose();
+  } finally {
+    workspaceCommentTest_tearDown();
+  }
+}
+
+function test_wsCommentXY() {
+  workspaceCommentTest_setUp();
+  try {
+    var comment =
+        new Blockly.WorkspaceComment(workspace, 'comment text', 10, 20, 'comment id');
+    var xy = comment.getXY();
+    assertEquals('Initial X position', 0, xy.x);
+    assertEquals('Initial Y position', 0, xy.y);
+
+    comment.moveBy(10, 100);
+    xy = comment.getXY();
+    assertEquals('New X position', 10, xy.x);
+    assertEquals('New Y position', 100, xy.y);
+    comment.dispose();
+  } finally {
+    workspaceCommentTest_tearDown();
+  }
+}
+
+function test_wsCommentText() {
+  workspaceCommentTest_setUp();
+
+  Blockly.Events.fire = temporary_fireEvent;
+  temporary_fireEvent.firedEvents_ = [];
+  try {
+    var comment =
+        new Blockly.WorkspaceComment(workspace, 'comment text', 10, 20, 'comment id');
+    assertEquals(
+        'Check comment text', 'comment text', comment.getText());
+    assertEquals(
+        'Workspace undo stack has one event', 1, workspace.undoStack_.length);
+
+    comment.setText('comment text');
+    assertEquals(
+        'Comment text has not changed', 'comment text', comment.getText());
+    // Setting the text to the old value does not fire an event.
+    assertEquals(
+        'Workspace undo stack has one event', 1, workspace.undoStack_.length);
+
+    comment.setText('new comment text');
+    assertEquals(
+        'Comment text has changed', 'new comment text', comment.getText());
+    assertEquals(
+        'Workspace undo stack has two events', 2, workspace.undoStack_.length);
+    comment.dispose();
+  } finally {
+    workspaceCommentTest_tearDown();
+    Blockly.Events.fire = savedFireFunc;
+  }
+}


### PR DESCRIPTION
### Resolves

Part of #1563 (for ws comments)

### Proposed Changes

- Test getters and setters for xy, height/width, and text content for workspace comments
- Enable events test (which had been removed, and had a util that I needed for these tests)

### Reason for Changes

Test test test
### Test Coverage

Testing 123