### PR TITLE
Separate updating translations from generating src.

### DIFF
--- a/core/scratch_msgs.js
+++ b/core/scratch_msgs.js
@@ -55,7 +55,7 @@ Blockly.ScratchMsgs.currentLocale_ = 'en';
 Blockly.ScratchMsgs.setLocale = function(locale) {
   if (Object.keys(Blockly.ScratchMsgs.locales).includes(locale)) {
     Blockly.ScratchMsgs.currentLocale_ = locale;
-    Blockly.Msg = Blockly.ScratchMsgs.locales[locale];
+    Blockly.Msg = Object.assign({}, Blockly.Msg, Blockly.ScratchMsgs.locales[locale]);
   } else {
     // keep current locale
     console.warn('Ignoring unrecognized locale: ' + locale);

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "test:messages": "node i18n/js_to_json.js",
     "test": "npm run test:lint && npm run test:messages && npm run test:setup && npm run test:unit",
     "version": "json -f package.json -I -e \"this.repository.sha = '$(git log -n1 --pretty=format:%H)'\"",
-    "translate": "npm run test:messages && node i18n/json_to_js.js && node i18n/create_scratch_msgs.js"
+    "translate": "npm run test:messages && node i18n/json_to_js.js",
+    "translate:update":  "node i18n/create_scratch_msgs.js"
   },
   "dependencies": {
     "exports-loader": "0.6.3",


### PR DESCRIPTION
* setLocale uses Object.assign so any new keys in Blockly.Msg are maintained after changing locale. I.e. if a translation doesn’t exist in the translation English default will be used. 
In theory, it could end up with something other than English if the key is in one translation, but not another. However, it’s unlikely as we’re pulling the translations from transifex and either they will all have the key (if the key exists in the `en.json` source on transifex), or none of them will have the key.

* translate script only generates `en` sources.
* translate:update script generates new scratch_msgs.js file. It will fail if the keys in the downloaded files don’t match the ones in messages.

