### PR TITLE
Add a character limit to the comment textareas.

### DIFF
--- a/core/scratch_block_comment.js
+++ b/core/scratch_block_comment.js
@@ -153,6 +153,12 @@ Blockly.ScratchBlockComment.TEXTAREA_OFFSET = 12;
 Blockly.ScratchBlockComment.MAX_LABEL_LENGTH = 16;
 
 /**
+ * Maximum character length for comment text.
+ * @private
+ */
+Blockly.ScratchBlockComment.COMMENT_TEXT_LIMIT = 8000;
+
+/**
  * Width that a minimized comment should have.
  * @private
  */
@@ -220,6 +226,7 @@ Blockly.ScratchBlockComment.prototype.createEditor_ = function() {
   var textarea = document.createElementNS(Blockly.HTML_NS, 'textarea');
   textarea.className = 'scratchCommentTextarea scratchCommentText';
   textarea.setAttribute('dir', this.block_.RTL ? 'RTL' : 'LTR');
+  textarea.setAttribute('maxlength', Blockly.ScratchBlockComment.COMMENT_TEXT_LIMIT);
   body.appendChild(textarea);
   this.textarea_ = textarea;
   this.textarea_.style.margin = (Blockly.ScratchBlockComment.TEXTAREA_OFFSET) + 'px';

--- a/core/workspace_comment.js
+++ b/core/workspace_comment.js
@@ -128,6 +128,12 @@ Blockly.WorkspaceComment = function(workspace, content, height, width, minimized
 Blockly.WorkspaceComment.MAX_LABEL_LENGTH = 16;
 
 /**
+ * Maximum character length for comment text.
+ * @private
+ */
+Blockly.WorkspaceComment.COMMENT_TEXT_LIMIT = 8000;
+
+/**
  * Dispose of this comment.
  * @package
  */

--- a/core/workspace_comment_render_svg.js
+++ b/core/workspace_comment_render_svg.js
@@ -182,6 +182,7 @@ Blockly.WorkspaceCommentSvg.prototype.createEditor_ = function() {
   var textarea = document.createElementNS(Blockly.HTML_NS, 'textarea');
   textarea.className = 'scratchCommentTextarea scratchCommentText';
   textarea.setAttribute('dir', this.RTL ? 'RTL' : 'LTR');
+  textarea.setAttribute('maxlength', Blockly.WorkspaceComment.COMMENT_TEXT_LIMIT);
   body.appendChild(textarea);
   this.textarea_ = textarea;
   this.textarea_.style.margin = (Blockly.WorkspaceCommentSvg.TEXTAREA_OFFSET) + 'px';


### PR DESCRIPTION
Title says it all.

There is some duplication here, but I would rather address that for all the comment constants in a future PR (tracking that issue in #1592).