### PR TITLE
Fix XML Serialization for Block Comments

### DIFF
--- a/core/xml.js
+++ b/core/xml.js
@@ -46,7 +46,9 @@ goog.require('goog.dom');
 Blockly.Xml.workspaceToDom = function(workspace, opt_noId) {
   var xml = goog.dom.createDom('xml');
   xml.appendChild(Blockly.Xml.variablesToDom(workspace.getAllVariables()));
-  var comments = workspace.getTopComments(true);
+  var comments = workspace.getTopComments(true).filter(function(topComment) {
+    return topComment instanceof Blockly.WorkspaceComment;
+  });
   for (var i = 0, comment; comment = comments[i]; i++) {
     xml.appendChild(comment.toXmlWithXY(opt_noId));
   }


### PR DESCRIPTION
### Proposed Changes

Fix xml serialization so that block comments are not duplicately serialized as workspace comments.

### Reason for Changes

Currently, creating a block comment, exporting it as xml, and importing that xml in a fresh page will create two comments in the first place. The original block comment as well as a new workspace comment with the same size/position/text.

This PR fixes that issue so that when serializing a workspace, only workspace comments are serialized as top level comments. Block comments naturally get serialized in the process of serializing the block that they're attached to.
