### PR TITLE
Workspace scroll bugfix and unit tests!

### DIFF
--- a/core/scratch_block_comment.js
+++ b/core/scratch_block_comment.js
@@ -57,13 +57,18 @@ Blockly.ScratchBlockComment = function(block, text, id, x, y, minimized) {
    * @private
    */
   this.text_ = text;
+
+  var xIsValidNumber = typeof x == 'number' && !isNaN(x);
+  var yIsValidNumber = typeof y == 'number' && !isNaN(y);
+
   /**
    * Whether this comment needs to be auto-positioned (based on provided values
    * for x and y position).
    * @type {boolean}
    * @private
    */
-  this.needsAutoPositioning_ = !x && x != 0 && !y && y != 0;
+  this.needsAutoPositioning_ = !xIsValidNumber && !yIsValidNumber;
+  // If both of the given x and y params are invalid, this comment needs to be auto positioned.
 
   /**
    * The x position of this comment in workspace coordinates. Default to 0 if
@@ -71,14 +76,14 @@ Blockly.ScratchBlockComment = function(block, text, id, x, y, minimized) {
    * @type {number}
    * @private
    */
-  this.x_ = typeof x == 'number' && !isNaN(x) ? x : 0;
+  this.x_ = xIsValidNumber ? x : 0;
   /**
    * The y position of this comment in workspace coordinates. Default to 0 if
    * y position is not provided or is not a valid number.
    * @type {number}
    * @private
    */
-  this.y_ = typeof y == 'number' && !isNaN(y) ? y : 0;
+  this.y_ = yIsValidNumber ? y : 0;
   /**
    * Whether this comment is minimized.
    * @type {boolean}

--- a/core/scratch_block_comment.js
+++ b/core/scratch_block_comment.js
@@ -58,17 +58,27 @@ Blockly.ScratchBlockComment = function(block, text, id, x, y, minimized) {
    */
   this.text_ = text;
   /**
-   * The x position of this comment in workspace coordinates.
-   * @type {number}
+   * Whether this comment needs to be auto-positioned (based on provided values
+   * for x and y position).
+   * @type {boolean}
    * @private
    */
-  this.x_ = x;
+  this.needsAutoPositioning_ = !x && x != 0 && !y && y != 0;
+
   /**
-   * The y position of this comment in workspace coordinates.
+   * The x position of this comment in workspace coordinates. Default to 0 if
+   * x position is not provided or is not a valid number.
    * @type {number}
    * @private
    */
-  this.y_ = y;
+  this.x_ = typeof x == 'number' && !isNaN(x) ? x : 0;
+  /**
+   * The y position of this comment in workspace coordinates. Default to 0 if
+   * y position is not provided or is not a valid number.
+   * @type {number}
+   * @private
+   */
+  this.y_ = typeof y == 'number' && !isNaN(y) ? y : 0;
   /**
    * Whether this comment is minimized.
    * @type {boolean}
@@ -290,7 +300,7 @@ Blockly.ScratchBlockComment.prototype.setVisible = function(visible) {
   if (visible) {
     // Decide on placement of the bubble if x and y coordinates are not provided
     // based on knowledge of the block that owns this comment:
-    if (!this.x_ && this.x_ != 0 && !this.y_ && this.y_ != 0) {
+    if (this.needsAutoPositioning_) {
       if (this.isMinimized_) {
         var minimizedOffset = 4 * Blockly.BlockSvg.GRID_UNIT;
         this.x_ = this.block_.RTL ?
@@ -314,6 +324,8 @@ Blockly.ScratchBlockComment.prototype.setVisible = function(visible) {
         }
         this.y_ = this.iconXY_.y - (Blockly.ScratchBubble.TOP_BAR_HEIGHT / 2);
       }
+      // This comment has been auto-positioned so reset the flag
+      this.needsAutoPositioning_ = false;
     }
 
     // Create the bubble.

--- a/core/scratch_block_comment.js
+++ b/core/scratch_block_comment.js
@@ -277,6 +277,38 @@ Blockly.ScratchBlockComment.prototype.updateColour = function() {
 };
 
 /**
+ * Auto position this comment given information about the block that owns this
+ * comment and the comment state, if this block needs auto positioning.
+ * @private
+ */
+Blockly.ScratchBlockComment.prototype.autoPosition_ = function() {
+  if (!this.needsAutoPositioning_) return;
+  if (this.isMinimized_) {
+    var minimizedOffset = 4 * Blockly.BlockSvg.GRID_UNIT;
+    this.x_ = this.block_.RTL ?
+        this.iconXY_.x - minimizedOffset :
+        this.iconXY_.x + minimizedOffset;
+    this.y_ = this.iconXY_.y - (Blockly.ScratchBubble.TOP_BAR_HEIGHT / 2);
+  } else {
+    // Check if the width of this block (and all it's children/descendents) is the
+    // same as the width of just this block
+    var fullStackWidth = Math.floor(this.block_.getHeightWidth().width);
+    var thisBlockWidth = Math.floor(this.block_.svgPath_.getBBox().width);
+    var offset = 8 * Blockly.BlockSvg.GRID_UNIT;
+    if (fullStackWidth == thisBlockWidth && !this.block_.parentBlock_) {
+      this.x_ = this.block_.RTL ?
+          this.iconXY_.x - this.width_ - offset :
+          this.iconXY_.x + offset;
+    } else {
+      this.x_ = this.block_.RTL ?
+          this.iconXY_.x - this.width_ - fullStackWidth - offset :
+          this.iconXY_.x + fullStackWidth + offset;
+    }
+    this.y_ = this.iconXY_.y - (Blockly.ScratchBubble.TOP_BAR_HEIGHT / 2);
+  }
+};
+
+/**
  * Show or hide the comment bubble.
  * @param {boolean} visible True if the bubble should be visible.
  * @package
@@ -298,32 +330,9 @@ Blockly.ScratchBlockComment.prototype.setVisible = function(visible) {
   var text = this.getText();
   var size = this.getBubbleSize();
   if (visible) {
-    // Decide on placement of the bubble if x and y coordinates are not provided
-    // based on knowledge of the block that owns this comment:
+    // Auto position this comment, if necessary.
     if (this.needsAutoPositioning_) {
-      if (this.isMinimized_) {
-        var minimizedOffset = 4 * Blockly.BlockSvg.GRID_UNIT;
-        this.x_ = this.block_.RTL ?
-            this.iconXY_.x - minimizedOffset :
-            this.iconXY_.x + minimizedOffset;
-        this.y_ = this.iconXY_.y - (Blockly.ScratchBubble.TOP_BAR_HEIGHT / 2);
-      } else {
-        // Check if the width of this block (and all it's children/descendents) is the
-        // same as the width of just this block
-        var fullStackWidth = Math.floor(this.block_.getHeightWidth().width);
-        var thisBlockWidth = Math.floor(this.block_.svgPath_.getBBox().width);
-        var offset = 8 * Blockly.BlockSvg.GRID_UNIT;
-        if (fullStackWidth == thisBlockWidth && !this.block_.parentBlock_) {
-          this.x_ = this.block_.RTL ?
-              this.iconXY_.x - this.width_ - offset :
-              this.iconXY_.x + offset;
-        } else {
-          this.x_ = this.block_.RTL ?
-              this.iconXY_.x - this.width_ - fullStackWidth - offset :
-              this.iconXY_.x + fullStackWidth + offset;
-        }
-        this.y_ = this.iconXY_.y - (Blockly.ScratchBubble.TOP_BAR_HEIGHT / 2);
-      }
+      this.autoPosition_();
       // This comment has been auto-positioned so reset the flag
       this.needsAutoPositioning_ = false;
     }
@@ -490,9 +499,16 @@ Blockly.ScratchBlockComment.prototype.moveTo = function(x, y) {
 Blockly.ScratchBlockComment.prototype.getXY = function() {
   if (this.bubble_) {
     return this.bubble_.getRelativeToSurfaceXY();
-  } else {
-    return new goog.math.Coordinate(this.x_, this.y_);
   }
+  // Auto position this comment if iconXY_ is provided
+  // (auto positioning will only occur if it is necessary).
+  if (this.needsAutoPositioning_ && this.iconXY_) {
+    this.autoPosition_();
+    // Do not reset the needsAutoPositioning flag here. This will be reset
+    // after the comment has been made visible and the re-auto positioned,
+    // because the block may have moved by that point.
+  }
+  return new goog.math.Coordinate(this.x_, this.y_);
 };
 
 /**

--- a/core/xml.js
+++ b/core/xml.js
@@ -690,6 +690,8 @@ Blockly.Xml.domToBlockHeadless_ = function(xmlBlock, workspace) {
         var bubbleY = parseInt(xmlChild.getAttribute('y'), 10);
         var minimized = xmlChild.getAttribute('minimized') || false;
 
+        // Note bubbleX and bubbleY can be NaN, but the ScratchBlockComment
+        // constructor will handle that.
         block.setCommentText(xmlChild.textContent, commentId, bubbleX, bubbleY,
             minimized == 'true');
 

--- a/tests/jsunit/scratch_block_comment_test.js
+++ b/tests/jsunit/scratch_block_comment_test.js
@@ -1,0 +1,177 @@
+/**
+ * @license
+ * Blockly Tests
+ *
+ * Copyright 2017 Google Inc.
+ * https://developers.google.com/blockly/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+goog.require('goog.testing');
+
+var block;
+var workspace;
+var originalCreateIcon = Blockly.ScratchBlockComment.createIcon;
+
+function scratchBlockCommentTest_setUp() {
+  workspace = new Blockly.Workspace();
+  // Mock the resizeContents function on the workspace
+  workspace.resizeContents = function () {};
+
+  var BLOCK_TYPE = 'test_json_minimal';
+
+  Blockly.defineBlocksWithJsonArray([{
+    "type": BLOCK_TYPE
+  }]);
+
+  block = new Blockly.BlockSvg(workspace, BLOCK_TYPE);
+
+  // Mock createIcon function since it is not necessary for these tests
+  Blockly.ScratchBlockComment.prototype.createIcon = function () {};
+}
+
+function scratchBlockCommentTest_tearDown() {
+  workspace.dispose();
+  block.dispose();
+
+  // Restore original createIcon function
+  Blockly.ScratchBlockComment.prototype.createIcon = originalCreateIcon;
+}
+
+function test_blockWithNoBlockComments() {
+  scratchBlockCommentTest_setUp();
+  try {
+    assertEquals('Workspace has a block.', 1, workspace.getTopBlocks(false).length);
+    assertEquals('Workspace does not have a comment.', 0, workspace.getTopComments(false).length);
+    assertEquals('Block does not have a comment', null, block.comment);
+    assertEquals('Block does not have comment text', '', block.getCommentText());
+  } finally {
+    scratchBlockCommentTest_tearDown();
+  }
+}
+
+function test_createBlockCommentMinimalArguments() {
+  scratchBlockCommentTest_setUp();
+  try {
+    var comment = new Blockly.ScratchBlockComment(block, 'Some comment text');
+    assertEquals('Workspace has a block.', 1, workspace.getTopBlocks(false).length);
+    assertEquals('Workspace has a comment.', 1, workspace.getTopComments(false).length);
+    assertEquals('Comment knows about workspace.', workspace, comment.workspace);
+  } finally {
+    scratchBlockCommentTest_tearDown();
+  }
+}
+
+function test_createBlockCommentAllArguments() {
+  scratchBlockCommentTest_setUp();
+  try {
+    var comment = new Blockly.ScratchBlockComment(block, 'Some comment text', 'aMockComment', 10, 20, true);
+    assertEquals('Workspace has a block.', 1, workspace.getTopBlocks(false).length);
+    assertEquals('Workspace has a comment.', 1, workspace.getTopComments(false).length);
+    assertEquals('Comment knows about workspace.', workspace, comment.workspace);
+  } finally {
+    scratchBlockCommentTest_tearDown();
+  }
+}
+
+function test_addCommentToBlock() {
+  scratchBlockCommentTest_setUp();
+  try {
+    block.setCommentText('Some comment text', 'aMockComment');
+    assertEquals('Workspace has a block.', 1, workspace.getTopBlocks(false).length);
+    assertEquals('Workspace has a comment.', 1, workspace.getTopComments(false).length);
+    assertNotEquals('Block has a comment', null, block.comment);
+    assertEquals('Block has comment text', 'Some comment text', block.getCommentText());
+  } finally {
+    scratchBlockCommentTest_tearDown();
+  }
+}
+
+function test_blockCommentXYWhenPositionProvided() {
+  scratchBlockCommentTest_setUp();
+  try {
+    var comment = new Blockly.ScratchBlockComment(block, 'Some comment text', 'aMockComment', 10, 20);
+    var commentXY = comment.getXY();
+    var commentX = commentXY.x;
+    var commentY = commentXY.y;
+    assertEquals('Comment x position is type number', 'number', typeof commentX);
+    assertEquals('Comment y position is type number', 'number', typeof commentY);
+
+    assertEquals('Comment x position is what was provided', 10, commentX);
+    assertEquals('Comment y position is what was provided', 20, commentY);
+  } finally {
+    scratchBlockCommentTest_tearDown();
+  }
+}
+
+function test_blockCommentXYWhenPositionNotProvided() {
+  scratchBlockCommentTest_setUp();
+  try {
+    var comment = new Blockly.ScratchBlockComment(
+        block, 'Some comment text', 'aMockComment');
+    var commentXY = comment.getXY();
+    var commentX = commentXY.x;
+    var commentY = commentXY.y;
+
+    console.log("COMMENT X: " + commentX);
+    console.log("COMMENT Y: " + commentY);
+
+    assertEquals('Comment x position is type number', 'number', typeof commentX);
+    assertEquals('Comment y position is type number', 'number', typeof commentY);
+
+    assertFalse('Comment x position is not NaN', isNaN(commentX));
+    assertFalse('Comment y position is not NaN', isNaN(commentY));
+  } finally {
+    scratchBlockCommentTest_tearDown();
+  }
+}
+
+function test_blockCommentXYNaNPositionProvided() {
+  scratchBlockCommentTest_setUp();
+  try {
+    var comment = new Blockly.ScratchBlockComment(
+        block, 'Some comment text', 'aMockComment', NaN, NaN);
+    var commentXY = comment.getXY();
+    var commentX = commentXY.x;
+    var commentY = commentXY.y;
+
+    assertEquals('Comment x position is type number', 'number', typeof commentX);
+    assertEquals('Comment y position is type number', 'number', typeof commentY);
+
+    assertFalse('Comment x position is not NaN', isNaN(commentX));
+    assertFalse('Comment y position is not NaN', isNaN(commentY));
+  } finally {
+    scratchBlockCommentTest_tearDown();
+  }
+}
+
+function test_blockCommentXYNullPositionProvided() {
+  scratchBlockCommentTest_setUp();
+  try {
+    var comment = new Blockly.ScratchBlockComment(
+        block, 'Some comment text', 'aMockComment', null, null);
+    var commentXY = comment.getXY();
+    var commentX = commentXY.x;
+    var commentY = commentXY.y;
+
+    assertEquals('Comment x position is type number', 'number', typeof commentX);
+    assertEquals('Comment y position is type number', 'number', typeof commentY);
+
+    assertFalse('Comment x position is not NaN', isNaN(commentX));
+    assertFalse('Comment y position is not NaN', isNaN(commentY));
+  } finally {
+    scratchBlockCommentTest_tearDown();
+  }
+}

--- a/tests/jsunit/vertical_tests.html
+++ b/tests/jsunit/vertical_tests.html
@@ -22,6 +22,7 @@
     <script src="json_test.js"></script>
     <script src="names_test.js"></script>
     <script src="procedure_test.js"></script>
+    <script src="scratch_block_comment_test.js"></script>
     <script src="svg_test.js"></script>
     <script src="utils_test.js"></script>
     <script src="widget_div_test.js"></script>


### PR DESCRIPTION
### Resolves

`Workspace scroll is wonky if block comments are on the screen. Scroll gets pinned to a corner of the workspace.` section of #1554.

### Proposed Changes

ScratchBlockComments should be able to handle `NaN` values for x and y positions, and their x and y positions properties should be updated after auto-positioning the comment (even if they are not rendered).

### Reason for Changes

The workspace metrics get wonky if scratch block comments are not correctly reporting positioning information.

### Test Coverage

Added unit tests! Particularly, `test_blockCommentXYNaNPositionProvided` and `test_blockCommentXYNullPositionProvided` fail prior to this fix and pass post changes.