### PR TITLE
Workspace Comment Rendering & Minimize

### DIFF
--- a/core/comment_events.js
+++ b/core/comment_events.js
@@ -246,10 +246,7 @@ Blockly.Events.CommentCreate = function(comment) {
    * Whether or not this comment is minimized.
    * @type {boolean}
    */
-  // TODO remove the instanceof check after adding minimize state to
-  // workspace comments
-  this.minimized = (comment instanceof Blockly.ScratchBlockComment &&
-      comment.isMinimized()) || false;
+  this.minimized = comment.isMinimized() || false;
 
   this.xml = comment.toXmlWithXY();
 };
@@ -323,8 +320,7 @@ Blockly.Events.CommentDelete = function(comment) {
   }
   Blockly.Events.CommentDelete.superClass_.constructor.call(this, comment);
   this.xy = comment.getXY();
-  this.minimized = (comment instanceof Blockly.ScratchBlockComment &&
-      comment.isMinimized()) || false;
+  this.minimized = comment.isMinimized() || false;
   this.text = comment.getText();
   var hw = comment.getHeightWidth();
   this.height = hw.height;

--- a/core/comment_events.js
+++ b/core/comment_events.js
@@ -191,11 +191,7 @@ Blockly.Events.CommentChange.prototype.run = function(forward) {
   var contents = forward ? this.newContents_ : this.oldContents_;
 
   if (contents.hasOwnProperty('minimized')) {
-    if (comment instanceof Blockly.ScratchBlockComment) {
-      // TODO remove this check when workspace comments also get a minimized
-      // state
-      comment.setMinimized(contents.minimized);
-    }
+    comment.setMinimized(contents.minimized);
   }
   if (contents.hasOwnProperty('width') && contents.hasOwnProperty('height')) {
     comment.setSize(contents.width, contents.height);

--- a/core/contextmenu.js
+++ b/core/contextmenu.js
@@ -467,7 +467,7 @@ Blockly.ContextMenu.workspaceCommentOption = function(ws, e) {
     var comment = new Blockly.WorkspaceCommentSvg(
         ws, Blockly.Msg.WORKSPACE_COMMENT_DEFAULT_TEXT,
         Blockly.WorkspaceCommentSvg.DEFAULT_SIZE,
-        Blockly.WorkspaceCommentSvg.DEFAULT_SIZE);
+        Blockly.WorkspaceCommentSvg.DEFAULT_SIZE, false);
 
     var injectionDiv = ws.getInjectionDiv();
     // Bounding rect coordinates are in client coordinates, meaning that they

--- a/core/css.js
+++ b/core/css.js
@@ -651,14 +651,23 @@ Blockly.Css.CONTENT = [
 
   '.scratchCommentBody {',
     'background-color: #fef49c;',
-    'display: flex',
-    'justify-content: center;',
-    'align-items: center;',
   '}',
 
   '.scratchCommentRect {',
     'fill: #fef49c;',
-    'stroke-width: 1px',
+  '}',
+
+  '.scratchCommentTarget {',
+    'fill: transparent;',
+  '}',
+
+  '.scratchWorkspaceCommentBorder {',
+    'stroke: #bcA903;',
+    'stroke-width: 1px;',
+  '}',
+
+  '.scratchCommentTargetFocused {',
+    'fill: none;',
   '}',
 
   '.scratchCommentTopBar {',

--- a/core/scratch_bubble.js
+++ b/core/scratch_bubble.js
@@ -260,8 +260,8 @@ Blockly.ScratchBubble.prototype.createTopBarLabel_ = function() {
         'dominant-baseline': 'middle'
       }, this.bubbleGroup_);
 
-  this.labelTextNode_ = document.createTextNode(this.labelText_);
-  this.topBarLabel_.appendChild(this.labelTextNode_);
+  var labelTextNode = document.createTextNode(this.labelText_);
+  this.topBarLabel_.appendChild(labelTextNode);
 };
 
 /**
@@ -402,10 +402,7 @@ Blockly.ScratchBubble.prototype.setMinimized = function(minimize, labelText) {
     }
     if (labelText && this.labelText_ != labelText) {
       // Update label and display
-      // TODO is there a better way to do this?
-      this.topBarLabel_.removeChild(this.labelTextNode_);
-      this.labelTextNode_ = document.createTextNode(labelText);
-      this.topBarLabel_.appendChild(this.labelTextNode_);
+      this.topBarLabel_.textContent = labelText;
     }
     Blockly.utils.removeAttribute(this.topBarLabel_, 'display');
   } else {

--- a/core/scratch_bubble.js
+++ b/core/scratch_bubble.js
@@ -89,9 +89,13 @@ Blockly.ScratchBubble = function(comment, workspace, content, anchorXY,
     Blockly.bindEventWithChecks_(
         this.minimizeArrow_, 'mousedown', this, this.minimizeArrowMouseDown_);
     Blockly.bindEventWithChecks_(
+        this.minimizeArrow_, 'mouseout', this, this.minimizeArrowMouseOut_);
+    Blockly.bindEventWithChecks_(
         this.minimizeArrow_, 'mouseup', this, this.minimizeArrowMouseUp_);
     Blockly.bindEventWithChecks_(
         this.deleteIcon_, 'mousedown', this, this.deleteMouseDown_);
+    Blockly.bindEventWithChecks_(
+        this.deleteIcon_, 'mouseout', this, this.deleteMouseOut_);
     Blockly.bindEventWithChecks_(
         this.deleteIcon_, 'mouseup', this, this.deleteMouseUp_);
     Blockly.bindEventWithChecks_(
@@ -314,7 +318,22 @@ Blockly.ScratchBubble.prototype.showContextMenu_ = function(e) {
  * @private
  */
 Blockly.ScratchBubble.prototype.minimizeArrowMouseDown_ = function(e) {
+  // Set a property indicating that this comment's minimize arrow got a mouse
+  // down event. This property will get reset if the mouse leaves the icon or
+  // when a mouse up occurs on this icon after this mouse down.
+  this.shouldToggleMinimize_ = true;
   e.stopPropagation();
+};
+
+/**
+ * Handle a mouse-out on bubble's minimize icon.
+ * @param {!Event} _e Mouse up event.
+ * @private
+ */
+Blockly.ScratchBubble.prototype.minimizeArrowMouseOut_ = function(_e) {
+  // If the mouse has left the minimize arrow icon, the
+  // shouldToggleMinimize property should get reset to false.
+  this.shouldToggleMinimize_ = false;
 };
 
 /**
@@ -323,19 +342,37 @@ Blockly.ScratchBubble.prototype.minimizeArrowMouseDown_ = function(e) {
  * @private
  */
 Blockly.ScratchBubble.prototype.minimizeArrowMouseUp_ = function(e) {
-  if (this.minimizeToggleCallback_) {
-    this.minimizeToggleCallback_.call(this);
+  // First check if this icon had a mouse down event
+  // on it and that the mouse never left the icon
+  if (this.shouldToggleMinimize_) {
+    this.shouldToggleMinimize_ = false;
+
+    if (this.minimizeToggleCallback_) {
+      this.minimizeToggleCallback_.call(this);
+    }
   }
   e.stopPropagation();
 };
 
 /**
- * Handle a mouse-down on bubble's minimize icon.
+ * Handle a mouse-down on bubble's delete icon.
  * @param {!Event} e Mouse up event.
  * @private
  */
 Blockly.ScratchBubble.prototype.deleteMouseDown_ = function(e) {
+  this.shouldDelete_ = true;
   e.stopPropagation();
+};
+
+/**
+ * Handle a mouse-out on bubble's delete icon.
+ * @param {!Event} _e Mouse out event.
+ * @private
+ */
+Blockly.ScratchBubble.prototype.deleteMouseOut_ = function(_e) {
+  // If the mouse has left the delete icon, the shouldDelete_ property
+  // should get reset to false.
+  this.shouldDelete_ = false;
 };
 
 /**
@@ -344,8 +381,14 @@ Blockly.ScratchBubble.prototype.deleteMouseDown_ = function(e) {
  * @private
  */
 Blockly.ScratchBubble.prototype.deleteMouseUp_ = function(e) {
-  if (this.deleteCallback_) {
-    this.deleteCallback_.call(this);
+  // First check that this is actually the same icon that had a mouse down event
+  // on it and that the mouse never left the icon
+  if (this.shouldDelete_) {
+    this.shouldDelete_ = false;
+
+    if (this.deleteCallback_) {
+      this.deleteCallback_.call(this);
+    }
   }
   e.stopPropagation();
 };

--- a/core/workspace_comment.js
+++ b/core/workspace_comment.js
@@ -40,12 +40,13 @@ goog.require('goog.math.Coordinate');
  * @param {string} content The content of this workspace comment.
  * @param {number} height Height of the comment.
  * @param {number} width Width of the comment.
+ * @param {boolean} minimized Whether this comment is in the minimized state
  * @param {string=} opt_id Optional ID.  Use this ID if provided, otherwise
  *     create a new ID.  If the ID conflicts with an in-use ID, a new one will
  *     be generated.
  * @constructor
  */
-Blockly.WorkspaceComment = function(workspace, content, height, width, opt_id) {
+Blockly.WorkspaceComment = function(workspace, content, height, width, minimized, opt_id) {
   /** @type {string} */
   this.id = (opt_id && !workspace.getCommentById(opt_id)) ?
       opt_id : Blockly.utils.genUid();
@@ -73,6 +74,13 @@ Blockly.WorkspaceComment = function(workspace, content, height, width, opt_id) {
    * @private
    */
   this.width_ = width;
+
+  /**
+   * The comment's minimized state.
+   * @type{boolean}
+   * @private
+   */
+  this.isMinimized_ = minimized;
 
   /**
    * @type {!Blockly.Workspace}
@@ -111,6 +119,13 @@ Blockly.WorkspaceComment = function(workspace, content, height, width, opt_id) {
 
   Blockly.WorkspaceComment.fireCreateEvent(this);
 };
+
+/**
+ * Maximum lable length (actual label length will include
+ * one additional character, the ellipsis).
+ * @private
+ */
+Blockly.WorkspaceComment.MAX_LABEL_LENGTH = 16;
 
 /**
  * Dispose of this comment.
@@ -263,6 +278,15 @@ Blockly.WorkspaceComment.prototype.setText = function(text) {
 };
 
 /**
+ * Check whether this comment is currently minimized.
+ * @return {boolean} True if minimized
+ * @package
+ */
+Blockly.WorkspaceComment.prototype.isMinimized = function() {
+  return this.isMinimized_;
+};
+
+/**
  * Encode a comment subtree as XML with XY coordinates.
  * @param {boolean=} opt_noId True if the encoder should skip the comment id.
  * @return {!Element} Tree of XML elements.
@@ -278,6 +302,23 @@ Blockly.WorkspaceComment.prototype.toXmlWithXY = function(opt_noId) {
 };
 
 /**
+ * Get the truncated text for this comment to display in the minimized
+ * top bar.
+ * @return {string} The truncated comment text
+ * @package
+ */
+Blockly.WorkspaceComment.prototype.getLabelText = function() {
+  if (this.content_.length > Blockly.WorkspaceComment.MAX_LABEL_LENGTH) {
+    if (this.RTL) {
+      return '\u2026' + this.content_.slice(0, Blockly.WorkspaceComment.MAX_LABEL_LENGTH);
+    }
+    return this.content_.slice(0, Blockly.WorkspaceComment.MAX_LABEL_LENGTH) + '\u2026';
+  } else {
+    return this.content_;
+  }
+};
+
+/**
  * Encode a comment subtree as XML, but don't serialize the XY coordinates or
  * width and height.  If you need that additional information use toXmlWithXY.
  * @param {boolean=} opt_noId True if the encoder should skip the comment id.
@@ -288,6 +329,9 @@ Blockly.WorkspaceComment.prototype.toXml = function(opt_noId) {
   var commentElement = goog.dom.createDom('comment');
   if (!opt_noId) {
     commentElement.setAttribute('id', this.id);
+  }
+  if (this.isMinimized_) {
+    commentElement.setAttribute('minimized', true);
   }
   commentElement.textContent = this.getText();
   return commentElement;
@@ -325,7 +369,7 @@ Blockly.WorkspaceComment.fromXml = function(xmlComment, workspace) {
   var info = Blockly.WorkspaceComment.parseAttributes(xmlComment);
 
   var comment = new Blockly.WorkspaceComment(
-      workspace, info.content, info.h, info.w, info.id);
+      workspace, info.content, info.h, info.w, info.minimized, info.id);
 
   if (!isNaN(info.x) && !isNaN(info.y)) {
     comment.moveBy(info.x, info.y);
@@ -370,6 +414,12 @@ Blockly.WorkspaceComment.parseAttributes = function(xml) {
      * @type {number}
      */
     y: parseInt(xml.getAttribute('y'), 10),
+    /**
+     * Whether this comment is minimized. Defaults to false if not specified in
+     * the XML.
+     * @type {boolean}
+     */
+    minimized: xml.getAttribute('minimized') || false,
     /* @type {string} */
     content: xml.textContent
   };

--- a/core/workspace_comment.js
+++ b/core/workspace_comment.js
@@ -419,7 +419,7 @@ Blockly.WorkspaceComment.parseAttributes = function(xml) {
      * the XML.
      * @type {boolean}
      */
-    minimized: xml.getAttribute('minimized') || false,
+    minimized: xml.getAttribute('minimized') == 'true' || false,
     /* @type {string} */
     content: xml.textContent
   };

--- a/core/workspace_comment_render_svg.js
+++ b/core/workspace_comment_render_svg.js
@@ -35,7 +35,7 @@ goog.require('Blockly.WorkspaceCommentSvg');
  * @const
  * @private
  */
-Blockly.WorkspaceCommentSvg.RESIZE_SIZE = 8;
+Blockly.WorkspaceCommentSvg.RESIZE_SIZE = 12 * Blockly.WorkspaceCommentSvg.BORDER_WIDTH;
 
 /**
  * Radius of the border around the comment.
@@ -43,7 +43,7 @@ Blockly.WorkspaceCommentSvg.RESIZE_SIZE = 8;
  * @const
  * @private
  */
-Blockly.WorkspaceCommentSvg.BORDER_RADIUS = 3;
+Blockly.WorkspaceCommentSvg.BORDER_WIDTH = 1;
 
 /**
  * Offset from the foreignobject edge to the textarea edge.
@@ -51,15 +51,37 @@ Blockly.WorkspaceCommentSvg.BORDER_RADIUS = 3;
  * @const
  * @private
  */
-Blockly.WorkspaceCommentSvg.TEXTAREA_OFFSET = 2;
+Blockly.WorkspaceCommentSvg.TEXTAREA_OFFSET = 12;
 
 /**
- * Offset from the top to make room for a top bar.
- * @type {number}
- * @const
+ * The height of the comment top bar.
+ * @package
+ */
+Blockly.WorkspaceCommentSvg.TOP_BAR_HEIGHT = 32;
+
+/**
+ * The size of the minimize arrow icon in the comment top bar.
  * @private
  */
-Blockly.WorkspaceCommentSvg.TOP_OFFSET = 10;
+Blockly.WorkspaceCommentSvg.MINIMIZE_ICON_SIZE = 16;
+
+/**
+ * The size of the delete icon in the comment top bar.
+ * @private
+ */
+Blockly.WorkspaceCommentSvg.DELETE_ICON_SIZE = 12;
+
+/**
+ * The inset for the top bar icons.
+ * @private
+ */
+Blockly.WorkspaceCommentSvg.TOP_BAR_ICON_INSET = 6;
+
+/**
+ * Width that a minimized comment should have.
+ * @private
+ */
+Blockly.WorkspaceCommentSvg.MINIMIZE_WIDTH = 200;
 
 /**
  * Returns a bounding box describing the dimensions of this comment.
@@ -83,31 +105,34 @@ Blockly.WorkspaceCommentSvg.prototype.render = function() {
   var size = this.getHeightWidth();
 
   // Add text area
-  this.createEditor_();
-  this.svgGroup_.appendChild(this.foreignObject_);
-
-  this.svgHandleTarget_ = Blockly.utils.createSvgElement('rect',
-      {
-        'class': 'blocklyCommentHandleTarget',
-        'x': 0,
-        'y': 0
-      });
-  this.svgGroup_.appendChild(this.svgHandleTarget_);
+  this.commentEditor_ = this.createEditor_();
   this.svgRectTarget_ = Blockly.utils.createSvgElement('rect',
       {
-        'class': 'blocklyCommentTarget',
+        'class': 'blocklyDraggable blocklyCommentTarget scratchCommentRect',
         'x': 0,
         'y': 0,
-        'rx': Blockly.WorkspaceCommentSvg.BORDER_RADIUS,
-        'ry': Blockly.WorkspaceCommentSvg.BORDER_RADIUS
+        'rx': 4 * Blockly.WorkspaceCommentSvg.BORDER_WIDTH,
+        'ry': 4 * Blockly.WorkspaceCommentSvg.BORDER_WIDTH
       });
   this.svgGroup_.appendChild(this.svgRectTarget_);
 
+  this.createCommentTopBar_();
+
+  this.svgGroup_.appendChild(this.commentEditor_);
+
   // Add the resize icon
   this.addResizeDom_();
-  if (this.isDeletable()) {
-    // Add the delete icon
-    this.addDeleteDom_();
+
+  // Show / hide relevant things based on minimized state
+  if (this.isMinimized()) {
+    this.minimizeArrow_.setAttributeNS('http://www.w3.org/1999/xlink',
+        'xlink:href', Blockly.mainWorkspace.options.pathToMedia + 'comment-arrow-up.svg');
+    this.commentEditor_.setAttribute('display', 'none');
+    this.resizeGroup_.setAttribute('display', 'none');
+  } else {
+    this.minimizeArrow_.setAttributeNS('http://www.w3.org/1999/xlink',
+        'xlink:href', Blockly.mainWorkspace.options.pathToMedia + 'comment-arrow-down.svg');
+    this.topBarLabel_.setAttribute('display', 'none');
   }
 
   this.setSize(size.width, size.height);
@@ -124,14 +149,14 @@ Blockly.WorkspaceCommentSvg.prototype.render = function() {
         this.resizeGroup_, 'mouseup', this, this.resizeMouseUp_);
   }
 
-  if (this.isDeletable()) {
-    Blockly.bindEventWithChecks_(
-        this.deleteGroup_, 'mousedown', this, this.deleteMouseDown_);
-    Blockly.bindEventWithChecks_(
-        this.deleteGroup_, 'mouseout', this, this.deleteMouseOut_);
-    Blockly.bindEventWithChecks_(
-        this.deleteGroup_, 'mouseup', this, this.deleteMouseUp_);
-  }
+  Blockly.bindEventWithChecks_(
+      this.minimizeArrow_, 'mousedown', this, this.minimizeArrowMouseDown_);
+  Blockly.bindEventWithChecks_(
+      this.minimizeArrow_, 'mouseup', this, this.minimizeArrowMouseUp_);
+  Blockly.bindEventWithChecks_(
+      this.deleteIcon_, 'mousedown', this, this.deleteMouseDown_);
+  Blockly.bindEventWithChecks_(
+      this.deleteIcon_, 'mouseup', this, this.deleteMouseUp_);
 };
 
 /**
@@ -152,29 +177,35 @@ Blockly.WorkspaceCommentSvg.prototype.createEditor_ = function() {
   this.foreignObject_ = Blockly.utils.createSvgElement(
       'foreignObject',
       {
-        'x': 0,
-        'y': Blockly.WorkspaceCommentSvg.TOP_OFFSET,
+        'x': Blockly.WorkspaceCommentSvg.BORDER_WIDTH,
+        'y': Blockly.WorkspaceCommentSvg.BORDER_WIDTH + Blockly.WorkspaceCommentSvg.TOP_BAR_HEIGHT,
         'class': 'blocklyCommentForeignObject'
       },
       null);
   var body = document.createElementNS(Blockly.HTML_NS, 'body');
   body.setAttribute('xmlns', Blockly.HTML_NS);
-  body.className = 'blocklyMinimalBody';
+  body.className = 'blocklyMinimalBody scratchCommentBody';
   var textarea = document.createElementNS(Blockly.HTML_NS, 'textarea');
-  textarea.className = 'blocklyCommentTextarea';
+  textarea.className = 'scratchCommentTextarea scratchCommentText';
   textarea.setAttribute('dir', this.RTL ? 'RTL' : 'LTR');
   body.appendChild(textarea);
   this.textarea_ = textarea;
+  this.textarea_.style.margin = (Blockly.WorkspaceCommentSvg.TEXTAREA_OFFSET) + 'px';
   this.foreignObject_.appendChild(body);
   // Don't zoom with mousewheel.
   Blockly.bindEventWithChecks_(textarea, 'wheel', this, function(e) {
     e.stopPropagation();
   });
-  Blockly.bindEventWithChecks_(textarea, 'change', this, function(
-      /* eslint-disable no-unused-vars */ e
-      /* eslint-enable no-unused-vars */) {
-    this.setText(textarea.value);
+  Blockly.bindEventWithChecks_(textarea, 'change', this, function(_e) {
+    if (this.text_ != textarea.value) {
+      Blockly.Events.fire(new Blockly.Events.CommentChange(
+          this, this.text_, textarea.value));
+      this.setText(textarea.value);
+    }
   });
+
+  this.labelText_ = this.getLabelText();
+
   return this.foreignObject_;
 };
 
@@ -186,7 +217,7 @@ Blockly.WorkspaceCommentSvg.prototype.addResizeDom_ = function() {
   this.resizeGroup_ = Blockly.utils.createSvgElement(
       'g',
       {
-        'class': this.RTL ? 'blocklyResizeSW' : 'blocklyResizeSE'
+        'class': this.RTL ? 'scratchCommentResizeSW' : 'scratchCommentResizeSE'
       },
       this.svgGroup_);
   var resizeSize = Blockly.WorkspaceCommentSvg.RESIZE_SIZE;
@@ -211,43 +242,107 @@ Blockly.WorkspaceCommentSvg.prototype.addResizeDom_ = function() {
 };
 
 /**
- * Add the delete icon to the DOM
+ * Create the comment top bar and its contents.
  * @private
  */
-Blockly.WorkspaceCommentSvg.prototype.addDeleteDom_ = function() {
-  this.deleteGroup_ = Blockly.utils.createSvgElement(
-      'g',
+Blockly.WorkspaceCommentSvg.prototype.createCommentTopBar_ = function() {
+  this.svgHandleTarget_ = Blockly.utils.createSvgElement('rect',
       {
-        'class': 'blocklyCommentDeleteIcon'
-      },
-      this.svgGroup_);
-  this.deleteIconBorder_ = Blockly.utils.createSvgElement('circle',
+        'class': 'blocklyDraggable scratchCommentTopBar',
+        'x': Blockly.WorkspaceCommentSvg.BORDER_WIDTH,
+        'y': Blockly.WorkspaceCommentSvg.BORDER_WIDTH,
+        'height': Blockly.WorkspaceCommentSvg.TOP_BAR_HEIGHT
+      }, this.svgGroup_);
+
+  this.createTopBarIcons_();
+  this.createTopBarLabel_();
+};
+
+/**
+ * Create the comment top bar label. This is the truncated comment text
+ * that shows when comment is minimized.
+ * @private
+ */
+Blockly.WorkspaceCommentSvg.prototype.createTopBarLabel_ = function() {
+  this.topBarLabel_ = Blockly.utils.createSvgElement('text',
       {
-        'class': 'blocklyDeleteIconShape',
-        'r': '7',
-        'cx': '7.5',
-        'cy': '7.5'
-      },
-      this.deleteGroup_);
-  // x icon.
-  Blockly.utils.createSvgElement(
-      'line',
+        'class': 'scratchCommentText',
+        'x': this.width_ / 2,
+        'y': (Blockly.WorkspaceCommentSvg.TOP_BAR_HEIGHT / 2) + Blockly.WorkspaceCommentSvg.BORDER_WIDTH,
+        'text-anchor': 'middle',
+        'dominant-baseline': 'middle'
+      }, this.svgGroup_);
+
+  this.labelTextNode_ = document.createTextNode(this.labelText_);
+  this.topBarLabel_.appendChild(this.labelTextNode_);
+};
+
+/**
+ * Create the minimize toggle and delete icons that in the comment top bar.
+ * @private
+ */
+Blockly.WorkspaceCommentSvg.prototype.createTopBarIcons_ = function() {
+  var topBarMiddleY = (Blockly.WorkspaceCommentSvg.TOP_BAR_HEIGHT / 2) +
+      Blockly.WorkspaceCommentSvg.BORDER_WIDTH;
+
+  // Minimize Toggle Icon in Comment Top Bar
+  var xInset = Blockly.WorkspaceCommentSvg.TOP_BAR_ICON_INSET;
+  this.minimizeArrow_ = Blockly.utils.createSvgElement('image',
       {
-        'x1': '5', 'y1': '10',
-        'x2': '10', 'y2': '5',
-        'stroke': '#fff',
-        'stroke-width': '2'
-      },
-      this.deleteGroup_);
-  Blockly.utils.createSvgElement(
-      'line',
+        'x': xInset,
+        'y': topBarMiddleY - Blockly.WorkspaceCommentSvg.MINIMIZE_ICON_SIZE / 2,
+        'width': Blockly.WorkspaceCommentSvg.MINIMIZE_ICON_SIZE,
+        'height': Blockly.WorkspaceCommentSvg.MINIMIZE_ICON_SIZE
+      }, this.svgGroup_);
+
+  // Delete Icon in Comment Top Bar
+  this.deleteIcon_ = Blockly.utils.createSvgElement('image',
       {
-        'x1': '5', 'y1': '5',
-        'x2': '10', 'y2': '10',
-        'stroke': '#fff',
-        'stroke-width': '2'
-      },
-      this.deleteGroup_);
+        'x': xInset,
+        'y': topBarMiddleY - Blockly.WorkspaceCommentSvg.DELETE_ICON_SIZE / 2,
+        'width': Blockly.WorkspaceCommentSvg.DELETE_ICON_SIZE,
+        'height': Blockly.WorkspaceCommentSvg.DELETE_ICON_SIZE
+      }, this.svgGroup_);
+  this.deleteIcon_.setAttributeNS('http://www.w3.org/1999/xlink',
+      'xlink:href', Blockly.mainWorkspace.options.pathToMedia + 'delete-x.svg');
+};
+
+/**
+ * Handle a mouse-down on bubble's minimize icon.
+ * @param {!Event} e Mouse up event.
+ * @private
+ */
+Blockly.WorkspaceCommentSvg.prototype.minimizeArrowMouseDown_ = function(e) {
+  e.stopPropagation();
+};
+
+/**
+ * Handle a mouse-up on bubble's minimize icon.
+ * @param {!Event} e Mouse up event.
+ * @private
+ */
+Blockly.WorkspaceCommentSvg.prototype.minimizeArrowMouseUp_ = function(e) {
+  this.toggleMinimize_();
+  e.stopPropagation();
+};
+
+/**
+ * Handle a mouse-down on bubble's minimize icon.
+ * @param {!Event} e Mouse up event.
+ * @private
+ */
+Blockly.WorkspaceCommentSvg.prototype.deleteMouseDown_ = function(e) {
+  e.stopPropagation();
+};
+
+/**
+ * Handle a mouse-up on bubble's delete icon.
+ * @param {!Event} e Mouse up event.
+ * @private
+ */
+Blockly.WorkspaceCommentSvg.prototype.deleteMouseUp_ = function(e) {
+  this.dispose();
+  e.stopPropagation();
 };
 
 /**
@@ -276,40 +371,46 @@ Blockly.WorkspaceCommentSvg.prototype.resizeMouseDown_ = function(e) {
   e.stopPropagation();
 };
 
-/**
- * Handle a mouse-down on comment's delete icon.
- * @param {!Event} e Mouse down event.
- * @private
- */
-Blockly.WorkspaceCommentSvg.prototype.deleteMouseDown_ = function(e) {
-  // highlight the delete icon
-  Blockly.utils.addClass(
-      /** @type {!Element} */ (this.deleteIconBorder_), 'blocklyDeleteIconHighlighted');
-  // This event has been handled.  No need to bubble up to the document.
-  e.stopPropagation();
-};
 
 /**
- * Handle a mouse-out on comment's delete icon.
- * @param {!Event} e Mouse out event.
+ * Set the minimized state of the bubble.
+ * @param {boolean} minimize Whether the bubble should be minimized
+ * @param {?string} labelText Optional label text for the comment top bar
+ *    when it is minimized.
  * @private
  */
-Blockly.WorkspaceCommentSvg.prototype.deleteMouseOut_ = function(/*e*/) {
-  // restore highlight on the delete icon
-  Blockly.utils.removeClass(
-      /** @type {!Element} */ (this.deleteIconBorder_), 'blocklyDeleteIconHighlighted');
-};
-
-/**
- * Handle a mouse-up on comment's delete icon.
- * @param {!Event} e Mouse up event.
- * @private
- */
-Blockly.WorkspaceCommentSvg.prototype.deleteMouseUp_ = function(e) {
-  // Delete this comment
-  this.dispose(true, true);
-  // This event has been handled.  No need to bubble up to the document.
-  e.stopPropagation();
+Blockly.WorkspaceCommentSvg.prototype.setRenderedMinimizeState_ = function(minimize, labelText) {
+  if (minimize) {
+    // Change minimize icon
+    this.minimizeArrow_.setAttributeNS('http://www.w3.org/1999/xlink',
+        'xlink:href', Blockly.mainWorkspace.options.pathToMedia + 'comment-arrow-up.svg');
+    // Hide text area
+    this.commentEditor_.setAttribute('display', 'none');
+    // Hide resize handle if it exists
+    if (this.resizeGroup_) {
+      this.resizeGroup_.setAttribute('display', 'none');
+    }
+    if (labelText && this.labelText_ != labelText) {
+      // Update label and display
+      // TODO is there a better way to do this?
+      this.topBarLabel_.removeChild(this.labelTextNode_);
+      this.labelTextNode_ = document.createTextNode(labelText);
+      this.topBarLabel_.appendChild(this.labelTextNode_);
+    }
+    Blockly.utils.removeAttribute(this.topBarLabel_, 'display');
+  } else {
+    // Change minimize icon
+    this.minimizeArrow_.setAttributeNS('http://www.w3.org/1999/xlink',
+        'xlink:href', Blockly.mainWorkspace.options.pathToMedia + 'comment-arrow-down.svg');
+    // Hide label
+    this.topBarLabel_.setAttribute('display', 'none');
+    // Show text area
+    Blockly.utils.removeAttribute(this.commentEditor_, 'display');
+    // Display resize handle if it exists
+    if (this.resizeGroup_) {
+      Blockly.utils.removeAttribute(this.resizeGroup_, 'display');
+    }
+  }
 };
 
 /**
@@ -377,22 +478,22 @@ Blockly.WorkspaceCommentSvg.prototype.resizeMouseMove_ = function(e) {
  * @private
  */
 Blockly.WorkspaceCommentSvg.prototype.resizeComment_ = function() {
-  var size = this.getHeightWidth();
-  var topOffset = Blockly.WorkspaceCommentSvg.TOP_OFFSET;
+  var doubleBorderWidth = 2 * Blockly.WorkspaceCommentSvg.BORDER_WIDTH;
+  var topOffset = Blockly.WorkspaceCommentSvg.TOP_BAR_HEIGHT;
   var textOffset = Blockly.WorkspaceCommentSvg.TEXTAREA_OFFSET * 2;
 
   this.foreignObject_.setAttribute('width',
-      size.width);
+      this.width_ - doubleBorderWidth);
   this.foreignObject_.setAttribute('height',
-      size.height - topOffset);
+      this.height_ - doubleBorderWidth - topOffset);
   if (this.RTL) {
     this.foreignObject_.setAttribute('x',
-        -size.width);
+        -this.width_);
   }
   this.textarea_.style.width =
-      (size.width - textOffset) + 'px';
+      (this.width_ - textOffset) + 'px';
   this.textarea_.style.height =
-      (size.height - textOffset - topOffset) + 'px';
+      (this.height_ - doubleBorderWidth - textOffset - topOffset) + 'px';
 };
 
 /**
@@ -404,23 +505,40 @@ Blockly.WorkspaceCommentSvg.prototype.resizeComment_ = function() {
 Blockly.WorkspaceCommentSvg.prototype.setSize = function(width, height) {
   var oldWidth = this.width_;
   var oldHeight = this.height_;
-  // Minimum size of a comment.
-  width = Math.max(width, 45);
-  height = Math.max(height, 20 + Blockly.WorkspaceCommentSvg.TOP_OFFSET);
-  this.width_ = width;
-  this.height_ = height;
-  Blockly.Events.fire(new Blockly.Events.CommentChange(this,
-      {width: oldWidth, height: oldHeight},
-      {width: this.width_, height: this.height_}));
-  this.svgRect_.setAttribute('width', width);
-  this.svgRect_.setAttribute('height', height);
+
+  var doubleBorderWidth = 2 * Blockly.WorkspaceCommentSvg.BORDER_WIDTH;
+
+  if (this.isMinimized_) {
+    width = Blockly.WorkspaceCommentSvg.MINIMIZE_WIDTH;
+    height = Blockly.WorkspaceCommentSvg.TOP_BAR_HEIGHT;
+  } else {
+    // Minimum size of a 'full size' (not minimized) comment.
+    width = Math.max(width, doubleBorderWidth + 50);
+    height = Math.max(height, doubleBorderWidth + 20 + Blockly.WorkspaceCommentSvg.TOP_BAR_HEIGHT);
+
+    // Note we are only updating this.width_ or this.height_ here
+    // and not in the case above, because when we're minimizing a comment,
+    // we want to keep track of the width/height of the maximized comment
+    this.width_ = width;
+    this.height_ = height;
+    Blockly.Events.fire(new Blockly.Events.CommentChange(this,
+        {width: oldWidth, height: oldHeight},
+        {width: this.width_, height: this.height_}));
+  }
+
   this.svgRectTarget_.setAttribute('width', width);
   this.svgRectTarget_.setAttribute('height', height);
-  this.svgHandleTarget_.setAttribute('width', width);
-  this.svgHandleTarget_.setAttribute('height', Blockly.WorkspaceCommentSvg.TOP_OFFSET);
+  this.svgHandleTarget_.setAttribute('width', width - doubleBorderWidth);
+  this.svgHandleTarget_.setAttribute('height', Blockly.WorkspaceCommentSvg.TOP_BAR_HEIGHT);
   if (this.RTL) {
-    this.svgRect_.setAttribute('transform', 'scale(-1 1)');
+    this.minimizeArrow_.setAttribute('x', width -
+        (Blockly.WorkspaceCommentSvg.MINIMIZE_ICON_SIZE) -
+        Blockly.WorkspaceCommentSvg.TOP_BAR_ICON_INSET);
     this.svgRectTarget_.setAttribute('transform', 'scale(-1 1)');
+  } else {
+    this.deleteIcon_.setAttribute('x', width -
+        Blockly.WorkspaceCommentSvg.DELETE_ICON_SIZE -
+        Blockly.WorkspaceCommentSvg.TOP_BAR_ICON_INSET);
   }
 
   var resizeSize = Blockly.WorkspaceCommentSvg.RESIZE_SIZE;
@@ -429,20 +547,53 @@ Blockly.WorkspaceCommentSvg.prototype.setSize = function(width, height) {
       // Mirror the resize group.
       this.resizeGroup_.setAttribute('transform', 'translate(' +
         (-width + resizeSize) + ',' + (height - resizeSize) + ') scale(-1 1)');
-      this.deleteGroup_.setAttribute('transform', 'translate(' +
-        (-width + resizeSize) + ',' + (-resizeSize) + ') scale(-1 1)');
     } else {
       this.resizeGroup_.setAttribute('transform', 'translate(' +
-        (width - resizeSize) + ',' +
-        (height - resizeSize) + ')');
-      this.deleteGroup_.setAttribute('transform', 'translate(' +
-        (width - resizeSize) + ',' +
-        (-resizeSize) + ')');
+        (width - doubleBorderWidth - resizeSize) + ',' +
+        (height -  doubleBorderWidth - resizeSize) + ')');
     }
+  }
+
+  if (this.isMinimized_) {
+    this.topBarLabel_.setAttribute('x', width / 2);
+    this.topBarLabel_.setAttribute('y', height / 2);
   }
 
   // Allow the contents to resize.
   this.resizeComment_();
+};
+
+/**
+ * Toggle the minimization state of this comment.
+ * @private
+ */
+Blockly.WorkspaceComment.prototype.toggleMinimize_ = function() {
+  this.setMinimized(!this.isMinimized_);
+};
+
+/**
+ * Set the minimized state for this comment.
+ * @param {boolean} minimize Whether the comment should be minimized
+ * @package
+ */
+Blockly.WorkspaceComment.prototype.setMinimized = function(minimize) {
+  if (this.isMinimized_ == minimize) return;
+  Blockly.Events.fire(new Blockly.Events.CommentChange(this,
+      {minimized: this.isMinimized_}, {minimized: minimize}));
+  this.isMinimized_ = minimize;
+  if (minimize) {
+    if (this.rendered_) {
+      this.setRenderedMinimizeState_(true, this.getLabelText());
+    }
+    this.setSize(Blockly.WorkspaceCommentSvg.MINIMIZE_WIDTH,
+        Blockly.WorkspaceCommentSvg.TOP_BAR_HEIGHT);
+  } else {
+    if (this.rendered_) {
+      this.setRenderedMinimizeState_(false);
+    }
+    this.setText(this.content_);
+    this.setSize(this.width_, this.height_);
+  }
 };
 
 /**

--- a/core/workspace_comment_render_svg.js
+++ b/core/workspace_comment_render_svg.js
@@ -151,9 +151,13 @@ Blockly.WorkspaceCommentSvg.prototype.render = function() {
   Blockly.bindEventWithChecks_(
       this.minimizeArrow_, 'mousedown', this, this.minimizeArrowMouseDown_);
   Blockly.bindEventWithChecks_(
+      this.minimizeArrow_, 'mouseout', this, this.minimizeArrowMouseOut_);
+  Blockly.bindEventWithChecks_(
       this.minimizeArrow_, 'mouseup', this, this.minimizeArrowMouseUp_);
   Blockly.bindEventWithChecks_(
       this.deleteIcon_, 'mousedown', this, this.deleteMouseDown_);
+  Blockly.bindEventWithChecks_(
+      this.deleteIcon_, 'mouseout', this, this.deleteMouseOut_);
   Blockly.bindEventWithChecks_(
       this.deleteIcon_, 'mouseup', this, this.deleteMouseUp_);
 };
@@ -306,11 +310,26 @@ Blockly.WorkspaceCommentSvg.prototype.createTopBarIcons_ = function() {
 
 /**
  * Handle a mouse-down on bubble's minimize icon.
- * @param {!Event} e Mouse up event.
+ * @param {!Event} e Mouse down event.
  * @private
  */
 Blockly.WorkspaceCommentSvg.prototype.minimizeArrowMouseDown_ = function(e) {
+  // Set a property to indicate that this minimize arrow icon had a mouse down
+  // event. This property will get reset if the mouse leaves the icon, or when
+  // a mouse up event occurs on this icon.
+  this.shouldToggleMinimize_ = true;
   e.stopPropagation();
+};
+
+/**
+ * Handle a mouse-out on bubble's minimize icon.
+ * @param {!Event} _e Mouse out event.
+ * @private
+ */
+Blockly.WorkspaceCommentSvg.prototype.minimizeArrowMouseOut_ = function(_e) {
+  // If the mouse leaves the minimize arrow icon, make sure the
+  // shouldToggleMinimize_ property gets reset.
+  this.shouldToggleMinimize_ = false;
 };
 
 /**
@@ -319,17 +338,36 @@ Blockly.WorkspaceCommentSvg.prototype.minimizeArrowMouseDown_ = function(e) {
  * @private
  */
 Blockly.WorkspaceCommentSvg.prototype.minimizeArrowMouseUp_ = function(e) {
-  this.toggleMinimize_();
+  // First check if this is the icon that had a mouse down event on it and that
+  // the mouse never left the icon.
+  if (this.shouldToggleMinimize_) {
+    this.shouldToggleMinimize = false;
+    this.toggleMinimize_();
+  }
   e.stopPropagation();
 };
 
 /**
  * Handle a mouse-down on bubble's minimize icon.
- * @param {!Event} e Mouse up event.
+ * @param {!Event} e Mouse down event.
  * @private
  */
 Blockly.WorkspaceCommentSvg.prototype.deleteMouseDown_ = function(e) {
+  // Set a property to indicate that this delete icon had a mouse down event.
+  // This property will get reset if the mouse leaves the icon, or when
+  // a mouse up event occurs on this icon.
+  this.shouldDelete_ = true;
   e.stopPropagation();
+};
+
+/**
+ * Handle a mouse-out on bubble's minimize icon.
+ * @param {!Event} _e Mouse out event.
+ * @private
+ */
+Blockly.WorkspaceCommentSvg.prototype.deleteMouseOut_ = function(_e) {
+  // If the mouse leaves the delete icon, reset the shouldDelete_ property.
+  this.shouldDelete_ = false;
 };
 
 /**
@@ -338,7 +376,11 @@ Blockly.WorkspaceCommentSvg.prototype.deleteMouseDown_ = function(e) {
  * @private
  */
 Blockly.WorkspaceCommentSvg.prototype.deleteMouseUp_ = function(e) {
-  this.dispose();
+  // First check that this same icon had a mouse down event on it and that the
+  // mouse never left the icon.
+  if (this.shouldDelete_) {
+    this.dispose();
+  }
   e.stopPropagation();
 };
 

--- a/core/workspace_comment_render_svg.js
+++ b/core/workspace_comment_render_svg.js
@@ -28,6 +28,13 @@ goog.provide('Blockly.WorkspaceCommentSvg.render');
 
 goog.require('Blockly.WorkspaceCommentSvg');
 
+/**
+ * Radius of the border around the comment.
+ * @type {number}
+ * @const
+ * @private
+ */
+Blockly.WorkspaceCommentSvg.BORDER_WIDTH = 1;
 
 /**
  * Size of the resize icon.
@@ -36,14 +43,6 @@ goog.require('Blockly.WorkspaceCommentSvg');
  * @private
  */
 Blockly.WorkspaceCommentSvg.RESIZE_SIZE = 12 * Blockly.WorkspaceCommentSvg.BORDER_WIDTH;
-
-/**
- * Radius of the border around the comment.
- * @type {number}
- * @const
- * @private
- */
-Blockly.WorkspaceCommentSvg.BORDER_WIDTH = 1;
 
 /**
  * Offset from the foreignobject edge to the textarea edge.
@@ -198,8 +197,6 @@ Blockly.WorkspaceCommentSvg.prototype.createEditor_ = function() {
   });
   Blockly.bindEventWithChecks_(textarea, 'change', this, function(_e) {
     if (this.text_ != textarea.value) {
-      Blockly.Events.fire(new Blockly.Events.CommentChange(
-          this, this.text_, textarea.value));
       this.setText(textarea.value);
     }
   });

--- a/core/workspace_comment_render_svg.js
+++ b/core/workspace_comment_render_svg.js
@@ -105,19 +105,19 @@ Blockly.WorkspaceCommentSvg.prototype.render = function() {
 
   // Add text area
   this.commentEditor_ = this.createEditor_();
+  this.svgGroup_.appendChild(this.commentEditor_);
+
+  this.createCommentTopBar_();
+
   this.svgRectTarget_ = Blockly.utils.createSvgElement('rect',
       {
-        'class': 'blocklyDraggable blocklyCommentTarget scratchCommentRect',
+        'class': 'blocklyDraggable scratchCommentTarget',
         'x': 0,
         'y': 0,
         'rx': 4 * Blockly.WorkspaceCommentSvg.BORDER_WIDTH,
         'ry': 4 * Blockly.WorkspaceCommentSvg.BORDER_WIDTH
       });
   this.svgGroup_.appendChild(this.svgRectTarget_);
-
-  this.createCommentTopBar_();
-
-  this.svgGroup_.appendChild(this.commentEditor_);
 
   // Add the resize icon
   this.addResizeDom_();
@@ -522,7 +522,8 @@ Blockly.WorkspaceCommentSvg.prototype.setSize = function(width, height) {
         {width: oldWidth, height: oldHeight},
         {width: this.width_, height: this.height_}));
   }
-
+  this.svgRect_.setAttribute('width', width);
+  this.svgRect_.setAttribute('height', height);
   this.svgRectTarget_.setAttribute('width', width);
   this.svgRectTarget_.setAttribute('height', height);
   this.svgHandleTarget_.setAttribute('width', width - doubleBorderWidth);
@@ -531,7 +532,7 @@ Blockly.WorkspaceCommentSvg.prototype.setSize = function(width, height) {
     this.minimizeArrow_.setAttribute('x', width -
         (Blockly.WorkspaceCommentSvg.MINIMIZE_ICON_SIZE) -
         Blockly.WorkspaceCommentSvg.TOP_BAR_ICON_INSET);
-    this.svgRectTarget_.setAttribute('transform', 'scale(-1 1)');
+    this.svgRect_.setAttribute('transform', 'scale(-1 1)');
   } else {
     this.deleteIcon_.setAttribute('x', width -
         Blockly.WorkspaceCommentSvg.DELETE_ICON_SIZE -
@@ -600,6 +601,7 @@ Blockly.WorkspaceComment.prototype.setMinimized = function(minimize) {
 Blockly.WorkspaceCommentSvg.prototype.disposeInternal_ = function() {
   this.textarea_ = null;
   this.foreignObject_ = null;
+  this.svgRect_ = null;
   this.svgRectTarget_ = null;
   this.svgHandleTarget_ = null;
 };
@@ -616,9 +618,9 @@ Blockly.WorkspaceCommentSvg.prototype.setFocus = function() {
     comment.textarea_.focus();
     comment.addFocus();
     Blockly.utils.addClass(
-        comment.svgRectTarget_, 'blocklyCommentTargetFocused');
+        comment.svgRectTarget_, 'scratchCommentTargetFocused');
     Blockly.utils.addClass(
-        comment.svgHandleTarget_, 'blocklyCommentHandleTargetFocused');
+        comment.svgHandleTarget_, 'scratchCommentHandleTargetFocused');
   }, 0);
 };
 
@@ -636,8 +638,8 @@ Blockly.WorkspaceCommentSvg.prototype.blurFocus = function() {
     comment.textarea_.blur();
     comment.removeFocus();
     Blockly.utils.removeClass(
-        comment.svgRectTarget_, 'blocklyCommentTargetFocused');
+        comment.svgRectTarget_, 'scratchCommentTargetFocused');
     Blockly.utils.removeClass(
-        comment.svgHandleTarget_, 'blocklyCommentHandleTargetFocused');
+        comment.svgHandleTarget_, 'scratchCommentHandleTargetFocused');
   }, 0);
 };

--- a/core/workspace_comment_render_svg.js
+++ b/core/workspace_comment_render_svg.js
@@ -270,8 +270,8 @@ Blockly.WorkspaceCommentSvg.prototype.createTopBarLabel_ = function() {
         'dominant-baseline': 'middle'
       }, this.svgGroup_);
 
-  this.labelTextNode_ = document.createTextNode(this.labelText_);
-  this.topBarLabel_.appendChild(this.labelTextNode_);
+  var labelTextNode = document.createTextNode(this.labelText_);
+  this.topBarLabel_.appendChild(labelTextNode);
 };
 
 /**
@@ -394,9 +394,7 @@ Blockly.WorkspaceCommentSvg.prototype.setRenderedMinimizeState_ = function(minim
     if (labelText && this.labelText_ != labelText) {
       // Update label and display
       // TODO is there a better way to do this?
-      this.topBarLabel_.removeChild(this.labelTextNode_);
-      this.labelTextNode_ = document.createTextNode(labelText);
-      this.topBarLabel_.appendChild(this.labelTextNode_);
+      this.topBarLabel_.textContent = labelText;
     }
     Blockly.utils.removeAttribute(this.topBarLabel_, 'display');
   } else {

--- a/core/workspace_comment_render_svg.js
+++ b/core/workspace_comment_render_svg.js
@@ -580,7 +580,9 @@ Blockly.WorkspaceComment.prototype.toggleMinimize_ = function() {
  * @package
  */
 Blockly.WorkspaceComment.prototype.setMinimized = function(minimize) {
-  if (this.isMinimized_ == minimize) return;
+  if (this.isMinimized_ == minimize) {
+    return;
+  }
   Blockly.Events.fire(new Blockly.Events.CommentChange(this,
       {minimized: this.isMinimized_}, {minimized: minimize}));
   this.isMinimized_ = minimize;

--- a/core/workspace_comment_render_svg.js
+++ b/core/workspace_comment_render_svg.js
@@ -370,7 +370,11 @@ Blockly.WorkspaceCommentSvg.prototype.resizeMouseDown_ = function(e) {
 
 
 /**
- * Set the minimized state of the bubble.
+ * Set the apperance of the workspace comment bubble to the minimized or full size
+ * appearance. In the minimized state, the comment should only have the top bar
+ * displayed, with the minimize icon swapped to the minimized state, and
+ * truncated comment text is shown in the middle of the top bar. There should be
+ * no resize handle when the workspace comment is in its minimized state.
  * @param {boolean} minimize Whether the bubble should be minimized
  * @param {?string} labelText Optional label text for the comment top bar
  *    when it is minimized.
@@ -570,7 +574,8 @@ Blockly.WorkspaceComment.prototype.toggleMinimize_ = function() {
 };
 
 /**
- * Set the minimized state for this comment.
+ * Set the minimized state for this comment. If the comment is rendered,
+ * change the appearance of the comment accordingly.
  * @param {boolean} minimize Whether the comment should be minimized
  * @package
  */

--- a/core/workspace_comment_svg.js
+++ b/core/workspace_comment_svg.js
@@ -51,19 +51,9 @@ Blockly.WorkspaceCommentSvg = function(workspace, content, height, width,
    * @private
    */
   this.svgGroup_ = Blockly.utils.createSvgElement(
-      'g', {'class': 'blocklyComment'}, null);
+      'g', {}, null);
   this.svgGroup_.translate_ = '';
 
-  this.svgRect_ = Blockly.utils.createSvgElement(
-      'rect',
-      {
-        'class': 'blocklyCommentRect',
-        'x': 0,
-        'y': 0,
-        'rx': Blockly.WorkspaceCommentSvg.BORDER_RADIUS,
-        'ry': Blockly.WorkspaceCommentSvg.BORDER_RADIUS
-      });
-  this.svgGroup_.appendChild(this.svgRect_);
 
   /**
    * Whether the comment is rendered onscreen and is a part of the DOM.
@@ -543,7 +533,7 @@ Blockly.WorkspaceCommentSvg.fromXml = function(xmlComment, workspace,
     var info = Blockly.WorkspaceComment.parseAttributes(xmlComment);
 
     var comment = new Blockly.WorkspaceCommentSvg(workspace,
-        info.content, info.h, info.w, info.id);
+        info.content, info.h, info.w, info.minimized, info.id);
     if (workspace.rendered) {
       comment.initSvg();
       comment.render(false);

--- a/core/workspace_comment_svg.js
+++ b/core/workspace_comment_svg.js
@@ -93,7 +93,7 @@ Blockly.WorkspaceCommentSvg = function(workspace, content, height, width,
  * @type {number}
  * @package
  */
-Blockly.WorkspaceCommentSvg.DEFAULT_SIZE = 100;
+Blockly.WorkspaceCommentSvg.DEFAULT_SIZE = 200;
 
 /**
  * Dispose of this comment.

--- a/core/workspace_comment_svg.js
+++ b/core/workspace_comment_svg.js
@@ -38,12 +38,13 @@ goog.require('Blockly.WorkspaceComment');
  * @param {string} content The content of this workspace comment.
  * @param {number} height Height of the comment.
  * @param {number} width Width of the comment.
+ * @param {boolean} minimized Whether this comment is minimized.
  * @param {string=} opt_id Optional ID.  Use this ID if provided, otherwise
  *     create a new ID.
  * @extends {Blockly.WorkspaceComment}
  * @constructor
  */
-Blockly.WorkspaceCommentSvg = function(workspace, content, height, width,
+Blockly.WorkspaceCommentSvg = function(workspace, content, height, width, minimized,
     opt_id) {
   // Create core elements for the block.
   /**
@@ -72,7 +73,7 @@ Blockly.WorkspaceCommentSvg = function(workspace, content, height, width,
       Blockly.utils.is3dSupported() && !!workspace.blockDragSurface_;
 
   Blockly.WorkspaceCommentSvg.superClass_.constructor.call(this,
-      workspace, content, height, width, opt_id);
+      workspace, content, height, width, minimized, opt_id);
 
   this.render();
 }; goog.inherits(Blockly.WorkspaceCommentSvg, Blockly.WorkspaceComment);

--- a/core/workspace_comment_svg.js
+++ b/core/workspace_comment_svg.js
@@ -55,6 +55,17 @@ Blockly.WorkspaceCommentSvg = function(workspace, content, height, width, minimi
       'g', {}, null);
   this.svgGroup_.translate_ = '';
 
+  this.svgRect_ = Blockly.utils.createSvgElement(
+      'rect',
+      {
+        'class': 'scratchCommentRect scratchWorkspaceCommentBorder',
+        'x': 0,
+        'y': 0,
+        'rx': 4 * Blockly.WorkspaceCommentSvg.BORDER_WIDTH,
+        'ry': 4 * Blockly.WorkspaceCommentSvg.BORDER_WIDTH
+      });
+  this.svgGroup_.appendChild(this.svgRect_);
+
 
   /**
    * Whether the comment is rendered onscreen and is a part of the DOM.

--- a/tests/jsunit/workspace_comment_test.js
+++ b/tests/jsunit/workspace_comment_test.js
@@ -171,7 +171,7 @@ function test_workspaceCommentMinimizedFromXml() {
   workspaceCommentTest_setUp();
   try {
     var comment = new Blockly.WorkspaceComment(workspace, 'comment text', 0, 0, true, 'comment id');
-    var commentXml = workspace.toXml();
+    var commentXml = comment.toXml();
     var xml = goog.dom.createDom('xml');
     xml.appendChild(commentXml);
     comment.dispose();

--- a/tests/jsunit/workspace_comment_test.js
+++ b/tests/jsunit/workspace_comment_test.js
@@ -47,7 +47,7 @@ function test_noWorkspaceComments() {
 function test_oneWorkspaceComment() {
   workspaceCommentTest_setUp();
   try {
-    var comment = new Blockly.WorkspaceComment(workspace, 'comment text', 0, 0, 'comment id');
+    var comment = new Blockly.WorkspaceComment(workspace, 'comment text', 0, 0, false, 'comment id');
     assertEquals('One comment on workspace (1).', 1, workspace.getTopComments(true).length);
     assertEquals('One comment on workspace  (2).', 1, workspace.getTopComments(false).length);
     assertEquals('Comment db contains this comment.', comment, workspace.commentDB_['comment id']);
@@ -63,7 +63,7 @@ function test_oneWorkspaceComment() {
 function test_getWorkspaceCommentById() {
   workspaceCommentTest_setUp();
   try {
-    var comment = new Blockly.WorkspaceComment(workspace, 'comment text', 0, 0, 'comment id');
+    var comment = new Blockly.WorkspaceComment(workspace, 'comment text', 0, 0, false, 'comment id');
     assertEquals('Getting a comment by id.', comment, workspace.getCommentById('comment id'));
     assertEquals('No comment found.', null, workspace.getCommentById('not a comment'));
     comment.dispose();
@@ -76,7 +76,7 @@ function test_getWorkspaceCommentById() {
 function test_disposeWsCommentTwice() {
   workspaceCommentTest_setUp();
   try {
-    var comment = new Blockly.WorkspaceComment(workspace, 'comment text', 0, 0, 'comment id');
+    var comment = new Blockly.WorkspaceComment(workspace, 'comment text', 0, 0, false, 'comment id');
     comment.dispose();
     // Nothing should go wrong the second time dispose is called.
     comment.dispose();
@@ -89,7 +89,7 @@ function test_wsCommentHeightWidth() {
   workspaceCommentTest_setUp();
   try {
     var comment =
-        new Blockly.WorkspaceComment(workspace, 'comment text', 10, 20, 'comment id');
+        new Blockly.WorkspaceComment(workspace, 'comment text', 10, 20, false, 'comment id');
     assertEquals('Initial width', 20, comment.getWidth());
     assertEquals('Initial height', 10, comment.getHeight());
 
@@ -110,7 +110,7 @@ function test_wsCommentXY() {
   workspaceCommentTest_setUp();
   try {
     var comment =
-        new Blockly.WorkspaceComment(workspace, 'comment text', 10, 20, 'comment id');
+        new Blockly.WorkspaceComment(workspace, 'comment text', 10, 20, false, 'comment id');
     var xy = comment.getXY();
     assertEquals('Initial X position', 0, xy.x);
     assertEquals('Initial Y position', 0, xy.y);
@@ -132,7 +132,7 @@ function test_wsCommentText() {
   temporary_fireEvent.firedEvents_ = [];
   try {
     var comment =
-        new Blockly.WorkspaceComment(workspace, 'comment text', 10, 20, 'comment id');
+        new Blockly.WorkspaceComment(workspace, 'comment text', 10, 20, false, 'comment id');
     assertEquals(
         'Check comment text', 'comment text', comment.getText());
     assertEquals(
@@ -154,5 +154,33 @@ function test_wsCommentText() {
   } finally {
     workspaceCommentTest_tearDown();
     Blockly.Events.fire = savedFireFunc;
+  }
+}
+
+function test_workspaceCommentMinimized() {
+  workspaceCommentTest_setUp();
+  try {
+    var comment = new Blockly.WorkspaceComment(workspace, 'comment text', 0, 0, true, 'comment id');
+    assertEquals('Comment is minimized', true, comment.isMinimized());
+  } finally {
+    workspaceCommentTest_tearDown();
+  }
+}
+
+function test_workspaceCommentMinimizedFromXml() {
+  workspaceCommentTest_setUp();
+  try {
+    var comment = new Blockly.WorkspaceComment(workspace, 'comment text', 0, 0, true, 'comment id');
+    var commentXml = workspace.toXml();
+    var xml = goog.dom.createDom('xml');
+    xml.appendChild(commentXml);
+    comment.dispose();
+    assertEquals('Comment is no longer on workspace', null, workspace.getCommentById('comment id'));
+    Blockly.Xml.domToWorkspace(xml, workspace);
+    var importedComment = workspace.getCommentById('comment id');
+    assertNotEquals('Comment loaded from xml is on workspace', null, importedComment)
+    assertEquals('Imported comment is minimized', true, importedComment.isMinimized());
+  } finally {
+    workspaceCommentTest_tearDown();
   }
 }


### PR DESCRIPTION
### Resolves

`Workspace comments need to be updated to look/work like block comments` section of #1554 

### Proposed Changes

Workspace comments now look and work like block comments with respect to sizing, text size/font, minimize/delete icons and functionality.

Screenshots of the new workspace comments:

![image](https://user-images.githubusercontent.com/1786240/41294279-a84d5cbc-6e25-11e8-8a80-04c6a6fc2739.png)

![image](https://user-images.githubusercontent.com/1786240/41294304-b7099f2c-6e25-11e8-9105-e5226c1df600.png)

### Reason for Changes

More comments work! Compatibility w/2.0 functionality.

### Test Coverage

Tested in the vertical playground and in the scratch-gui. Added unit tests for minimize functionality.