### PR TITLE
Change the extension button status so it can be kept up-to-date.

### DIFF
--- a/core/blockly.js
+++ b/core/blockly.js
@@ -385,18 +385,14 @@ Blockly.statusButtonCallback = function(id) {
 };
 
 /**
- * Update the visual state of a status button in an extension category header.
+ * Refresh the visual state of a status button in all extension category headers.
  * @param {Blockly.Workspace} workspace A workspace.
- * @param {string} id An extension id.
- * @param {Blockly.StatusButtonState} newStatus the new state for the button.
  */
-Blockly.updateStatusButton = function(workspace, id, newStatus) {
+Blockly.refreshStatusButtons = function(workspace) {
   var buttons = workspace.getFlyout().buttons_;
   for (var i = 0; i < buttons.length; i++) {
     if (buttons[i] instanceof Blockly.FlyoutExtensionCategoryHeader) {
-      if (buttons[i].extensionId == id) {
-        buttons[i].setStatus(newStatus);
-      }
+      buttons[i].refreshStatus();
     }
   }
 };

--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -541,6 +541,7 @@ Blockly.Flyout.prototype.show = function(xmlList) {
         var curButton = new Blockly.FlyoutExtensionCategoryHeader(this.workspace_,
             this.targetWorkspace_, xml);
         contents.push({type: 'button', button: curButton});
+        gaps.push(default_gap);
       } else if (tagName == 'BUTTON' || tagName == 'LABEL') {
         // Labels behave the same as buttons, but are styled differently.
         var isLabel = tagName == 'LABEL';

--- a/core/flyout_extension_category_header.js
+++ b/core/flyout_extension_category_header.js
@@ -75,7 +75,7 @@ Blockly.FlyoutExtensionCategoryHeader.prototype.createDom = function() {
 
   this.addTextSvg(true);
 
-  this.setStatus(Blockly.StatusButtonState.NOT_READY);
+  this.refreshStatus();
 
   var statusButtonWidth = 25;
   var marginX = 15;
@@ -109,7 +109,8 @@ Blockly.FlyoutExtensionCategoryHeader.prototype.createDom = function() {
  * Set the image on the status button using a status string.
  * @param {Blockly.StatusButtonState} status The status string.
  */
-Blockly.FlyoutExtensionCategoryHeader.prototype.setStatus = function(status) {
+Blockly.FlyoutExtensionCategoryHeader.prototype.refreshStatus = function(status) {
+  var status = Blockly.FlyoutExtensionCategoryHeader.getExtensionState(this.extensionId);
   var basePath = Blockly.mainWorkspace.options.pathToMedia;
   if (status == Blockly.StatusButtonState.READY) {
     this.setImageSrc(basePath + 'status-ready.svg');
@@ -125,8 +126,8 @@ Blockly.FlyoutExtensionCategoryHeader.prototype.setStatus = function(status) {
  * @package
  */
 Blockly.FlyoutExtensionCategoryHeader.prototype.setImageSrc = function(src) {
-  if (src === null) {
-    // No change if null.
+  if (src === null || this.imageSrc_ === src) {
+    // No change if null or already set.
     return;
   }
   this.imageSrc_ = src;
@@ -134,4 +135,14 @@ Blockly.FlyoutExtensionCategoryHeader.prototype.setImageSrc = function(src) {
     this.imageElement_.setAttributeNS('http://www.w3.org/1999/xlink',
         'xlink:href', this.imageSrc_ || '');
   }
+};
+
+/**
+ * Gets the extension state. Overridden externally.
+ * @param {string} extensionId The ID of the extension in question.
+ * @return {Blockly.StatusButtonState} The state of the extension.
+ * @public
+ */
+Blockly.FlyoutExtensionCategoryHeader.getExtensionState = function(/* extensionId */) {
+  return Blockly.StatusButtonState.NOT_READY;
 };


### PR DESCRIPTION
Instead of making a public API to set the status, make a public API for registering how to get the status, and then make a way to cause all extension buttons to refresh using that API

Part of fixing https://github.com/LLK/scratch-gui/issues/2541 and https://github.com/LLK/scratch-gui/issues/2542, but will need to be updated in the GUI as well.