### PR TITLE
Add extension status button stub

### DIFF
--- a/blocks_vertical/default_toolbox.js
+++ b/blocks_vertical/default_toolbox.js
@@ -524,6 +524,7 @@ Blockly.Blocks.defaultToolbox = '<xml id="toolbox-categories" style="display: no
   '</category>' +
   '<category name="Extensions" id="extensions" colour="#FF6680" secondaryColour="#FF4D6A" '+
     'iconURI="../media/extensions/wedo2-block-icon.svg">'+
+    '<button type="status" extensionId="extensions"></button>'+
     '<block type="extension_pen_down" id="extension_pen_down"></block>'+
     '<block type="extension_music_drum" id="extension_music_drum">'+
       '<value name="NUMBER">'+

--- a/core/blockly.js
+++ b/core/blockly.js
@@ -375,6 +375,15 @@ Blockly.prompt = function(message, defaultValue, callback, _opt_title,
 };
 
 /**
+ * A callback for status buttons. The window.alert is here for testing and
+ * should be overridden.
+ * @param {string} id An identifier.
+ */
+Blockly.statusButtonCallback = function(id) {
+  window.alert('status button was pressed for ' + id);
+};
+
+/**
  * Helper function for defining a block from JSON.  The resulting function has
  * the correct value of jsonDef at the point in code where jsonInit is called.
  * @param {!Object} jsonDef The JSON definition of a block.

--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -536,6 +536,22 @@ Blockly.Flyout.prototype.show = function(xmlList) {
         } else {
           gaps.push(default_gap);
         }
+      } else if ((tagName == 'BUTTON') &&
+        (xml.getAttribute('type') === 'status')) {
+        // Scratch extensions can display a status button
+        var extensionId = xml.getAttribute('extensionId');
+        if (extensionId) {
+          var callbackKey = 'STATUS_PRESSED_' + extensionId.toUpperCase();
+          xml.setAttribute('callbackKey', callbackKey);
+          var callback = function(id) {
+            Blockly.statusButtonCallback(id);
+          }.bind(this, extensionId);
+          this.workspace_.registerButtonCallback(callbackKey, callback);
+          // @todo: make a new image button class to use here
+          var curButton = new Blockly.FlyoutButton(this.workspace_,
+              this.targetWorkspace_, xml, false);
+          contents.push({type: 'button', button: curButton});
+        }
       } else if (tagName == 'BUTTON' || tagName == 'LABEL') {
         // Labels behave the same as buttons, but are styled differently.
         var isLabel = tagName == 'LABEL';

--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -536,16 +536,13 @@ Blockly.Flyout.prototype.show = function(xmlList) {
         } else {
           gaps.push(default_gap);
         }
-      } else if ((tagName == 'BUTTON') &&
-        (xml.getAttribute('type') === 'status')) {
+      } else if ((tagName == 'BUTTON') && (xml.getAttribute('type') == 'status')) {
         // Scratch extensions can display a status button
         var extensionId = xml.getAttribute('extensionId');
         if (extensionId) {
           var callbackKey = 'STATUS_PRESSED_' + extensionId.toUpperCase();
           xml.setAttribute('callbackKey', callbackKey);
-          var callback = function(id) {
-            Blockly.statusButtonCallback(id);
-          }.bind(this, extensionId);
+          var callback = Blockly.statusButtonCallback.bind(this, extensionId);
           this.workspace_.registerButtonCallback(callbackKey, callback);
           // @todo: make a new image button class to use here
           var curButton = new Blockly.FlyoutButton(this.workspace_,


### PR DESCRIPTION
### Proposed Changes

Add a button that scratch extensions can optionally show. This version is not yet styled- it uses the basic flyout button class. In the future I'll make a subclass that can display a status button to spec (a small image button inline with the category label, which can change state to show different images).  

### Reason for Changes

Work in progress on supporting hardware extensions, where the user needs to be able to initiate a bluetooth connection workflow.