### PR TITLE
Fix issues with scrolling workspace just after resizing a comment.

### DIFF
--- a/core/scratch_bubble.js
+++ b/core/scratch_bubble.js
@@ -400,6 +400,7 @@ Blockly.ScratchBubble.prototype.deleteMouseUp_ = function(e) {
  */
 Blockly.ScratchBubble.prototype.resizeMouseDown_ = function(e) {
   this.resizeStartSize_ = {width: this.width_, height: this.height_};
+  this.workspace_.setResizesEnabled(false);
   Blockly.ScratchBubble.superClass_.resizeMouseDown_.call(this, e);
 };
 
@@ -419,6 +420,8 @@ Blockly.ScratchBubble.prototype.resizeMouseUp_ = function(_e) {
   Blockly.Events.fire(new Blockly.Events.CommentChange(
       this.comment, {width: oldHW.width , height: oldHW.height},
       {width: this.width_, height: this.height_}));
+
+  this.workspace_.setResizesEnabled(true);
 };
 
 /**

--- a/core/workspace_comment_render_svg.js
+++ b/core/workspace_comment_render_svg.js
@@ -383,6 +383,7 @@ Blockly.WorkspaceCommentSvg.prototype.deleteMouseUp_ = function(e) {
 Blockly.WorkspaceCommentSvg.prototype.resizeMouseDown_ = function(e) {
   this.resizeStartSize_ = {width: this.width_, height: this.height_};
   this.unbindDragEvents_();
+  this.workspace.setResizesEnabled(false);
   if (Blockly.utils.isRightButton(e)) {
     // No right-click.
     e.stopPropagation();
@@ -478,6 +479,8 @@ Blockly.WorkspaceCommentSvg.prototype.resizeMouseUp_ = function(/*e*/) {
   Blockly.Events.fire(new Blockly.Events.CommentChange(
       this, {width: oldHW.width , height: oldHW.height},
       {width: this.width_, height: this.height_}));
+
+  this.workspace.setResizesEnabled(true);
 };
 
 /**


### PR DESCRIPTION
Fixes another workspace scroll issue where resizing a comment was not causing the workspace to recalculate the size of its contents.