### PR TITLE
Remove explicit z-index from comment foreign body.

### DIFF
--- a/core/css.js
+++ b/core/css.js
@@ -649,6 +649,10 @@ Blockly.Css.CONTENT = [
 
   // Scratch Comments
 
+  '.scratchCommentForeignObject {',
+    'position: relative;',
+  '}',
+
   '.scratchCommentBody {',
     'background-color: #fef49c;',
   '}',

--- a/core/scratch_block_comment.js
+++ b/core/scratch_block_comment.js
@@ -196,7 +196,7 @@ Blockly.ScratchBlockComment.prototype.createEditor_ = function() {
       {
         'x': Blockly.ScratchBubble.BORDER_WIDTH,
         'y': Blockly.ScratchBubble.BORDER_WIDTH + Blockly.ScratchBubble.TOP_BAR_HEIGHT,
-        'class': 'blocklyCommentForeignObject'
+        'class': 'scratchCommentForeignObject'
       },
       null);
   var body = document.createElementNS(Blockly.HTML_NS, 'body');

--- a/core/workspace_comment_render_svg.js
+++ b/core/workspace_comment_render_svg.js
@@ -168,21 +168,12 @@ Blockly.WorkspaceCommentSvg.prototype.render = function() {
  * @private
  */
 Blockly.WorkspaceCommentSvg.prototype.createEditor_ = function() {
-  /* Create the editor.  Here's the markup that will be generated:
-    <foreignObject class="blocklyCommentForeignObject" x="0" y="10" width="164" height="164">
-      <body xmlns="http://www.w3.org/1999/xhtml" class="blocklyMinimalBody">
-        <textarea xmlns="http://www.w3.org/1999/xhtml"
-            class="blocklyCommentTextarea"
-            style="height: 164px; width: 164px;"></textarea>
-      </body>
-    </foreignObject>
-  */
   this.foreignObject_ = Blockly.utils.createSvgElement(
       'foreignObject',
       {
         'x': Blockly.WorkspaceCommentSvg.BORDER_WIDTH,
         'y': Blockly.WorkspaceCommentSvg.BORDER_WIDTH + Blockly.WorkspaceCommentSvg.TOP_BAR_HEIGHT,
-        'class': 'blocklyCommentForeignObject'
+        'class': 'scratchCommentForeignObject'
       },
       null);
   var body = document.createElementNS(Blockly.HTML_NS, 'body');


### PR DESCRIPTION
### Resolves

`Comments overlap each other:` section of #1554

### Proposed Changes

Remove explicit z-ordering index from comment foreign objects which was causing overlapping comments to look like they were blending into each other. See screenshots in #1554.