### PR TITLE
Add block separators to list category

### DIFF
--- a/core/data_category.js
+++ b/core/data_category.js
@@ -475,6 +475,7 @@ Blockly.DataCategory.createValue = function(valueName, type, value) {
       '</value>';
   return valueField;
 };
+
 /**
  * Construct a block separator. Add the separator to the given xmlList.
  * @param {!Array.<!Element>} xmlList Array of XML block elements.

--- a/core/data_category.js
+++ b/core/data_category.js
@@ -74,14 +74,17 @@ Blockly.DataCategory = function(workspace) {
     var firstVariable = variableModelList[0];
 
     Blockly.DataCategory.addAddToList(xmlList, firstVariable);
+    Blockly.DataCategory.addSep(xmlList);
     Blockly.DataCategory.addDeleteOfList(xmlList, firstVariable);
     Blockly.DataCategory.addDeleteAllOfList(xmlList, firstVariable);
     Blockly.DataCategory.addInsertAtList(xmlList, firstVariable);
     Blockly.DataCategory.addReplaceItemOfList(xmlList, firstVariable);
+    Blockly.DataCategory.addSep(xmlList);
     Blockly.DataCategory.addItemOfList(xmlList, firstVariable);
     Blockly.DataCategory.addItemNumberOfList(xmlList, firstVariable);
     Blockly.DataCategory.addLengthOfList(xmlList, firstVariable);
     Blockly.DataCategory.addListContainsItem(xmlList, firstVariable);
+    Blockly.DataCategory.addSep(xmlList);
     Blockly.DataCategory.addShowList(xmlList, firstVariable);
     Blockly.DataCategory.addHideList(xmlList, firstVariable);
   }
@@ -471,4 +474,17 @@ Blockly.DataCategory.createValue = function(valueName, type, value) {
       '</shadow>' +
       '</value>';
   return valueField;
+};
+/**
+ * Construct a block separator. Add the separator to the given xmlList.
+ * @param {!Array.<!Element>} xmlList Array of XML block elements.
+ */
+Blockly.DataCategory.addSep = function(xmlList) {
+    var gap = 36;
+    var sepText = '<xml>' +
+        '<sep gap="' + gap + '"/>' +
+        '</xml>';
+    var sep = Blockly.Xml.textToDom(sepText).firstChild;
+    xmlList.push(sep);
+  }
 };

--- a/core/data_category.js
+++ b/core/data_category.js
@@ -481,10 +481,10 @@ Blockly.DataCategory.createValue = function(valueName, type, value) {
  * @param {!Array.<!Element>} xmlList Array of XML block elements.
  */
 Blockly.DataCategory.addSep = function(xmlList) {
-    var gap = 36;
-    var sepText = '<xml>' +
-        '<sep gap="' + gap + '"/>' +
-        '</xml>';
-    var sep = Blockly.Xml.textToDom(sepText).firstChild;
-    xmlList.push(sep);
+  var gap = 36;
+  var sepText = '<xml>' +
+      '<sep gap="' + gap + '"/>' +
+      '</xml>';
+  var sep = Blockly.Xml.textToDom(sepText).firstChild;
+  xmlList.push(sep);
 };

--- a/core/data_category.js
+++ b/core/data_category.js
@@ -487,5 +487,4 @@ Blockly.DataCategory.addSep = function(xmlList) {
         '</xml>';
     var sep = Blockly.Xml.textToDom(sepText).firstChild;
     xmlList.push(sep);
-  }
 };


### PR DESCRIPTION
### Resolves

Resolves #1645

### Proposed Changes

Adds a method to add separators to the category and places the method in the appropriate places.

### Reason for Changes

Scratch 2.0 has separators in the list category.