### PR TITLE
Add menu option for loudness in "when > _" hat block

### DIFF
--- a/blocks_vertical/event.js
+++ b/blocks_vertical/event.js
@@ -182,8 +182,8 @@ Blockly.Blocks['event_whengreaterthan'] = {
           "type": "field_dropdown",
           "name": "WHENGREATERTHANMENU",
           "options": [
-            [Blockly.Msg.EVENT_WHENGREATERTHAN_TIMER, 'TIMER'],
-            [Blockly.Msg.EVENT_WHENGREATERTHAN_LOUDNESS, 'LOUDNESS']
+            [Blockly.Msg.EVENT_WHENGREATERTHAN_LOUDNESS, 'LOUDNESS'],
+            [Blockly.Msg.EVENT_WHENGREATERTHAN_TIMER, 'TIMER']
           ]
         },
         {

--- a/blocks_vertical/event.js
+++ b/blocks_vertical/event.js
@@ -182,7 +182,8 @@ Blockly.Blocks['event_whengreaterthan'] = {
           "type": "field_dropdown",
           "name": "WHENGREATERTHANMENU",
           "options": [
-            [Blockly.Msg.EVENT_WHENGREATERTHAN_TIMER, 'TIMER']
+            [Blockly.Msg.EVENT_WHENGREATERTHAN_TIMER, 'TIMER'],
+            [Blockly.Msg.EVENT_WHENGREATERTHAN_LOUDNESS, 'LOUDNESS']
           ]
         },
         {

--- a/msg/messages.js
+++ b/msg/messages.js
@@ -83,6 +83,7 @@ Blockly.Msg.EVENT_WHENBROADCASTRECEIVED = 'when I receive %1';
 Blockly.Msg.EVENT_WHENBACKDROPSWITCHESTO = 'when backdrop switches to %1';
 Blockly.Msg.EVENT_WHENGREATERTHAN = 'when %1 > %2';
 Blockly.Msg.EVENT_WHENGREATERTHAN_TIMER = 'timer';
+Blockly.Msg.EVENT_WHENGREATERTHAN_LOUDNESS = 'loudness';
 Blockly.Msg.EVENT_BROADCAST = 'broadcast %1';
 Blockly.Msg.EVENT_BROADCASTANDWAIT = 'broadcast %1 and wait';
 Blockly.Msg.EVENT_WHENKEYPRESSED = 'when %1 key pressed';


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Block side of resolving https://github.com/LLK/scratch-vm/issues/338

### Proposed Changes

_Describe what this Pull Request does_

Add a menu item for loudness to the "when >" hat, add a new message entry for this string, and make loudness the default menu item like in scratch 2
