### PR TITLE
When opt_noId is specified to true, shadow ids should also be removed.

### DIFF
--- a/core/xml.js
+++ b/core/xml.js
@@ -213,7 +213,13 @@ Blockly.Xml.blockToDom = function(block, opt_noId) {
       }
       var shadow = input.connection.getShadowDom();
       if (shadow && (!childBlock || !childBlock.isShadow())) {
-        container.appendChild(Blockly.Xml.cloneShadow_(shadow));
+        var shadowClone = Blockly.Xml.cloneShadow_(shadow);
+        // Remove the ID from the shadow dom clone if opt_noId
+        // is specified to true.
+        if (opt_noId && shadowClone.getAttribute('id')) {
+          shadowClone.removeAttribute('id');
+        }
+        container.appendChild(shadowClone);
       }
       if (childBlock) {
         container.appendChild(Blockly.Xml.blockToDom(childBlock, opt_noId));


### PR DESCRIPTION
### Resolves

Resolves LLK/scratch-vm#1389

### Proposed Changes

`blockToDom` was not correctly removing ids from the entire block tree when `opt_noId` was specified (e.g. dragging a block outside the workspace). In particular, shadows were being serialized to XML with their IDs. This was resulting in a bug where sharing the love of the same block more than once would result in multiple stacks of blocks referencing the same shadow block. Deleting any of these stacks would result in crashing the workspace.

These changes remove the IDs from the shadow dom being serialized if the `opt_noId` flag is specified.

### Test Coverage

Manual testing in the vertical_playground and the scratch-gui to ensure that shadow IDs are no longer being preserved and the bug referenced in LLK/scratch-vm#1389 is resolved.