### PR TITLE
Adding %{..} support to toolbox buttons and labels.

### DIFF
--- a/core/flyout_button.js
+++ b/core/flyout_button.js
@@ -171,7 +171,7 @@ Blockly.FlyoutButton.prototype.createDom = function() {
         'text-anchor': 'middle'
       },
       this.svgGroup_);
-  svgText.textContent = this.text_;
+  svgText.textContent = Blockly.utils.replaceMessageReferences(this.text_);
 
   this.width = Blockly.Field.getCachedWidth(svgText);
 


### PR DESCRIPTION
See https://github.com/google/blockly/pull/1929

### Resolves

https://github.com/google/blockly/pull/1927

### Proposed Changes

Support `%{..}` translations in toolbox button and labels.

### Test Coverage

Tested in Blockly playground and code demo.