### PR TITLE
Separate local and global variables in block palette

### DIFF
--- a/core/data_category.js
+++ b/core/data_category.js
@@ -42,13 +42,39 @@ goog.require('Blockly.Workspace');
  */
 Blockly.DataCategory = function(workspace) {
   var variableModelList = workspace.getVariablesOfType('');
-  variableModelList.sort(Blockly.VariableModel.compareByName);
+
+  var globalVariableList = variableModelList.filter(function(entry) {
+    return !entry.isLocal;
+  });
+  var localVariableList = variableModelList.filter(function(entry) {
+    return entry.isLocal;
+  });
+
+  globalVariableList.sort(Blockly.VariableModel.compareByName);
+  localVariableList.sort(Blockly.VariableModel.compareByName);
+
   var xmlList = [];
 
   Blockly.DataCategory.addCreateButton(xmlList, workspace, 'VARIABLE');
 
-  for (var i = 0; i < variableModelList.length; i++) {
-    Blockly.DataCategory.addDataVariable(xmlList, variableModelList[i]);
+  if (globalVariableList.length > 0) {
+    Blockly.DataCategory.addLabel(xmlList, Blockly.Msg.FOR_ALL_SPRITES + ':');
+  }
+
+  for (var i = 0; i < globalVariableList.length; i++) {
+    Blockly.DataCategory.addDataVariable(xmlList, globalVariableList[i]);
+  }
+
+  if (globalVariableList.length > 0) {
+    xmlList[xmlList.length - 1].setAttribute('gap', 24);
+  }
+
+  if (localVariableList.length > 0) {
+    Blockly.DataCategory.addLabel(xmlList, Blockly.Msg.FOR_THIS_SPRITE_ONLY + ':');
+  }
+
+  for (var i = 0; i < localVariableList.length; i++) {
+    Blockly.DataCategory.addDataVariable(xmlList, localVariableList[i]);
   }
 
   if (variableModelList.length > 0) {
@@ -438,6 +464,18 @@ Blockly.DataCategory.addBlock = function(xmlList, variable, blockType,
     xmlList.push(block);
   }
 };
+
+/**
+ * Construct a flyout label with the given text tag. Add the label to the given
+ *     xmlList.
+ * @param {!Array.<!Element>} xmlList Array of XML block elements.
+ * @param {string} text Text content of the label.
+ */
+Blockly.DataCategory.addLabel = function(xmlList, text) {
+  var labelText = '<xml><label text="' + text + '"></label></xml>';
+  var label = Blockly.Xml.textToDom(labelText).firstChild;
+  xmlList.push(label);
+}
 
 /**
  * Create the text representation of a value dom element with a shadow of the

--- a/core/data_category.js
+++ b/core/data_category.js
@@ -475,7 +475,7 @@ Blockly.DataCategory.addLabel = function(xmlList, text) {
   var labelText = '<xml><label text="' + text + '"></label></xml>';
   var label = Blockly.Xml.textToDom(labelText).firstChild;
   xmlList.push(label);
-}
+};
 
 /**
  * Create the text representation of a value dom element with a shadow of the

--- a/core/data_category.js
+++ b/core/data_category.js
@@ -449,7 +449,7 @@ Blockly.DataCategory.addLabel = function(xmlList, text) {
  * Construct variable blocks from the given variable model list, with global
  *     (for all sprites) and local (for this sprite only) variables separated
  *     into labeled groups. Add the blocks and labels to the given xmlList.
- * @param {!Array.<!Element}> xmlList Array of XML block elements.
+ * @param {!Array.<!Element>} xmlList Array of XML block elements.
  * @param {!Array.<!Blockly.VariableModel>} variableModelList List of variable
  *     models to create variable blocks from.
  * @param {boolean} forLists Whether or not the variables are lists. (This

--- a/core/data_category.js
+++ b/core/data_category.js
@@ -41,41 +41,12 @@ goog.require('Blockly.Workspace');
  * @return {!Array.<!Element>} Array of XML block elements.
  */
 Blockly.DataCategory = function(workspace) {
-  var variableModelList = workspace.getVariablesOfType('');
-
-  var globalVariableList = variableModelList.filter(function(entry) {
-    return !entry.isLocal;
-  });
-  var localVariableList = variableModelList.filter(function(entry) {
-    return entry.isLocal;
-  });
-
-  globalVariableList.sort(Blockly.VariableModel.compareByName);
-  localVariableList.sort(Blockly.VariableModel.compareByName);
-
   var xmlList = [];
+  var variableModelList;
 
   Blockly.DataCategory.addCreateButton(xmlList, workspace, 'VARIABLE');
-
-  if (globalVariableList.length > 0) {
-    Blockly.DataCategory.addLabel(xmlList, Blockly.Msg.FOR_ALL_SPRITES + ':');
-  }
-
-  for (var i = 0; i < globalVariableList.length; i++) {
-    Blockly.DataCategory.addDataVariable(xmlList, globalVariableList[i]);
-  }
-
-  if (globalVariableList.length > 0) {
-    xmlList[xmlList.length - 1].setAttribute('gap', 24);
-  }
-
-  if (localVariableList.length > 0) {
-    Blockly.DataCategory.addLabel(xmlList, Blockly.Msg.FOR_THIS_SPRITE_ONLY + ':');
-  }
-
-  for (var i = 0; i < localVariableList.length; i++) {
-    Blockly.DataCategory.addDataVariable(xmlList, localVariableList[i]);
-  }
+  variableModelList = workspace.getVariablesOfType('');
+  Blockly.DataCategory.buildCategory(xmlList, variableModelList, false);
 
   if (variableModelList.length > 0) {
     xmlList[xmlList.length - 1].setAttribute('gap', 24);
@@ -90,10 +61,7 @@ Blockly.DataCategory = function(workspace) {
   // Now add list variables to the flyout
   Blockly.DataCategory.addCreateButton(xmlList, workspace, 'LIST');
   variableModelList = workspace.getVariablesOfType(Blockly.LIST_VARIABLE_TYPE);
-  variableModelList.sort(Blockly.VariableModel.compareByName);
-  for (var i = 0; i < variableModelList.length; i++) {
-    Blockly.DataCategory.addDataList(xmlList, variableModelList[i]);
-  }
+  Blockly.DataCategory.buildCategory(xmlList, variableModelList, true);
 
   if (variableModelList.length > 0) {
     xmlList[xmlList.length - 1].setAttribute('gap', 24);
@@ -475,6 +443,50 @@ Blockly.DataCategory.addLabel = function(xmlList, text) {
   var labelText = '<xml><label text="' + text + '"></label></xml>';
   var label = Blockly.Xml.textToDom(labelText).firstChild;
   xmlList.push(label);
+};
+
+/**
+ * Construct variable blocks from the given variable model list, with global
+ *     (for all sprites) and local (for this sprite only) variables separated
+ *     into labeled groups. Add the blocks and labels to the given xmlList.
+ * @param {!Array.<!Element}> xmlList Array of XML block elements.
+ * @param {!Array.<!Blockly.VariableModel>} variableModelList List of variable
+ *     models to create variable blocks from.
+ * @param {boolean} forLists Whether or not the variables are lists. (This
+ *     determines whether "variable" or "list" blocks are created.)
+ */
+Blockly.DataCategory.addVariableBlocks = function(xmlList, variableModelList, forLists) {
+  var globalVariableList = variableModelList.filter(function(entry) {
+    return !entry.isLocal;
+  });
+  var localVariableList = variableModelList.filter(function(entry) {
+    return entry.isLocal;
+  });
+
+  globalVariableList.sort(Blockly.VariableModel.compareByName);
+  localVariableList.sort(Blockly.VariableModel.compareByName);
+
+  // Helper function to add the blocks for all the variables in the passed array.
+  var addVariables = function(array) {
+    for (var i = 0; i < array.length; i++) {
+      if (forLists) {
+        Blockly.DataCategory.addDataList(xmlList, array[i]);
+      } else {
+        Blockly.DataCategory.addDataVariable(xmlList, array[i]);
+      }
+    }
+  };
+
+  if (globalVariableList.length > 0) {
+    Blockly.DataCategory.addLabel(xmlList, Blockly.Msg.FOR_ALL_SPRITES + ':');
+    addVariables(globalVariableList);
+    xmlList[xmlList.length - 1].setAttribute('gap', 24);
+  }
+
+  if (localVariableList.length > 0) {
+    Blockly.DataCategory.addLabel(xmlList, Blockly.Msg.FOR_THIS_SPRITE_ONLY + ':');
+    addVariables(localVariableList);
+  }
 };
 
 /**

--- a/core/data_category.js
+++ b/core/data_category.js
@@ -46,7 +46,7 @@ Blockly.DataCategory = function(workspace) {
 
   Blockly.DataCategory.addCreateButton(xmlList, workspace, 'VARIABLE');
   variableModelList = workspace.getVariablesOfType('');
-  Blockly.DataCategory.buildCategory(xmlList, variableModelList, false);
+  Blockly.DataCategory.addVariableBlocks(xmlList, variableModelList, 'VARIABLE');
 
   if (variableModelList.length > 0) {
     xmlList[xmlList.length - 1].setAttribute('gap', 24);
@@ -61,7 +61,7 @@ Blockly.DataCategory = function(workspace) {
   // Now add list variables to the flyout
   Blockly.DataCategory.addCreateButton(xmlList, workspace, 'LIST');
   variableModelList = workspace.getVariablesOfType(Blockly.LIST_VARIABLE_TYPE);
-  Blockly.DataCategory.buildCategory(xmlList, variableModelList, true);
+  Blockly.DataCategory.addVariableBlocks(xmlList, variableModelList, 'LIST');
 
   if (variableModelList.length > 0) {
     xmlList[xmlList.length - 1].setAttribute('gap', 24);
@@ -452,10 +452,10 @@ Blockly.DataCategory.addLabel = function(xmlList, text) {
  * @param {!Array.<!Element>} xmlList Array of XML block elements.
  * @param {!Array.<!Blockly.VariableModel>} variableModelList List of variable
  *     models to create variable blocks from.
- * @param {boolean} forLists Whether or not the variables are lists. (This
- *     determines whether "variable" or "list" blocks are created.)
+ * @param {string} type Type of variable this is for. (This determines whether
+ *     "variable" or "list" blocks are created.)
  */
-Blockly.DataCategory.addVariableBlocks = function(xmlList, variableModelList, forLists) {
+Blockly.DataCategory.addVariableBlocks = function(xmlList, variableModelList, type) {
   var globalVariableList = variableModelList.filter(function(entry) {
     return !entry.isLocal;
   });
@@ -469,7 +469,7 @@ Blockly.DataCategory.addVariableBlocks = function(xmlList, variableModelList, fo
   // Helper function to add the blocks for all the variables in the passed array.
   var addVariables = function(array) {
     for (var i = 0; i < array.length; i++) {
-      if (forLists) {
+      if (type === 'LIST') {
         Blockly.DataCategory.addDataList(xmlList, array[i]);
       } else {
         Blockly.DataCategory.addDataVariable(xmlList, array[i]);

--- a/msg/messages.js
+++ b/msg/messages.js
@@ -322,6 +322,8 @@ Blockly.Msg.VARIABLE_ALREADY_EXISTS_FOR_ANOTHER_TYPE = 'A variable named "%1" al
 Blockly.Msg.DELETE_VARIABLE_CONFIRMATION = 'Delete %1 uses of the "%2" variable?';
 Blockly.Msg.CANNOT_DELETE_VARIABLE_PROCEDURE = 'Can\'t delete the variable "%1" because it\'s part of the definition of the function "%2"';
 Blockly.Msg.DELETE_VARIABLE = 'Delete the "%1" variable';
+Blockly.Msg.FOR_ALL_SPRITES = 'For all sprites';
+Blockly.Msg.FOR_THIS_SPRITE_ONLY = 'For this sprite only';
 
 // Custom Procedures
 // @todo Remove these once fully managed by Scratch VM / Scratch GUI


### PR DESCRIPTION
Resolves #1636.

![The Variables category, showing: "For all sprites: Global A, Global B. For this sprite only: Local A, Local B."](https://user-images.githubusercontent.com/9948030/43030874-3d9e67ba-8c6d-11e8-814f-9d960eb19aaa.png)

This PR will still need a bit of work, but here is a first draft, to prompt code and design discussion.

### Design question

**Which labels should show up?** Here are the two main options to consider:

1. Given there is a global variable, only show the "For all sprites" label when there is *also* at least one local variable.
2. Make labels show up according to whether there are any variables of the particular scope. That is, if there are any local variables, show the label "For this sprite only", and if there are any global variables, show the label "For all sprites".
3. (Alternatively, always show both labels, alongside the text "None" when there are no variables of a particular scope, or never show either label, as in Scratch 1.4.)

Those (first) two options basically combat each other in a crucial way. The first takes the perspective of, "Don't expose the user to potentially confusing/overwhelming behavior." The second takes, "Do expose the user to potentially interesting/useful/educational behavior." To make these clear, see a case of a beginning user creating a variable. They click on "Make a Variable", type a name (like Fruit), and leave "For all sprites" selected, since it's the default one and they aren't sure what the difference between the options is. Now assume we go with option 2 above. They will, immediately and throughout working on their project, see the label "For all sprites". They might respond in one of three ways:

* Confusion: Why did I make this sprite "for all sprites"? Does that matter? Should I be worried? Do I have to know the difference between "for all sprites" and "for this sprite only"?
* Interest: All the same questions as above, but in an "I want to learn" / "I am curious" perspective!
* Disregard: Just ignoring it.

I'm inclined towards the second option, because I think the vast majority of users will either ignore the label or be interested in the difference between "for all sprites" and "for this sprite only". I suppose a few might get confused or overwhelmed by the new label (maybe users with experience in 2.0 who never even paid attention to the local/global option). But it's not really that much of an extra load in the UI - that is, to the human using the UI - and it has a fairly obvious meaning, seeing as it's identical in language to the choice selected in the "make a variable" prompt.

As I said, I think option 2 is best here, but I'm interested in other opinions, if you have one.

### Definitely TODOs

- [ ] Figure out how to deal with the "For this sprite only" and "For all sprites" messages, regarding localization. These are already defined in scratch-gui, but I'm not sure how to access that same translation from scratch-blocks. Temporarily, I've added some messages to `msg/messages.js`.
- [x] Clean up and separate the code for building the variable blocks, in such a way that it's easy to...
- [x] Also do all this for list blocks.
- [ ] In [the screenshot](https://user-images.githubusercontent.com/9948030/43030874-3d9e67ba-8c6d-11e8-814f-9d960eb19aaa.png), the gap between "Global B" and "For this sprite only" seems to be smaller than the one between "Local B" and "set Global A to". This should probably be the other way around.
