### PR TITLE
Add flyout extension category header

### DIFF
--- a/blocks_vertical/default_toolbox.js
+++ b/blocks_vertical/default_toolbox.js
@@ -523,8 +523,7 @@ Blockly.Blocks.defaultToolbox = '<xml id="toolbox-categories" style="display: no
   '<category name="%{BKY_CATEGORY_MYBLOCKS}" id="more" colour="#FF6680" secondaryColour="#FF4D6A" custom="PROCEDURE">' +
   '</category>' +
   '<category name="Extensions" id="extensions" colour="#FF6680" secondaryColour="#FF4D6A" ' +
-    'iconURI="../media/extensions/wedo2-block-icon.svg">' +
-    '<button type="status" extensionId="extensions"></button>' +
+    'iconURI="../media/extensions/wedo2-block-icon.svg" showStatusButton="true">' +
     '<block type="extension_pen_down" id="extension_pen_down"></block>' +
     '<block type="extension_music_drum" id="extension_music_drum">' +
       '<value name="NUMBER">' +

--- a/core/blockly.js
+++ b/core/blockly.js
@@ -381,6 +381,23 @@ Blockly.prompt = function(message, defaultValue, callback, _opt_title,
  */
 Blockly.statusButtonCallback = function(id) {
   window.alert('status button was pressed for ' + id);
+  Blockly.updateStatusButton(id, Blockly.StatusButtonState.READY);
+};
+
+/**
+ * Update the visual state of a status button in an extension category header.
+ * @param {string} id An extension id.
+ * @param {Blockly.StatusButtonState} newStatus the new state for the status button.
+ */
+Blockly.updateStatusButton = function(id, newStatus) {
+  var buttons = this.getMainWorkspace().getFlyout().buttons_;
+  for (var i = 0; i < buttons.length; i++) {
+    if (buttons[i] instanceof Blockly.FlyoutExtensionCategoryHeader) {
+      if (buttons[i].extensionId == id) {
+        buttons[i].setStatus(newStatus);
+      }
+    }
+  }
 };
 
 /**

--- a/core/blockly.js
+++ b/core/blockly.js
@@ -381,16 +381,16 @@ Blockly.prompt = function(message, defaultValue, callback, _opt_title,
  */
 Blockly.statusButtonCallback = function(id) {
   window.alert('status button was pressed for ' + id);
-  Blockly.updateStatusButton(id, Blockly.StatusButtonState.READY);
 };
 
 /**
  * Update the visual state of a status button in an extension category header.
+ * @param {Blockly.Workspace} workspace A workspace.
  * @param {string} id An extension id.
- * @param {Blockly.StatusButtonState} newStatus the new state for the status button.
+ * @param {Blockly.StatusButtonState} newStatus the new state for the button.
  */
-Blockly.updateStatusButton = function(id, newStatus) {
-  var buttons = this.getMainWorkspace().getFlyout().buttons_;
+Blockly.updateStatusButton = function(workspace, id, newStatus) {
+  var buttons = workspace.getFlyout().buttons_;
   for (var i = 0; i < buttons.length; i++) {
     if (buttons[i] instanceof Blockly.FlyoutExtensionCategoryHeader) {
       if (buttons[i].extensionId == id) {

--- a/core/constants.js
+++ b/core/constants.js
@@ -366,3 +366,12 @@ Blockly.PROCEDURES_PROTOTYPE_BLOCK_TYPE = 'procedures_prototype';
  * @const {string}
  */
 Blockly.PROCEDURES_CALL_BLOCK_TYPE = 'procedures_call';
+
+/**
+ * ENUM for flyout status button states.
+ * @const
+ */
+Blockly.StatusButtonState = {
+  "READY": "ready",
+  "NOT_READY": "not ready",
+};

--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -32,6 +32,7 @@ goog.require('Blockly.Events');
 goog.require('Blockly.Events.BlockCreate');
 goog.require('Blockly.Events.VarCreate');
 goog.require('Blockly.FlyoutButton');
+goog.require('Blockly.FlyoutExtensionCategoryHeader');
 goog.require('Blockly.Gesture');
 goog.require('Blockly.Touch');
 goog.require('Blockly.WorkspaceSvg');
@@ -536,19 +537,10 @@ Blockly.Flyout.prototype.show = function(xmlList) {
         } else {
           gaps.push(default_gap);
         }
-      } else if ((tagName == 'BUTTON') && (xml.getAttribute('type') == 'status')) {
-        // Scratch extensions can display a status button
-        var extensionId = xml.getAttribute('extensionId');
-        if (extensionId) {
-          var callbackKey = 'STATUS_PRESSED_' + extensionId.toUpperCase();
-          xml.setAttribute('callbackKey', callbackKey);
-          var callback = Blockly.statusButtonCallback.bind(this, extensionId);
-          this.workspace_.registerButtonCallback(callbackKey, callback);
-          // @todo: make a new image button class to use here
-          var curButton = new Blockly.FlyoutButton(this.workspace_,
-              this.targetWorkspace_, xml, false);
-          contents.push({type: 'button', button: curButton});
-        }
+      } else if ((tagName == 'LABEL') && (xml.getAttribute('showStatusButton') == 'true')) {
+        var curButton = new Blockly.FlyoutExtensionCategoryHeader(this.workspace_,
+            this.targetWorkspace_, xml);
+        contents.push({type: 'button', button: curButton});
       } else if (tagName == 'BUTTON' || tagName == 'LABEL') {
         // Labels behave the same as buttons, but are styled differently.
         var isLabel = tagName == 'LABEL';

--- a/core/flyout_button.js
+++ b/core/flyout_button.js
@@ -142,18 +142,15 @@ Blockly.FlyoutButton.prototype.createDom = function() {
   this.svgGroup_ = Blockly.utils.createSvgElement('g', {'class': cssClass},
       this.workspace_.getCanvas());
 
-  this.addTextSvg();
+  this.addTextSvg(this.isLabel_);
 
   this.mouseUpWrapper_ = Blockly.bindEventWithChecks_(this.svgGroup_, 'mouseup',
       this, this.onMouseUp_);
   return this.svgGroup_;
 };
 
-Blockly.FlyoutButton.prototype.addTextSvg = function() {
-  var ws = this.getTargetWorkspace();
-  var flyoutWidth = ws.getFlyout().getWidth();
-
-  if (!this.isLabel_) {
+Blockly.FlyoutButton.prototype.addTextSvg = function(isLabel) {
+  if (!isLabel) {
     // Shadow rectangle (light source does not mirror in RTL).
     var shadow = Blockly.utils.createSvgElement('rect',
         {
@@ -168,7 +165,7 @@ Blockly.FlyoutButton.prototype.addTextSvg = function() {
   // Background rectangle.
   var rect = Blockly.utils.createSvgElement('rect',
       {
-        'class': this.isLabel_ ?
+        'class': isLabel ?
             'blocklyFlyoutLabelBackground' : 'blocklyFlyoutButtonBackground',
         'rx': 4, 'ry': 4
       },
@@ -176,7 +173,7 @@ Blockly.FlyoutButton.prototype.addTextSvg = function() {
 
   var svgText = Blockly.utils.createSvgElement('text',
       {
-        'class': this.isLabel_ ? 'blocklyFlyoutLabelText' : 'blocklyText',
+        'class': isLabel ? 'blocklyFlyoutLabelText' : 'blocklyText',
         'x': 0,
         'y': 0,
         'text-anchor': 'middle'
@@ -186,7 +183,7 @@ Blockly.FlyoutButton.prototype.addTextSvg = function() {
 
   this.width = Blockly.Field.getCachedWidth(svgText);
 
-  if (!this.isLabel_) {
+  if (!isLabel) {
     this.width += 2 * Blockly.FlyoutButton.MARGIN;
     shadow.setAttribute('width', this.width);
     shadow.setAttribute('height', this.height);

--- a/core/flyout_button.js
+++ b/core/flyout_button.js
@@ -142,6 +142,17 @@ Blockly.FlyoutButton.prototype.createDom = function() {
   this.svgGroup_ = Blockly.utils.createSvgElement('g', {'class': cssClass},
       this.workspace_.getCanvas());
 
+  this.addTextSvg();
+
+  this.mouseUpWrapper_ = Blockly.bindEventWithChecks_(this.svgGroup_, 'mouseup',
+      this, this.onMouseUp_);
+  return this.svgGroup_;
+};
+
+Blockly.FlyoutButton.prototype.addTextSvg = function() {
+  var ws = this.getTargetWorkspace();
+  var flyoutWidth = ws.getFlyout().getWidth();
+
   if (!this.isLabel_) {
     // Shadow rectangle (light source does not mirror in RTL).
     var shadow = Blockly.utils.createSvgElement('rect',
@@ -190,10 +201,6 @@ Blockly.FlyoutButton.prototype.createDom = function() {
     Blockly.Field.IE_TEXT_OFFSET : '0');
   svgText.setAttribute('x', this.width / 2);
   svgText.setAttribute('y', this.height / 2);
-
-  this.mouseUpWrapper_ = Blockly.bindEventWithChecks_(this.svgGroup_, 'mouseup',
-      this, this.onMouseUp_);
-  return this.svgGroup_;
 };
 
 /**

--- a/core/flyout_button.js
+++ b/core/flyout_button.js
@@ -149,6 +149,11 @@ Blockly.FlyoutButton.prototype.createDom = function() {
   return this.svgGroup_;
 };
 
+/**
+ * Add the text element for the label or button.
+ * @param {boolean} isLabel True if this is a label and not button.
+ * @package
+ */
 Blockly.FlyoutButton.prototype.addTextSvg = function(isLabel) {
   if (!isLabel) {
     // Shadow rectangle (light source does not mirror in RTL).

--- a/core/flyout_button.js
+++ b/core/flyout_button.js
@@ -42,6 +42,62 @@ goog.require('goog.math.Coordinate');
  */
 Blockly.FlyoutButton = function(workspace, targetWorkspace, xml, isLabel) {
 
+  this.init(workspace, targetWorkspace, xml, isLabel);
+
+  /**
+   * Function to call when this button is clicked.
+   * @type {function(!Blockly.FlyoutButton)}
+   * @private
+   */
+  this.callback_ = null;
+
+  var callbackKey = xml.getAttribute('callbackKey');
+  if (this.isLabel_ && callbackKey) {
+    console.warn('Labels should not have callbacks. Label text: ' + this.text_);
+  } else if (!this.isLabel_ &&
+      !(callbackKey && targetWorkspace.getButtonCallback(callbackKey))) {
+    console.warn('Buttons should have callbacks. Button text: ' + this.text_);
+  } else {
+    this.callback_ = targetWorkspace.getButtonCallback(callbackKey);
+  }
+};
+
+/**
+ * The margin around the text in the button.
+ */
+Blockly.FlyoutButton.MARGIN = 40;
+
+/**
+ * The width of the button's rect.
+ * @type {number}
+ */
+Blockly.FlyoutButton.prototype.width = 0;
+
+/**
+ * The height of the button's rect.
+ * @type {number}
+ */
+Blockly.FlyoutButton.prototype.height = 40; // Can't be computed like the width
+
+/**
+ * Opaque data that can be passed to Blockly.unbindEvent_.
+ * @type {Array.<!Array>}
+ * @private
+ */
+Blockly.FlyoutButton.prototype.onMouseUpWrapper_ = null;
+
+/**
+* Initialize the button or label. This is a helper function to so that the
+* constructor can be overridden.
+* @param {!Blockly.WorkspaceSvg} workspace The workspace in which to place this
+*     button.
+* @param {!Blockly.WorkspaceSvg} targetWorkspace The flyout's target workspace.
+* @param {!Element} xml The XML specifying the label/button.
+* @param {boolean} isLabel Whether this button should be styled as a label.
+ */
+Blockly.FlyoutButton.prototype.init = function(
+    workspace, targetWorkspace, xml, isLabel) {
+
   /**
    * @type {!Blockly.WorkspaceSvg}
    * @private
@@ -81,53 +137,12 @@ Blockly.FlyoutButton = function(workspace, targetWorkspace, xml, isLabel) {
   this.isCategoryLabel_ = xml.getAttribute('category-label') === 'true';
 
   /**
-   * Function to call when this button is clicked.
-   * @type {function(!Blockly.FlyoutButton)}
-   * @private
-   */
-  this.callback_ = null;
-
-  var callbackKey = xml.getAttribute('callbackKey');
-  if (this.isLabel_ && callbackKey) {
-    console.warn('Labels should not have callbacks. Label text: ' + this.text_);
-  } else if (!this.isLabel_ &&
-      !(callbackKey && targetWorkspace.getButtonCallback(callbackKey))) {
-    console.warn('Buttons should have callbacks. Button text: ' + this.text_);
-  } else {
-    this.callback_ = targetWorkspace.getButtonCallback(callbackKey);
-  }
-
-  /**
    * If specified, a CSS class to add to this button.
    * @type {?string}
    * @private
    */
   this.cssClass_ = xml.getAttribute('web-class') || null;
 };
-
-/**
- * The margin around the text in the button.
- */
-Blockly.FlyoutButton.MARGIN = 40;
-
-/**
- * The width of the button's rect.
- * @type {number}
- */
-Blockly.FlyoutButton.prototype.width = 0;
-
-/**
- * The height of the button's rect.
- * @type {number}
- */
-Blockly.FlyoutButton.prototype.height = 40; // Can't be computed like the width
-
-/**
- * Opaque data that can be passed to Blockly.unbindEvent_.
- * @type {Array.<!Array>}
- * @private
- */
-Blockly.FlyoutButton.prototype.onMouseUpWrapper_ = null;
 
 /**
  * Create the button elements.

--- a/core/flyout_button.js
+++ b/core/flyout_button.js
@@ -31,7 +31,8 @@ goog.require('goog.math.Coordinate');
 
 
 /**
- * Class for a button in the flyout.
+ * Class for a button or label in the flyout. Labels behave the same as buttons,
+ * but are styled differently.
  * @param {!Blockly.WorkspaceSvg} workspace The workspace in which to place this
  *     button.
  * @param {!Blockly.WorkspaceSvg} targetWorkspace The flyout's target workspace.
@@ -40,7 +41,6 @@ goog.require('goog.math.Coordinate');
  * @constructor
  */
 Blockly.FlyoutButton = function(workspace, targetWorkspace, xml, isLabel) {
-  // Labels behave the same as buttons, but are styled differently.
 
   /**
    * @type {!Blockly.WorkspaceSvg}

--- a/core/flyout_extension_category_header.js
+++ b/core/flyout_extension_category_header.js
@@ -1,0 +1,156 @@
+/**
+ * @license
+ * Visual Blocks Editor
+ *
+ * Copyright 2018 Google Inc.
+ * https://developers.google.com/blockly/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Class for a button in the flyout that displays an image.
+ * @author ericr@media.mit.edu (Eric Rosenbaum)
+ */
+'use strict';
+
+goog.provide('Blockly.FlyoutExtensionCategoryHeader');
+
+goog.require('Blockly.FlyoutButton');
+
+/**
+ * Class for a button in the flyout that displays an image.
+ * @param {!Blockly.WorkspaceSvg} workspace The workspace in which to place this
+ *     button.
+ * @param {!Blockly.WorkspaceSvg} targetWorkspace The flyout's target workspace.
+ * @param {!Element} xml The XML specifying the button.
+ * @constructor
+ */
+Blockly.FlyoutExtensionCategoryHeader = function(workspace, targetWorkspace, xml) {
+  /**
+   * @type {!Blockly.WorkspaceSvg}
+   * @private
+   */
+  this.workspace_ = workspace;
+
+  /**
+   * @type {!Blockly.Workspace}
+   * @private
+   */
+  this.targetWorkspace_ = targetWorkspace;
+
+  /**
+  * @type {string}
+  * @private
+  */
+  this.text_ = xml.getAttribute('text');
+
+  /**
+   * @type {number}
+   * @private
+   */
+  this.flyoutWidth_ = this.targetWorkspace_.getFlyout().getWidth();
+
+  /**
+   * @type {string}
+   * @private
+   */
+  this.extensionId_ = xml.getAttribute('id');
+
+  /**
+   * Whether this is a label at the top of a category.
+   * @type {boolean}
+   * @private
+   */
+  this.isCategoryLabel_  = true;
+
+  /**
+   * @type {!goog.math.Coordinate}
+   * @private
+   */
+  this.position_ = new goog.math.Coordinate(0, 0);
+};
+goog.inherits(Blockly.FlyoutExtensionCategoryHeader, Blockly.FlyoutButton);
+
+/**
+ * Create the label and button elements.
+ * @return {!Element} The SVG group.
+ */
+Blockly.FlyoutExtensionCategoryHeader.prototype.createDom = function() {
+  var cssClass = 'blocklyFlyoutLabel';
+
+  this.svgGroup_ = Blockly.utils.createSvgElement('g', {'class': cssClass},
+      this.workspace_.getCanvas());
+
+  this.addTextSvg(true);
+
+  this.setStatus(Blockly.StatusButtonState.NOT_READY);
+
+  var statusButtonWidth = 25;
+  var marginX = 15;
+  var marginY = 10;
+
+  var statusButtonX = (this.flyoutWidth_ - statusButtonWidth - marginX) / this.workspace_.scale;
+
+  if (this.imageSrc_) {
+    /** @type {SVGElement} */
+    this.imageElement_ = Blockly.utils.createSvgElement(
+        'image',
+        {
+          'class': 'blocklyFlyoutButton',
+          'height': statusButtonWidth + 'px',
+          'width': statusButtonWidth + 'px',
+          'x': statusButtonX + 'px',
+          'y': marginY + 'px'
+        },
+        this.svgGroup_);
+    this.setImageSrc(this.imageSrc_);
+  }
+
+  this.callback_ = Blockly.statusButtonCallback.bind(this, this.extensionId_);
+
+  this.mouseUpWrapper_ = Blockly.bindEventWithChecks_(this.imageElement_, 'mouseup',
+      this, this.onMouseUp_);
+  return this.svgGroup_;
+};
+
+/**
+ * Set the image on the status button using a status string.
+ * @param {string} status The status string.
+ */
+Blockly.FlyoutExtensionCategoryHeader.prototype.setStatus = function(status) {
+  var basePath = Blockly.mainWorkspace.options.pathToMedia;
+  if (status == Blockly.StatusButtonState.READY) {
+    this.setImageSrc(basePath + 'status-ready.svg');
+  }
+  if (status == Blockly.StatusButtonState.NOT_READY) {
+    this.setImageSrc(basePath + 'status-not-ready.svg');
+  }
+};
+
+/**
+ * Set the source URL of the image for the button.
+ * @param {?string} src New source.
+ * @package
+ */
+Blockly.FlyoutExtensionCategoryHeader.prototype.setImageSrc = function(src) {
+  if (src === null) {
+    // No change if null.
+    return;
+  }
+  this.imageSrc_ = src;
+  if (this.imageElement_) {
+    this.imageElement_.setAttributeNS('http://www.w3.org/1999/xlink',
+        'xlink:href', this.imageSrc_ || '');
+  }
+};

--- a/core/flyout_extension_category_header.js
+++ b/core/flyout_extension_category_header.js
@@ -19,7 +19,8 @@
  */
 
 /**
- * @fileoverview Class for a button in the flyout that displays an image.
+ * @fileoverview Class for a category header in the flyout for Scratch
+ * extensions which can display a textual label and a status button.
  * @author ericr@media.mit.edu (Eric Rosenbaum)
  */
 'use strict';
@@ -29,11 +30,12 @@ goog.provide('Blockly.FlyoutExtensionCategoryHeader');
 goog.require('Blockly.FlyoutButton');
 
 /**
- * Class for a button in the flyout that displays an image.
+ * Class for a category header in the flyout for Scratch extensions which can
+ * display a textual label and a status button.
  * @param {!Blockly.WorkspaceSvg} workspace The workspace in which to place this
- *     button.
+ *     header.
  * @param {!Blockly.WorkspaceSvg} targetWorkspace The flyout's target workspace.
- * @param {!Element} xml The XML specifying the button.
+ * @param {!Element} xml The XML specifying the header.
  * @constructor
  */
 Blockly.FlyoutExtensionCategoryHeader = function(workspace, targetWorkspace, xml) {
@@ -71,7 +73,7 @@ Blockly.FlyoutExtensionCategoryHeader = function(workspace, targetWorkspace, xml
    * @type {boolean}
    * @private
    */
-  this.isCategoryLabel_  = true;
+  this.isCategoryLabel_ = true;
 
   /**
    * @type {!goog.math.Coordinate}
@@ -125,7 +127,7 @@ Blockly.FlyoutExtensionCategoryHeader.prototype.createDom = function() {
 
 /**
  * Set the image on the status button using a status string.
- * @param {string} status The status string.
+ * @param {Blockly.StatusButtonState} status The status string.
  */
 Blockly.FlyoutExtensionCategoryHeader.prototype.setStatus = function(status) {
   var basePath = Blockly.mainWorkspace.options.pathToMedia;

--- a/core/flyout_extension_category_header.js
+++ b/core/flyout_extension_category_header.js
@@ -63,9 +63,8 @@ Blockly.FlyoutExtensionCategoryHeader = function(workspace, targetWorkspace, xml
 
   /**
    * @type {string}
-   * @private
    */
-  this.extensionId_ = xml.getAttribute('id');
+  this.extensionId = xml.getAttribute('id');
 
   /**
    * Whether this is a label at the top of a category.
@@ -117,7 +116,7 @@ Blockly.FlyoutExtensionCategoryHeader.prototype.createDom = function() {
     this.setImageSrc(this.imageSrc_);
   }
 
-  this.callback_ = Blockly.statusButtonCallback.bind(this, this.extensionId_);
+  this.callback_ = Blockly.statusButtonCallback.bind(this, this.extensionId);
 
   this.mouseUpWrapper_ = Blockly.bindEventWithChecks_(this.imageElement_, 'mouseup',
       this, this.onMouseUp_);

--- a/core/flyout_extension_category_header.js
+++ b/core/flyout_extension_category_header.js
@@ -36,26 +36,12 @@ goog.require('Blockly.FlyoutButton');
  *     header.
  * @param {!Blockly.WorkspaceSvg} targetWorkspace The flyout's target workspace.
  * @param {!Element} xml The XML specifying the header.
+ * @extends {Blockly.FlyoutButton}
  * @constructor
  */
 Blockly.FlyoutExtensionCategoryHeader = function(workspace, targetWorkspace, xml) {
-  /**
-   * @type {!Blockly.WorkspaceSvg}
-   * @private
-   */
-  this.workspace_ = workspace;
 
-  /**
-   * @type {!Blockly.Workspace}
-   * @private
-   */
-  this.targetWorkspace_ = targetWorkspace;
-
-  /**
-  * @type {string}
-  * @private
-  */
-  this.text_ = xml.getAttribute('text');
+  this.init(workspace, targetWorkspace, xml, false);
 
   /**
    * @type {number}
@@ -74,12 +60,6 @@ Blockly.FlyoutExtensionCategoryHeader = function(workspace, targetWorkspace, xml
    * @private
    */
   this.isCategoryLabel_ = true;
-
-  /**
-   * @type {!goog.math.Coordinate}
-   * @private
-   */
-  this.position_ = new goog.math.Coordinate(0, 0);
 };
 goog.inherits(Blockly.FlyoutExtensionCategoryHeader, Blockly.FlyoutButton);
 

--- a/core/toolbox.js
+++ b/core/toolbox.js
@@ -199,10 +199,13 @@ Blockly.Toolbox.prototype.showAll_ = function() {
 
     // create a label node to go at the top of the category
     var labelString = '<xml><label text="' + category.name_ + '"' +
+      ' id="' + category.id_ + '"' +
       ' category-label="true"' +
+      ' showStatusButton="' + category.showStatusButton_ + '"' +
       ' web-class="categoryLabel">' +
       '</label></xml>';
     var labelXML = Blockly.Xml.textToDom(labelString);
+
     allContents.push(labelXML.firstChild);
 
     allContents = allContents.concat(category.getContents());
@@ -660,6 +663,7 @@ Blockly.Toolbox.Category = function(parent, parentHtml, domTree) {
   this.setColour(domTree);
   this.custom_ = domTree.getAttribute('custom');
   this.iconURI_ = domTree.getAttribute('iconURI');
+  this.showStatusButton_ = domTree.getAttribute('showStatusButton');
   this.contents_ = [];
   if (!this.custom_) {
     this.parseContents_(domTree);

--- a/media/status-not-ready.svg
+++ b/media/status-not-ready.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 21.0.2, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 20 20" style="enable-background:new 0 0 20 20;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#FF8C1A;}
+	.st1{fill:#FFFFFF;}
+</style>
+<circle class="st0" cx="10" cy="10" r="8.5"/>
+<path class="st1" d="M9.1,10.6l-0.3-3C8.7,7,8.6,6.6,8.6,6.4c0-0.3,0.2-0.6,0.5-0.8c0.3-0.2,0.7-0.3,1.2-0.3c0.6,0,1,0.1,1.2,0.4
+	c0.2,0.2,0.3,0.6,0.3,1.1c0,0.3,0,0.6-0.1,0.8l-0.5,3.1c-0.1,0.4-0.2,0.7-0.3,0.8c-0.2,0.2-0.4,0.3-0.8,0.3c-0.4,0-0.7-0.1-0.8-0.3
+	C9.2,11.3,9.1,11,9.1,10.6z M10.3,14.8c-0.4,0-0.8-0.1-1.1-0.2c-0.3-0.2-0.5-0.4-0.5-0.7c0-0.3,0.2-0.5,0.5-0.7
+	c0.3-0.2,0.7-0.3,1.1-0.3s0.8,0.1,1.2,0.3s0.5,0.4,0.5,0.7c0,0.3-0.2,0.5-0.5,0.7C11.1,14.7,10.7,14.8,10.3,14.8z"/>
+</svg>

--- a/media/status-ready.svg
+++ b/media/status-ready.svg
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 21.0.2, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 20 20" style="enable-background:new 0 0 20 20;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#FF8C1A;}
+	.st1{fill:#FFFFFF;}
+	.st2{fill:#0FBD8C;}
+</style>
+<g id="Layer_1">
+	<circle class="st0" cx="10" cy="10" r="8.5"/>
+	<path class="st1" d="M9.1,10.6l-0.3-3C8.7,7,8.6,6.6,8.6,6.4c0-0.3,0.2-0.6,0.5-0.8c0.3-0.2,0.7-0.3,1.2-0.3c0.6,0,1,0.1,1.2,0.4
+		c0.2,0.2,0.3,0.6,0.3,1.1c0,0.3,0,0.6-0.1,0.8l-0.5,3.1c-0.1,0.4-0.2,0.7-0.3,0.8c-0.2,0.2-0.4,0.3-0.8,0.3c-0.4,0-0.7-0.1-0.8-0.3
+		C9.2,11.3,9.1,11,9.1,10.6z M10.3,14.8c-0.4,0-0.8-0.1-1.1-0.2c-0.3-0.2-0.5-0.4-0.5-0.7c0-0.3,0.2-0.5,0.5-0.7
+		c0.3-0.2,0.7-0.3,1.1-0.3s0.8,0.1,1.2,0.3s0.5,0.4,0.5,0.7c0,0.3-0.2,0.5-0.5,0.7C11.1,14.7,10.7,14.8,10.3,14.8z"/>
+</g>
+<g id="Layer_2">
+	<circle class="st2" cx="10" cy="10" r="8.5"/>
+</g>
+</svg>


### PR DESCRIPTION
Adds a new class that extends Flyout Button called FlyoutExtensionCategoryHeader. 

If an extension category XML includes `showStatusButton = "true"`, then instead of a label at the top of the category, put this new header that includes the text label and a button that serves both as a status indicator for device connectivity, and a button to launch the Scratch GUI's device connection modal. There's a global function updateStatusButton that the GUI will use to update it.

As part of the work I modified FlyoutButton to use a helper function to add its text SVG.

Notes:

- I tried but was not quickly able to make the new text SVG of the label layout exactly right in RTL, so that will have to wait for future work. 
- Ideally this header would support additional buttons (which we may wish to add in the future), enabled by additional flags in the XML, but that will also have to wait for future work.
- No alt text on the button images yet