### PR TITLE
Add flyout image button and flyout status button

### DIFF
--- a/core/blockly.js
+++ b/core/blockly.js
@@ -381,6 +381,18 @@ Blockly.prompt = function(message, defaultValue, callback, _opt_title,
  */
 Blockly.statusButtonCallback = function(id) {
   window.alert('status button was pressed for ' + id);
+  Blockly.updateStatusButton(id, 'ready');
+};
+
+Blockly.updateStatusButton = function(id, newStatus) {
+  var buttons = this.getMainWorkspace().getFlyout().buttons_;
+  for (var i=0; i<buttons.length; i++) {
+    if (buttons[i] instanceof Blockly.FlyoutStatusButton) {
+      if (buttons[i].extensionId == id) {
+        buttons[i].setStatus(newStatus);
+      }
+    }
+  }
 };
 
 /**

--- a/core/blockly.js
+++ b/core/blockly.js
@@ -377,13 +377,18 @@ Blockly.prompt = function(message, defaultValue, callback, _opt_title,
 /**
  * A callback for status buttons. The window.alert is here for testing and
  * should be overridden.
- * @param {string} id An identifier.
+ * @param {string} id An identifier for the status button.
  */
 Blockly.statusButtonCallback = function(id) {
   window.alert('status button was pressed for ' + id);
-  Blockly.updateStatusButton(id, 'ready');
+  Blockly.updateStatusButton(id, Blockly.StatusButtonState.READY);
 };
 
+/**
+ * Update a status button with a new status.
+ * @param {string} id An identifier for the status button.
+ * @param {string} newStatus The new status to set.
+ */
 Blockly.updateStatusButton = function(id, newStatus) {
   var buttons = this.getMainWorkspace().getFlyout().buttons_;
   for (var i=0; i<buttons.length; i++) {

--- a/core/constants.js
+++ b/core/constants.js
@@ -366,3 +366,12 @@ Blockly.PROCEDURES_PROTOTYPE_BLOCK_TYPE = 'procedures_prototype';
  * @const {string}
  */
 Blockly.PROCEDURES_CALL_BLOCK_TYPE = 'procedures_call';
+
+/**
+ * ENUM for flyout status button states.
+ * @const
+ */
+Blockly.StatusButtonState = {
+  "READY": "ready",
+  "NOT_READY": "not ready",
+};

--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -545,8 +545,6 @@ Blockly.Flyout.prototype.show = function(xmlList) {
           xml.setAttribute('callbackKey', callbackKey);
           var callback = Blockly.statusButtonCallback.bind(this, extensionId);
           this.workspace_.registerButtonCallback(callbackKey, callback);
-          xml.setAttribute('imageSrc',
-              Blockly.mainWorkspace.options.pathToMedia + 'status-not-ready.svg');
           var curButton = new Blockly.FlyoutStatusButton(this.workspace_,
               this.targetWorkspace_, xml);
           contents.push({type: 'button', button: curButton});

--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -32,6 +32,7 @@ goog.require('Blockly.Events');
 goog.require('Blockly.Events.BlockCreate');
 goog.require('Blockly.Events.VarCreate');
 goog.require('Blockly.FlyoutButton');
+goog.require('Blockly.FlyoutStatusButton');
 goog.require('Blockly.Gesture');
 goog.require('Blockly.Touch');
 goog.require('Blockly.WorkspaceSvg');
@@ -544,9 +545,10 @@ Blockly.Flyout.prototype.show = function(xmlList) {
           xml.setAttribute('callbackKey', callbackKey);
           var callback = Blockly.statusButtonCallback.bind(this, extensionId);
           this.workspace_.registerButtonCallback(callbackKey, callback);
-          // @todo: make a new image button class to use here
-          var curButton = new Blockly.FlyoutButton(this.workspace_,
-              this.targetWorkspace_, xml, false);
+          xml.setAttribute('imageSrc',
+              Blockly.mainWorkspace.options.pathToMedia + 'status-not-ready.svg');
+          var curButton = new Blockly.FlyoutStatusButton(this.workspace_,
+              this.targetWorkspace_, xml);
           contents.push({type: 'button', button: curButton});
         }
       } else if (tagName == 'BUTTON' || tagName == 'LABEL') {

--- a/core/flyout_image_button.js
+++ b/core/flyout_image_button.js
@@ -1,0 +1,87 @@
+'use strict';
+
+goog.provide('Blockly.FlyoutImageButton');
+
+goog.require('Blockly.FlyoutButton');
+goog.require('goog.dom');
+goog.require('goog.math.Coordinate');
+
+Blockly.FlyoutImageButton = function(workspace, targetWorkspace, xml) {
+  /**
+   * @type {!Blockly.WorkspaceSvg}
+   * @private
+   */
+  this.workspace_ = workspace;
+
+  /**
+   * @type {!Blockly.Workspace}
+   * @private
+   */
+  this.targetWorkspace_ = targetWorkspace;
+
+  /**
+   * @type {!goog.math.Coordinate}
+   * @private
+   */
+  this.position_ = new goog.math.Coordinate(0, 0);
+
+  this.imageSrc = xml.getAttribute('imageSrc');
+
+  this.height_ = 0;
+  this.width_ = 0;
+
+  /**
+   * Function to call when this button is clicked.
+   * @type {function(!Blockly.FlyoutButton)}
+   * @private
+   */
+  this.callback_ = null;
+  var callbackKey = xml.getAttribute('callbackKey');
+  if (callbackKey) {
+    this.callback_ = targetWorkspace.getButtonCallback(callbackKey);
+  }
+};
+goog.inherits(Blockly.FlyoutImageButton, Blockly.FlyoutButton);
+
+/**
+ * Create the button elements.
+ * @return {!Element} The button's SVG group.
+ */
+Blockly.FlyoutImageButton.prototype.createDom = function() {
+  var cssClass = 'blocklyFlyoutButton';
+
+  this.svgGroup_ = Blockly.utils.createSvgElement('g', {'class': cssClass},
+      this.workspace_.getCanvas());
+
+  /** @type {SVGElement} */
+  this.imageElement_ = Blockly.utils.createSvgElement(
+      'image',
+      {
+        'height': this.height_ + 'px',
+        'width': this.width_ + 'px'
+      },
+      this.svgGroup_);
+  this.setImageSrc(this.imageSrc);
+
+  this.width += 2 * Blockly.FlyoutButton.MARGIN;
+
+  this.mouseUpWrapper_ = Blockly.bindEventWithChecks_(this.svgGroup_, 'mouseup',
+      this, this.onMouseUp_);
+  return this.svgGroup_;
+};
+
+/**
+ * Set the source URL of this image.
+ * @param {?string} src New source.
+ * @override
+ */
+Blockly.FlyoutImageButton.prototype.setImageSrc = function(src) {
+  if (src === null) {
+    // No change if null.
+    return;
+  }
+  if (this.imageElement_) {
+    this.imageElement_.setAttributeNS('http://www.w3.org/1999/xlink',
+        'xlink:href', src || '');
+  }
+};

--- a/core/flyout_image_button.js
+++ b/core/flyout_image_button.js
@@ -1,11 +1,41 @@
+/**
+ * @license
+ * Visual Blocks Editor
+ *
+ * Copyright 2018 Google Inc.
+ * https://developers.google.com/blockly/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Class for a button in the flyout that displays an image.
+ * @author ericr@media.mit.edu (Eric Rosenbaum)
+ */
 'use strict';
 
 goog.provide('Blockly.FlyoutImageButton');
 
 goog.require('Blockly.FlyoutButton');
-goog.require('goog.dom');
-goog.require('goog.math.Coordinate');
 
+/**
+ * Class for a button in the flyout that displays an image.
+ * @param {!Blockly.WorkspaceSvg} workspace The workspace in which to place this
+ *     button.
+ * @param {!Blockly.WorkspaceSvg} targetWorkspace The flyout's target workspace.
+ * @param {!Element} xml The XML specifying the button.
+ * @constructor
+ */
 Blockly.FlyoutImageButton = function(workspace, targetWorkspace, xml) {
   /**
    * @type {!Blockly.WorkspaceSvg}
@@ -25,10 +55,12 @@ Blockly.FlyoutImageButton = function(workspace, targetWorkspace, xml) {
    */
   this.position_ = new goog.math.Coordinate(0, 0);
 
-  this.imageSrc = xml.getAttribute('imageSrc');
-
-  this.height_ = 0;
-  this.width_ = 0;
+  /**
+   * The URL of the image to display on the button.
+   * @type {string}
+   * @private
+   */
+  this.imageSrc_ = xml.getAttribute('imageSrc');
 
   /**
    * Function to call when this button is clicked.
@@ -53,15 +85,17 @@ Blockly.FlyoutImageButton.prototype.createDom = function() {
   this.svgGroup_ = Blockly.utils.createSvgElement('g', {'class': cssClass},
       this.workspace_.getCanvas());
 
-  /** @type {SVGElement} */
-  this.imageElement_ = Blockly.utils.createSvgElement(
-      'image',
-      {
-        'height': this.height_ + 'px',
-        'width': this.width_ + 'px'
-      },
-      this.svgGroup_);
-  this.setImageSrc(this.imageSrc);
+  if (this.imageSrc_) {
+    /** @type {SVGElement} */
+    this.imageElement_ = Blockly.utils.createSvgElement(
+        'image',
+        {
+          'height': this.height + 'px',
+          'width': this.width + 'px'
+        },
+        this.svgGroup_);
+    this.setImageSrc(this.imageSrc_);
+  }
 
   this.width += 2 * Blockly.FlyoutButton.MARGIN;
 
@@ -71,17 +105,18 @@ Blockly.FlyoutImageButton.prototype.createDom = function() {
 };
 
 /**
- * Set the source URL of this image.
+ * Set the source URL of the image for the button.
  * @param {?string} src New source.
- * @override
+ * @package
  */
 Blockly.FlyoutImageButton.prototype.setImageSrc = function(src) {
   if (src === null) {
     // No change if null.
     return;
   }
+  this.imageSrc_ = src;
   if (this.imageElement_) {
     this.imageElement_.setAttributeNS('http://www.w3.org/1999/xlink',
-        'xlink:href', src || '');
+        'xlink:href', this.imageSrc_ || '');
   }
 };

--- a/core/flyout_status_button.js
+++ b/core/flyout_status_button.js
@@ -1,0 +1,30 @@
+'use strict';
+
+goog.provide('Blockly.FlyoutStatusButton');
+
+goog.require('Blockly.FlyoutImageButton');
+
+Blockly.FlyoutStatusButton = function(workspace, targetWorkspace, xml) {
+
+  // xml.setAttribute('imageSrc',
+  //     Blockly.mainWorkspace.options.pathToMedia + 'status-not-ready.svg');
+
+  Blockly.FlyoutStatusButton.superClass_.constructor.call(this, workspace, targetWorkspace, xml);
+
+  this.extensionId = xml.getAttribute('extensionId');
+
+  this.height_ = 25;
+  this.width_ = 25;
+
+  this.setStatus('not ready');
+};
+goog.inherits(Blockly.FlyoutStatusButton, Blockly.FlyoutImageButton);
+
+Blockly.FlyoutStatusButton.prototype.setStatus = function(status) {
+  var basePath = Blockly.mainWorkspace.options.pathToMedia;
+  if (status === 'ready') {
+    this.setImageSrc(basePath + 'status-ready.svg');
+  } else {
+    this.setImageSrc(basePath + 'status-not-ready.svg');
+  }
+};

--- a/core/flyout_status_button.js
+++ b/core/flyout_status_button.js
@@ -1,30 +1,64 @@
+/**
+ * @license
+ * Visual Blocks Editor
+ *
+ * Copyright 2018 Google Inc.
+ * https://developers.google.com/blockly/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Class for a status button in the flyout.
+ * @author ericr@media.mit.edu (Eric Rosenbaum)
+ */
 'use strict';
 
 goog.provide('Blockly.FlyoutStatusButton');
 
 goog.require('Blockly.FlyoutImageButton');
 
+/**
+ * Class for a status button in the flyout.
+ * @param {!Blockly.WorkspaceSvg} workspace The workspace in which to place this
+ *     button.
+ * @param {!Blockly.WorkspaceSvg} targetWorkspace The flyout's target workspace.
+ * @param {!Element} xml The XML specifying the button.
+ * @constructor
+ */
 Blockly.FlyoutStatusButton = function(workspace, targetWorkspace, xml) {
-
-  // xml.setAttribute('imageSrc',
-  //     Blockly.mainWorkspace.options.pathToMedia + 'status-not-ready.svg');
-
   Blockly.FlyoutStatusButton.superClass_.constructor.call(this, workspace, targetWorkspace, xml);
 
   this.extensionId = xml.getAttribute('extensionId');
 
-  this.height_ = 25;
-  this.width_ = 25;
+  // Flyout status buttons have a fixed size.
+  this.width = 25;
+  this.height = 25;
 
-  this.setStatus('not ready');
+  this.setStatus(Blockly.StatusButtonState.NOT_READY);
 };
 goog.inherits(Blockly.FlyoutStatusButton, Blockly.FlyoutImageButton);
 
+/**
+ * Set the image on the status button using a status string.
+ * @param {string} status The status string.
+ */
 Blockly.FlyoutStatusButton.prototype.setStatus = function(status) {
   var basePath = Blockly.mainWorkspace.options.pathToMedia;
-  if (status === 'ready') {
+  if (status == Blockly.StatusButtonState.READY) {
     this.setImageSrc(basePath + 'status-ready.svg');
-  } else {
+  }
+  if (status == Blockly.StatusButtonState.NOT_READY) {
     this.setImageSrc(basePath + 'status-not-ready.svg');
   }
 };

--- a/media/status-not-ready.svg
+++ b/media/status-not-ready.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 21.0.2, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 20 20" style="enable-background:new 0 0 20 20;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#FF8C1A;}
+	.st1{fill:#FFFFFF;}
+</style>
+<circle class="st0" cx="10" cy="10" r="8.5"/>
+<path class="st1" d="M9.1,10.6l-0.3-3C8.7,7,8.6,6.6,8.6,6.4c0-0.3,0.2-0.6,0.5-0.8c0.3-0.2,0.7-0.3,1.2-0.3c0.6,0,1,0.1,1.2,0.4
+	c0.2,0.2,0.3,0.6,0.3,1.1c0,0.3,0,0.6-0.1,0.8l-0.5,3.1c-0.1,0.4-0.2,0.7-0.3,0.8c-0.2,0.2-0.4,0.3-0.8,0.3c-0.4,0-0.7-0.1-0.8-0.3
+	C9.2,11.3,9.1,11,9.1,10.6z M10.3,14.8c-0.4,0-0.8-0.1-1.1-0.2c-0.3-0.2-0.5-0.4-0.5-0.7c0-0.3,0.2-0.5,0.5-0.7
+	c0.3-0.2,0.7-0.3,1.1-0.3s0.8,0.1,1.2,0.3s0.5,0.4,0.5,0.7c0,0.3-0.2,0.5-0.5,0.7C11.1,14.7,10.7,14.8,10.3,14.8z"/>
+</svg>

--- a/media/status-ready.svg
+++ b/media/status-ready.svg
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 21.0.2, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 20 20" style="enable-background:new 0 0 20 20;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#FF8C1A;}
+	.st1{fill:#FFFFFF;}
+	.st2{fill:#0FBD8C;}
+</style>
+<g id="Layer_1">
+	<circle class="st0" cx="10" cy="10" r="8.5"/>
+	<path class="st1" d="M9.1,10.6l-0.3-3C8.7,7,8.6,6.6,8.6,6.4c0-0.3,0.2-0.6,0.5-0.8c0.3-0.2,0.7-0.3,1.2-0.3c0.6,0,1,0.1,1.2,0.4
+		c0.2,0.2,0.3,0.6,0.3,1.1c0,0.3,0,0.6-0.1,0.8l-0.5,3.1c-0.1,0.4-0.2,0.7-0.3,0.8c-0.2,0.2-0.4,0.3-0.8,0.3c-0.4,0-0.7-0.1-0.8-0.3
+		C9.2,11.3,9.1,11,9.1,10.6z M10.3,14.8c-0.4,0-0.8-0.1-1.1-0.2c-0.3-0.2-0.5-0.4-0.5-0.7c0-0.3,0.2-0.5,0.5-0.7
+		c0.3-0.2,0.7-0.3,1.1-0.3s0.8,0.1,1.2,0.3s0.5,0.4,0.5,0.7c0,0.3-0.2,0.5-0.5,0.7C11.1,14.7,10.7,14.8,10.3,14.8z"/>
+</g>
+<g id="Layer_2">
+	<circle class="st2" cx="10" cy="10" r="8.5"/>
+</g>
+</svg>


### PR DESCRIPTION
### Proposed Changes

Further work on the status button for extensions to display in the flyout. 

- Add a FlyoutImageButton class that inherits from FlyoutButton, but displays an image.
- Add a FlyoutStatusButton class that inherits from FlyoutImageButton, but has a setStatus function to be used by the extension to update the button's image.
- Add status enums for 'ready' and 'not ready' states.
- Add a top-level function to update a status button with a status enum and an id (we'll use the scratch extension id).

One remaining chunk of work for a future PR is to position the status button to spec. 