### PR TITLE
Log warning instead of throwing error on variable conflicts

### DIFF
--- a/core/variable_map.js
+++ b/core/variable_map.js
@@ -182,15 +182,22 @@ Blockly.VariableMap.prototype.createVariable = function(name,
   var variable = this.getVariable(name, opt_type);
   if (variable) {
     if (opt_id && variable.getId() != opt_id) {
-      throw Error('Variable "' + name + '" is already in use and its id is "'
+      // There is a variable conflict. Variable conflicts should be eliminated
+      // in the scratch-vm, or before we get to this point,
+      // so log a warning, because throwing an error crashes projects.
+      console.warn('Variable "' + name + '" is already in use and its id is "'
                   + variable.getId() + '" which conflicts with the passed in ' +
                   'id, "' + opt_id + '".');
     }
     // The variable already exists and has the same ID.
     return variable;
   }
-  if (opt_id && this.getVariableById(opt_id)) {
-    throw Error('Variable id, "' + opt_id + '", is already in use.');
+  if (opt_id) {
+    variable = this.getVariableById(opt_id);
+    if (variable) {
+      console.warn('Variable id, "' + opt_id + '", is already in use.');
+      return variable;
+    }
   }
   opt_id = opt_id || Blockly.utils.genUid();
   opt_type = opt_type || '';


### PR DESCRIPTION
### Resolves

Prevents variable conflicts from causing user-facing possibly fatal errors.

### Proposed Changes

Log a warning when a variable conflict occurs instead of throwing an error. When an error is thrown, it makes blocks in the project disappear from the workspace or eventually makes whole projects crash. Instead we should log a warning so that the situation causing the variable conflict can be noted and resolved in scratch-vm.

### Reason for Changes

Helps to lessen the repercussions of variable conflicts that are not yet resolved e.g. in the following two issues:

LLK/scratch-gui#2180
LLK/scratch-gui#2094

### Test Coverage

Manually tested the two issues mentioned above.
