### PR TITLE
Smaller comment label length

### DIFF
--- a/core/scratch_block_comment.js
+++ b/core/scratch_block_comment.js
@@ -150,7 +150,7 @@ Blockly.ScratchBlockComment.TEXTAREA_OFFSET = 12;
  * one additional character, the ellipsis).
  * @private
  */
-Blockly.ScratchBlockComment.MAX_LABEL_LENGTH = 16;
+Blockly.ScratchBlockComment.MAX_LABEL_LENGTH = 12;
 
 /**
  * Maximum character length for comment text.

--- a/core/workspace_comment.js
+++ b/core/workspace_comment.js
@@ -125,7 +125,7 @@ Blockly.WorkspaceComment = function(workspace, content, height, width, minimized
  * one additional character, the ellipsis).
  * @private
  */
-Blockly.WorkspaceComment.MAX_LABEL_LENGTH = 16;
+Blockly.WorkspaceComment.MAX_LABEL_LENGTH = 12;
 
 /**
  * Maximum character length for comment text.


### PR DESCRIPTION
Resolves #1602 

Capital letters are bigger than lower case letters in the font we've chosen. Change the maximum label length so that the characters don't over lap with the icons on the comment.