### PR TITLE
Throw Errors instead of using goog.asserts

### DIFF
--- a/core/block.js
+++ b/core/block.js
@@ -40,11 +40,11 @@ goog.require('Blockly.FieldLabelSerializable');
 goog.require('Blockly.FieldVariableGetter');
 goog.require('Blockly.Input');
 goog.require('Blockly.Mutator');
+goog.require('Blockly.utils');
 goog.require('Blockly.Warning');
 goog.require('Blockly.Workspace');
 goog.require('Blockly.Xml');
-goog.require('goog.array');
-goog.require('goog.asserts');
+
 goog.require('goog.math.Coordinate');
 goog.require('goog.string');
 
@@ -174,15 +174,16 @@ Blockly.Block = function(workspace, prototypeName, opt_id) {
     /** @type {string} */
     this.type = prototypeName;
     var prototype = Blockly.Blocks[prototypeName];
-    goog.asserts.assertObject(prototype,
-        'Error: Unknown block type "%s".', prototypeName);
+    if (!prototype || typeof prototype != 'object') {
+      throw TypeError('Unknown block type: ' + prototypeName);
+    }
     goog.mixin(this, prototype);
   }
 
   workspace.addTopBlock(this);
 
   // Call an initialization function, if it exists.
-  if (goog.isFunction(this.init)) {
+  if (typeof this.init == 'function') {
     this.init();
   }
   // Record initial inline state.
@@ -205,7 +206,7 @@ Blockly.Block = function(workspace, prototypeName, opt_id) {
 
   }
   // Bind an onchange function, if it exists.
-  if (goog.isFunction(this.onchange)) {
+  if (typeof this.onchange == 'function') {
     this.setOnChange(this.onchange);
   }
 };
@@ -546,14 +547,14 @@ Blockly.Block.prototype.setParent = function(newParent) {
   }
   if (this.parentBlock_) {
     // Remove this block from the old parent's child list.
-    goog.array.remove(this.parentBlock_.childBlocks_, this);
+    Blockly.utils.arrayRemove(this.parentBlock_.childBlocks_, this);
 
     // Disconnect from superior blocks.
     if (this.previousConnection && this.previousConnection.isConnected()) {
-      throw 'Still connected to previous block.';
+      throw Error('Still connected to previous block.');
     }
     if (this.outputConnection && this.outputConnection.isConnected()) {
-      throw 'Still connected to parent block.';
+      throw Error('Still connected to parent block.');
     }
     this.parentBlock_ = null;
     // This block hasn't actually moved on-screen, so there's no need to update
@@ -841,8 +842,8 @@ Blockly.Block.prototype.setColour = function(colour, colourSecondary, colourTert
  * @throws {Error} if onchangeFn is not falsey or a function.
  */
 Blockly.Block.prototype.setOnChange = function(onchangeFn) {
-  if (onchangeFn && !goog.isFunction(onchangeFn)) {
-    throw new Error("onchange must be a function.");
+  if (onchangeFn && typeof onchangeFn != 'function') {
+    throw new Error('onchange must be a function.');
   }
   if (this.onchangeWrapper_) {
     this.workspace.removeChangeListener(this.onchangeWrapper_);
@@ -964,7 +965,9 @@ Blockly.Block.prototype.getFieldValue = function(name) {
  */
 Blockly.Block.prototype.setFieldValue = function(newValue, name) {
   var field = this.getField(name);
-  goog.asserts.assertObject(field, 'Field "%s" not found.', name);
+  if (!field) {
+    throw Error('Field "' + name + '" not found.');
+  }
   field.setValue(newValue);
 };
 
@@ -980,16 +983,20 @@ Blockly.Block.prototype.setPreviousStatement = function(newBoolean, opt_check) {
       opt_check = null;
     }
     if (!this.previousConnection) {
-      goog.asserts.assert(!this.outputConnection,
-          'Remove output connection prior to adding previous connection.');
+      if (this.outputConnection) {
+        throw Error('Remove output connection prior to adding previous ' +
+            'connection.');
+      }
       this.previousConnection =
           this.makeConnection_(Blockly.PREVIOUS_STATEMENT);
     }
     this.previousConnection.setCheck(opt_check);
   } else {
     if (this.previousConnection) {
-      goog.asserts.assert(!this.previousConnection.isConnected(),
-          'Must disconnect previous statement before removing connection.');
+      if (this.previousConnection.isConnected()) {
+        throw Error('Must disconnect previous statement before removing ' +
+            'connection.');
+      }
       this.previousConnection.dispose();
       this.previousConnection = null;
     }
@@ -1013,8 +1020,10 @@ Blockly.Block.prototype.setNextStatement = function(newBoolean, opt_check) {
     this.nextConnection.setCheck(opt_check);
   } else {
     if (this.nextConnection) {
-      goog.asserts.assert(!this.nextConnection.isConnected(),
-          'Must disconnect next statement before removing connection.');
+      if (this.nextConnection.isConnected()) {
+        throw Error('Must disconnect next statement before removing ' +
+            'connection.');
+      }
       this.nextConnection.dispose();
       this.nextConnection = null;
     }
@@ -1034,15 +1043,18 @@ Blockly.Block.prototype.setOutput = function(newBoolean, opt_check) {
       opt_check = null;
     }
     if (!this.outputConnection) {
-      goog.asserts.assert(!this.previousConnection,
-          'Remove previous connection prior to adding output connection.');
+      if (this.previousConnection) {
+        throw Error('Remove previous connection prior to adding output ' +
+            'connection.');
+      }
       this.outputConnection = this.makeConnection_(Blockly.OUTPUT_VALUE);
     }
     this.outputConnection.setCheck(opt_check);
   } else {
     if (this.outputConnection) {
-      goog.asserts.assert(!this.outputConnection.isConnected(),
-          'Must disconnect output value before removing connection.');
+      if (this.outputConnection.isConnected()) {
+        throw Error('Must disconnect output value before removing connection.');
+      }
       this.outputConnection.dispose();
       this.outputConnection = null;
     }
@@ -1168,12 +1180,14 @@ Blockly.Block.prototype.toString = function(opt_maxLength, opt_emptyToken) {
       }
     }
   }
-  text = goog.string.trim(text.join(' ')) || '???';
+  text = text.join(' ').trim() || '???';
   if (opt_maxLength) {
     // TODO: Improve truncation so that text from this block is given priority.
     // E.g. "1+2+3+4+5+6+7+8+9=0" should be "...6+7+8+9=0", not "1+2+3+4+5...".
     // E.g. "1+2+3+4+5=6+7+8+9+0" should be "...4+5=6+7...".
-    text = goog.string.truncate(text, opt_maxLength);
+    if (text.length > opt_maxLength) {
+      text = text.substring(0, opt_maxLength - 3) + '...';
+    }
   }
   return text;
 };
@@ -1217,9 +1231,10 @@ Blockly.Block.prototype.jsonInit = function(json) {
   var warningPrefix = json['type'] ? 'Block "' + json['type'] + '": ' : '';
 
   // Validate inputs.
-  goog.asserts.assert(
-      json['output'] == undefined || json['previousStatement'] == undefined,
-      warningPrefix + 'Must not have both an output and a previousStatement.');
+  if (json['output'] && json['previousStatement']) {
+    throw Error(warningPrefix +
+        'Must not have both an output and a previousStatement.');
+  }
 
   // Set basic properties of block.
   if (json['colour'] !== undefined) {
@@ -1261,9 +1276,11 @@ Blockly.Block.prototype.jsonInit = function(json) {
     var localizedValue = Blockly.utils.replaceMessageReferences(rawValue);
     this.setHelpUrl(localizedValue);
   }
-  if (goog.isString(json['extensions'])) {
-    console.warn('JSON attribute \'extensions\' should be an array of ' +
-      'strings. Found raw string in JSON for \'' + json['type'] + '\' block.');
+  if (typeof json['extensions'] == 'string') {
+    console.warn(
+        warningPrefix + 'JSON attribute \'extensions\' should be an array of' +
+        ' strings. Found raw string in JSON for \'' + json['type'] +
+        '\' block.');
     json['extensions'] = [json['extensions']];  // Correct and continue.
   }
 
@@ -1300,8 +1317,8 @@ Blockly.Block.prototype.jsonInit = function(json) {
  * @param {boolean=} opt_disableCheck Option flag to disable overwrite checks.
  */
 Blockly.Block.prototype.mixin = function(mixinObj, opt_disableCheck) {
-  if (goog.isDef(opt_disableCheck) && !goog.isBoolean(opt_disableCheck)) {
-    throw new Error("opt_disableCheck must be a boolean if provided");
+  if (opt_disableCheck !== undefined && typeof opt_disableCheck != 'boolean') {
+    throw new Error('opt_disableCheck must be a boolean if provided');
   }
   if (!opt_disableCheck) {
     var overwrites = [];
@@ -1393,7 +1410,7 @@ Blockly.Block.prototype.interpolate_ = function(message, args, lastDummyAlign) {
   }
   // Add last dummy input if needed.
   if (elements.length && (typeof elements[elements.length - 1] == 'string' ||
-      goog.string.startsWith(
+      Blockly.utils.startsWith(
           elements[elements.length - 1]['type'], 'field_'))) {
     var dummyInput = {type: 'input_dummy'};
     if (lastDummyAlign) {
@@ -1513,9 +1530,12 @@ Blockly.Block.prototype.moveInputBefore = function(name, refName) {
       }
     }
   }
-  goog.asserts.assert(inputIndex != -1, 'Named input "%s" not found.', name);
-  goog.asserts.assert(
-      refIndex != -1, 'Reference input "%s" not found.', refName);
+  if (inputIndex == -1) {
+    throw Error('Named input "' + name + '" not found.');
+  }
+  if (refIndex == -1) {
+    throw Error('Reference input "' + refName + '" not found.');
+  }
   this.moveNumberedInputBefore(inputIndex, refIndex);
 };
 
@@ -1527,11 +1547,15 @@ Blockly.Block.prototype.moveInputBefore = function(name, refName) {
 Blockly.Block.prototype.moveNumberedInputBefore = function(
     inputIndex, refIndex) {
   // Validate arguments.
-  goog.asserts.assert(inputIndex != refIndex, 'Can\'t move input to itself.');
-  goog.asserts.assert(inputIndex < this.inputList.length,
-      'Input index ' + inputIndex + ' out of bounds.');
-  goog.asserts.assert(refIndex <= this.inputList.length,
-      'Reference input ' + refIndex + ' out of bounds.');
+  if (inputIndex == refIndex) {
+    throw Error('Can\'t move input to itself.');
+  }
+  if (inputIndex >= this.inputList.length) {
+    throw RangeError('Input index ' + inputIndex + ' out of bounds.');
+  }
+  if (refIndex > this.inputList.length) {
+    throw RangeError('Reference input ' + refIndex + ' out of bounds.');
+  }
   // Remove input.
   var input = this.inputList[inputIndex];
   this.inputList.splice(inputIndex, 1);
@@ -1546,7 +1570,7 @@ Blockly.Block.prototype.moveNumberedInputBefore = function(
  * Remove an input from this block.
  * @param {string} name The name of the input.
  * @param {boolean=} opt_quiet True to prevent error if input is not present.
- * @throws {goog.asserts.AssertionError} if the input is not present and
+ * @throws {Error} if the input is not present and
  *     opt_quiet is not true.
  */
 Blockly.Block.prototype.removeInput = function(name, opt_quiet) {
@@ -1569,7 +1593,7 @@ Blockly.Block.prototype.removeInput = function(name, opt_quiet) {
     }
   }
   if (!opt_quiet) {
-    goog.asserts.fail('Input "%s" not found.', name);
+    throw Error('Input not found: ' + name);
   }
 };
 
@@ -1702,7 +1726,9 @@ Blockly.Block.prototype.getRelativeToSurfaceXY = function() {
  * @param {number} dy Vertical offset, in workspace units.
  */
 Blockly.Block.prototype.moveBy = function(dx, dy) {
-  goog.asserts.assert(!this.parentBlock_, 'Block has parent.');
+  if (this.parentBlock_) {
+    throw Error('Block has parent.');
+  }
   var event = new Blockly.Events.BlockMove(this);
   this.xy_.translate(dx, dy);
   event.recordNew();

--- a/core/block_drag_surface.js
+++ b/core/block_drag_surface.js
@@ -31,7 +31,6 @@
 
 goog.provide('Blockly.BlockDragSurfaceSvg');
 goog.require('Blockly.utils');
-goog.require('goog.asserts');
 goog.require('goog.math.Coordinate');
 
 
@@ -179,8 +178,9 @@ Blockly.BlockDragSurfaceSvg.prototype.createDropShadowDom_ = function(defs) {
  * surface.
  */
 Blockly.BlockDragSurfaceSvg.prototype.setBlocksAndShow = function(blocks) {
-  goog.asserts.assert(
-      this.dragGroup_.childNodes.length == 0, 'Already dragging a block.');
+  if (this.dragGroup_.childNodes.length) {
+    throw Error('Already dragging a block.');
+  }
   // appendChild removes the blocks from the previous parent
   this.dragGroup_.appendChild(blocks);
   this.SVG_.style.display = 'block';
@@ -286,8 +286,9 @@ Blockly.BlockDragSurfaceSvg.prototype.clearAndHide = function(opt_newSurface) {
     this.dragGroup_.removeChild(this.getCurrentBlock());
   }
   this.SVG_.style.display = 'none';
-  goog.asserts.assert(
-      this.dragGroup_.childNodes.length == 0, 'Drag group was not cleared.');
+  if (this.dragGroup_.childNodes.length) {
+    throw Error('Drag group was not cleared.');
+  }
   this.surfaceXY_ = null;
 
   // Reset the overflow property back to hidden so that nothing appears outside

--- a/core/block_dragger.js
+++ b/core/block_dragger.js
@@ -33,7 +33,6 @@ goog.require('Blockly.Events.EndBlockDrag');
 goog.require('Blockly.InsertionMarkerManager');
 
 goog.require('goog.math.Coordinate');
-goog.require('goog.asserts');
 
 
 /**

--- a/core/block_events.js
+++ b/core/block_events.js
@@ -300,7 +300,7 @@ Blockly.Events.Delete = function(block) {
     return;  // Blank event to be populated by fromJson.
   }
   if (block.getParent()) {
-    throw 'Connected blocks cannot be deleted.';
+    throw Error('Connected blocks cannot be deleted.');
   }
   Blockly.Events.Delete.superClass_.constructor.call(this, block);
 

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -39,7 +39,6 @@ goog.require('Blockly.Touch');
 goog.require('Blockly.utils');
 
 goog.require('goog.Timer');
-goog.require('goog.asserts');
 goog.require('goog.dom');
 goog.require('goog.math.Coordinate');
 
@@ -144,7 +143,9 @@ Blockly.BlockSvg.INLINE = -1;
  * May be called more than once.
  */
 Blockly.BlockSvg.prototype.initSvg = function() {
-  goog.asserts.assert(this.workspace.rendered, 'Workspace is headless.');
+  if (!this.workspace.rendered) {
+    throw TypeError('Workspace is headless.');
+  }
   if (!this.isInsertionMarker()) { // Insertion markers not allowed to have inputs or icons
     // Input shapes are empty holes drawn when a value input is not connected.
     for (var i = 0, input; input = this.inputList[i]; i++) {
@@ -362,7 +363,9 @@ Blockly.BlockSvg.prototype.getRelativeToSurfaceXY = function() {
  * @param {number} dy Vertical offset in workspace units.
  */
 Blockly.BlockSvg.prototype.moveBy = function(dx, dy) {
-  goog.asserts.assert(!this.parentBlock_, 'Block has parent.');
+  if (this.parentBlock_) {
+    throw Error('Block has parent.');
+  }
   var eventsEnabled = Blockly.Events.isEnabled();
   if (eventsEnabled) {
     var event = new Blockly.Events.BlockMove(this);
@@ -648,7 +651,7 @@ Blockly.BlockSvg.prototype.onMouseDown_ = function(e) {
  * @private
  */
 Blockly.BlockSvg.prototype.showHelp_ = function() {
-  var url = goog.isFunction(this.helpUrl) ? this.helpUrl() : this.helpUrl;
+  var url = (typeof this.helpUrl == 'function') ? this.helpUrl() : this.helpUrl;
   if (url) {
     // @todo rewrite
     alert(url);
@@ -984,7 +987,7 @@ Blockly.BlockSvg.prototype.getCommentText = function() {
 Blockly.BlockSvg.prototype.setCommentText = function(text, commentId,
     commentX, commentY, minimized) {
   var changedState = false;
-  if (goog.isString(text)) {
+  if (typeof text == 'string') {
     if (!this.comment) {
       this.comment = new Blockly.ScratchBlockComment(this, text, commentId,
           commentX, commentY, minimized);
@@ -1000,7 +1003,7 @@ Blockly.BlockSvg.prototype.setCommentText = function(text, commentId,
   }
   if (changedState && this.rendered) {
     this.render();
-    if (goog.isString(text)) {
+    if (typeof text == 'string') {
       this.comment.setVisible(true);
     }
     // Adding or removing a comment icon will cause the block to change shape.
@@ -1049,7 +1052,7 @@ Blockly.BlockSvg.prototype.setWarningText = function(text, opt_id) {
   }
 
   var changedState = false;
-  if (goog.isString(text)) {
+  if (typeof text == 'string') {
     if (!this.warning) {
       this.warning = new Blockly.Warning(this);
       changedState = true;

--- a/core/bubble_dragger.js
+++ b/core/bubble_dragger.js
@@ -31,7 +31,6 @@ goog.require('Blockly.Events.CommentMove');
 goog.require('Blockly.WorkspaceCommentSvg');
 
 goog.require('goog.math.Coordinate');
-goog.require('goog.asserts');
 
 
 /**

--- a/core/connection.js
+++ b/core/connection.js
@@ -28,7 +28,6 @@ goog.provide('Blockly.Connection');
 
 goog.require('Blockly.Events.BlockMove');
 
-goog.require('goog.asserts');
 goog.require('goog.dom');
 
 
@@ -173,7 +172,7 @@ Blockly.Connection.prototype.connect_ = function(childConnection) {
       // Statement blocks may be inserted into the middle of a stack.
       // Split the stack.
       if (!orphanBlock.previousConnection) {
-        throw 'Orphan block does not have a previous connection.';
+        throw Error('Orphan block does not have a previous connection.');
       }
       // Attempt to reattach the orphan at the bottom of the newly inserted
       // block.  Since this block may be a stack, walk down to the end.
@@ -239,7 +238,7 @@ Blockly.Connection.prototype.connect_ = function(childConnection) {
  */
 Blockly.Connection.prototype.dispose = function() {
   if (this.isConnected()) {
-    throw 'Disconnect connection before disposing of it.';
+    throw Error('Disconnect connection before disposing of it.');
   }
   if (this.inDB_) {
     this.db_.removeConnection_(this);
@@ -334,24 +333,24 @@ Blockly.Connection.prototype.checkConnection_ = function(target) {
     case Blockly.Connection.CAN_CONNECT:
       break;
     case Blockly.Connection.REASON_SELF_CONNECTION:
-      throw 'Attempted to connect a block to itself.';
+      throw Error('Attempted to connect a block to itself.');
     case Blockly.Connection.REASON_DIFFERENT_WORKSPACES:
       // Usually this means one block has been deleted.
-      throw 'Blocks not on same workspace.';
+      throw Error('Blocks not on same workspace.');
     case Blockly.Connection.REASON_WRONG_TYPE:
-      throw 'Attempt to connect incompatible types.';
+      throw Error('Attempt to connect incompatible types.');
     case Blockly.Connection.REASON_TARGET_NULL:
-      throw 'Target connection is null.';
+      throw Error('Target connection is null.');
     case Blockly.Connection.REASON_CHECKS_FAILED:
       var msg = 'Connection checks failed. ';
       msg += this + ' expected '  + this.check_ + ', found ' + target.check_;
-      throw msg;
+      throw Error(msg);
     case Blockly.Connection.REASON_SHADOW_PARENT:
-      throw 'Connecting non-shadow to shadow block.';
+      throw Error('Connecting non-shadow to shadow block.');
     case Blockly.Connection.REASON_CUSTOM_PROCEDURE:
       throw 'Trying to replace a shadow on a custom procedure definition.';
     default:
-      throw 'Unknown connection failure: this should never happen!';
+      throw Error('Unknown connection failure: this should never happen!');
   }
 };
 
@@ -480,7 +479,7 @@ Blockly.Connection.prototype.isConnectionAllowed = function(candidate) {
       break;
     }
     default:
-      throw 'Unknown connection type in isConnectionAllowed';
+      throw Error('Unknown connection type in isConnectionAllowed');
   }
 
   // Don't let blocks try to connect to themselves or ones they nest.
@@ -518,7 +517,9 @@ Blockly.Connection.prototype.connect = function(otherConnection) {
  * @private
  */
 Blockly.Connection.connectReciprocally_ = function(first, second) {
-  goog.asserts.assert(first && second, 'Cannot connect null connections.');
+  if (!first || !second) {
+    throw Error('Cannot connect null connections.');
+  }
   first.targetConnection = second;
   second.targetConnection = first;
 };
@@ -552,10 +553,12 @@ Blockly.Connection.singleConnection_ = function(block, orphanBlock) {
  */
 Blockly.Connection.prototype.disconnect = function() {
   var otherConnection = this.targetConnection;
-  goog.asserts.assert(otherConnection, 'Source connection not connected.');
-  goog.asserts.assert(otherConnection.targetConnection == this,
-      'Target connection not connected to source connection.');
-
+  if (!otherConnection) {
+    throw Error('Source connection not connected.');
+  }
+  if (otherConnection.targetConnection != this) {
+    throw Error('Target connection not connected to source connection.');
+  }
   var parentBlock, childBlock, parentConnection;
   if (this.isSuperior()) {
     // Superior block.
@@ -609,7 +612,7 @@ Blockly.Connection.prototype.respawnShadow_ = function() {
     } else if (blockShadow.previousConnection) {
       this.connect(blockShadow.previousConnection);
     } else {
-      throw 'Child block does not have output or previous statement.';
+      throw Error('Child block does not have output or previous statement.');
     }
   }
 };
@@ -669,7 +672,7 @@ Blockly.Connection.prototype.onCheckChanged_ = function() {
 Blockly.Connection.prototype.setCheck = function(check) {
   if (check) {
     // Ensure that check is in an array.
-    if (!goog.isArray(check)) {
+    if (!Array.isArray(check)) {
       check = [check];
     }
     this.check_ = check;

--- a/core/connection_db.js
+++ b/core/connection_db.js
@@ -51,7 +51,7 @@ Blockly.ConnectionDB.constructor = Blockly.ConnectionDB;
  */
 Blockly.ConnectionDB.prototype.addConnection = function(connection) {
   if (connection.inDB_) {
-    throw 'Connection already in database.';
+    throw Error('Connection already in database.');
   }
   if (connection.getSourceBlock().isInFlyout) {
     // Don't bother maintaining a database of connections in a flyout.
@@ -137,11 +137,11 @@ Blockly.ConnectionDB.prototype.findPositionForConnection_ = function(
  */
 Blockly.ConnectionDB.prototype.removeConnection_ = function(connection) {
   if (!connection.inDB_) {
-    throw 'Connection not in database.';
+    throw Error('Connection not in database.');
   }
   var removalIndex = this.findConnection(connection);
   if (removalIndex == -1) {
-    throw 'Unable to find connection in connectionDB.';
+    throw Error('Unable to find connection in connectionDB.');
   }
   connection.inDB_ = false;
   this.splice(removalIndex, 1);

--- a/core/contextmenu.js
+++ b/core/contextmenu.js
@@ -242,7 +242,8 @@ Blockly.ContextMenu.blockDeleteOption = function(block) {
  * @package
  */
 Blockly.ContextMenu.blockHelpOption = function(block) {
-  var url = goog.isFunction(block.helpUrl) ? block.helpUrl() : block.helpUrl;
+  var url = (typeof block.helpUrl == 'function') ?
+      block.helpUrl() : block.helpUrl;
   var helpOption = {
     enabled: !!url,
     text: Blockly.Msg.HELP,

--- a/core/events.js
+++ b/core/events.js
@@ -383,7 +383,7 @@ Blockly.Events.fromJson = function(json, workspace) {
       event = new Blockly.Events.EndBlockDrag(null, false);
       break;
     default:
-      throw 'Unknown event type.';
+      throw Error('Unknown event type.');
   }
   event.fromJson(json);
   event.workspaceId = workspace.id;

--- a/core/extensions.js
+++ b/core/extensions.js
@@ -36,9 +36,6 @@ goog.provide('Blockly.Extensions');
 goog.require('Blockly.Mutator');
 goog.require('Blockly.utils');
 
-goog.require('goog.string');
-
-
 /**
  * The set of all registered extensions, keyed by extension name/id.
  * @private
@@ -56,13 +53,13 @@ Blockly.Extensions.ALL_ = {};
  *     registered, or extensionFn is not a function.
  */
 Blockly.Extensions.register = function(name, initFn) {
-  if (!goog.isString(name) || goog.string.isEmptyOrWhitespace(name)) {
+  if ((typeof name != 'string') || (name.trim() == '')) {
     throw new Error('Error: Invalid extension name "' + name + '"');
   }
   if (Blockly.Extensions.ALL_[name]) {
     throw new Error('Error: Extension "' + name + '" is already registered.');
   }
-  if (!goog.isFunction(initFn)) {
+  if (typeof initFn != 'function') {
     throw new Error('Error: Extension "' + name + '" must be a function');
   }
   Blockly.Extensions.ALL_[name] = initFn;
@@ -76,7 +73,7 @@ Blockly.Extensions.register = function(name, initFn) {
  *     registered.
  */
 Blockly.Extensions.registerMixin = function(name, mixinObj) {
-  if (!goog.isObject(mixinObj)){
+  if (!mixinObj || typeof mixinObj != 'object'){
     throw new Error('Error: Mixin "' + name + '" must be a object');
   }
   Blockly.Extensions.register(name, function() {
@@ -110,7 +107,7 @@ Blockly.Extensions.registerMutator = function(name, mixinObj, opt_helperFn,
   var hasMutatorDialog =
       Blockly.Extensions.checkMutatorDialog_(mixinObj, errorPrefix);
 
-  if (opt_helperFn && !goog.isFunction(opt_helperFn)) {
+  if (opt_helperFn && (typeof opt_helperFn != 'function')) {
     throw new Error('Extension "' + name + '" is not a function');
   }
 
@@ -138,7 +135,7 @@ Blockly.Extensions.registerMutator = function(name, mixinObj, opt_helperFn,
  */
 Blockly.Extensions.apply = function(name, block, isMutator) {
   var extensionFn = Blockly.Extensions.ALL_[name];
-  if (!goog.isFunction(extensionFn)) {
+  if (typeof extensionFn != 'function') {
     throw new Error('Error: Extension "' + name + '" not found.');
   }
   if (isMutator) {
@@ -332,7 +329,7 @@ Blockly.Extensions.buildTooltipForDropdown = function(dropdownName,
   if (document) { // Relies on document.readyState
     Blockly.utils.runAfterPageLoad(function() {
       for (var key in lookupTable) {
-        // Will print warnings is reference is missing.
+        // Will print warnings if reference is missing.
         Blockly.utils.checkMessageReferences(lookupTable[key]);
       }
     });

--- a/core/field.js
+++ b/core/field.js
@@ -31,7 +31,6 @@ goog.provide('Blockly.Field');
 goog.require('Blockly.Events.BlockChange');
 goog.require('Blockly.Gesture');
 
-goog.require('goog.asserts');
 goog.require('goog.dom');
 goog.require('goog.math.Size');
 goog.require('goog.style');
@@ -81,10 +80,10 @@ Blockly.Field.TYPE_MAP_ = {};
  *     object containing a fromJson function.
  */
 Blockly.Field.register = function(type, fieldClass) {
-  if (!goog.isString(type) || goog.string.isEmptyOrWhitespace(type)) {
+  if ((typeof type != 'string') || (type.trim() == '')) {
     throw new Error('Invalid field type "' + type + '"');
   }
-  if (!goog.isObject(fieldClass) || !goog.isFunction(fieldClass.fromJson)) {
+  if (!fieldClass || (typeof fieldClass.fromJson != 'function')) {
     throw new Error('Field "' + fieldClass +
         '" must have a fromJson function');
   }
@@ -205,7 +204,9 @@ Blockly.Field.prototype.SERIALIZABLE = true;
  * @param {!Blockly.Block} block The block containing this field.
  */
 Blockly.Field.prototype.setSourceBlock = function(block) {
-  goog.asserts.assert(!this.sourceBlock_, 'Field already bound to a block.');
+  if (this.sourceBlock_) {
+    throw Error('Field already bound to a block.');
+  }
   this.sourceBlock_ = block;
 };
 

--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -317,7 +317,7 @@ Blockly.FieldDropdown.prototype.trimOptions_ = function() {
   this.prefixField = null;
   this.suffixField = null;
   var options = this.menuGenerator_;
-  if (!goog.isArray(options)) {
+  if (!Array.isArray(options)) {
     return;
   }
   var hasImages = false;
@@ -373,7 +373,7 @@ Blockly.FieldDropdown.prototype.trimOptions_ = function() {
  *     Otherwise false.
  */
 Blockly.FieldDropdown.prototype.isOptionListDynamic = function() {
-  return goog.isFunction(this.menuGenerator_);
+  return typeof this.menuGenerator_ == 'function';
 };
 
 /**

--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -33,7 +33,6 @@ goog.require('Blockly.Msg');
 goog.require('Blockly.scratchBlocksUtils');
 goog.require('Blockly.utils');
 
-goog.require('goog.asserts');
 goog.require('goog.dom');
 goog.require('goog.dom.TagName');
 goog.require('goog.userAgent');
@@ -429,7 +428,9 @@ Blockly.FieldTextInput.prototype.onHtmlInputChange_ = function(e) {
  */
 Blockly.FieldTextInput.prototype.validate_ = function() {
   var valid = true;
-  goog.asserts.assertObject(Blockly.FieldTextInput.htmlInput_);
+  if (!Blockly.FieldTextInput.htmlInput_) {
+    throw Error('htmlInput not defined');
+  }
   var htmlInput = Blockly.FieldTextInput.htmlInput_;
   if (this.sourceBlock_) {
     valid = this.callValidator(htmlInput.value);

--- a/core/field_variable.js
+++ b/core/field_variable.js
@@ -30,7 +30,6 @@ goog.require('Blockly.FieldDropdown');
 goog.require('Blockly.Msg');
 goog.require('Blockly.VariableModel');
 goog.require('Blockly.Variables');
-goog.require('goog.asserts');
 goog.require('goog.string');
 
 
@@ -159,8 +158,9 @@ Blockly.FieldVariable.dispose = function() {
  * @param {!Blockly.Block} block The block containing this field.
  */
 Blockly.FieldVariable.prototype.setSourceBlock = function(block) {
-  goog.asserts.assert(!block.isShadow(),
-      'Variable fields are not allowed to exist on shadow blocks.');
+  if (block.isShadow()) {
+    throw Error('Variable fields are not allowed to exist on shadow blocks.');
+  }
   Blockly.FieldVariable.superClass_.setSourceBlock.call(this, block);
 };
 

--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -858,7 +858,7 @@ Blockly.Flyout.prototype.placeNewBlock_ = function(oldBlock) {
   var targetWorkspace = this.targetWorkspace_;
   var svgRootOld = oldBlock.getSvgRoot();
   if (!svgRootOld) {
-    throw 'oldBlock is not rendered.';
+    throw Error('oldBlock is not rendered.');
   }
 
   // Create the new block by cloning the block in the flyout (via XML).
@@ -872,7 +872,7 @@ Blockly.Flyout.prototype.placeNewBlock_ = function(oldBlock) {
   var block = Blockly.Xml.domToBlock(xml, targetWorkspace);
   var svgRootNew = block.getSvgRoot();
   if (!svgRootNew) {
-    throw 'block is not rendered.';
+    throw Error('block is not rendered.');
   }
 
   // The offset in pixels between the main workspace's origin and the upper left

--- a/core/flyout_dragger.js
+++ b/core/flyout_dragger.js
@@ -28,7 +28,6 @@ goog.provide('Blockly.FlyoutDragger');
 
 goog.require('Blockly.WorkspaceDragger');
 
-goog.require('goog.asserts');
 goog.require('goog.math.Coordinate');
 
 

--- a/core/flyout_horizontal.js
+++ b/core/flyout_horizontal.js
@@ -128,7 +128,7 @@ Blockly.HorizontalFlyout.prototype.setMetrics_ = function(xyRatio) {
     return;
   }
 
-  if (goog.isNumber(xyRatio.x)) {
+  if (typeof xyRatio.x == 'number') {
     this.workspace_.scrollX = -metrics.contentWidth * xyRatio.x;
   }
 

--- a/core/flyout_vertical.js
+++ b/core/flyout_vertical.js
@@ -248,7 +248,7 @@ Blockly.VerticalFlyout.prototype.setMetrics_ = function(xyRatio) {
   if (!metrics) {
     return;
   }
-  if (goog.isNumber(xyRatio.y)) {
+  if (typeof xyRatio.y == 'number') {
     this.workspace_.scrollY = -metrics.contentHeight * xyRatio.y;
   }
   this.workspace_.translate(this.workspace_.scrollX + metrics.absoluteLeft,

--- a/core/generator.js
+++ b/core/generator.js
@@ -28,7 +28,6 @@
 goog.provide('Blockly.Generator');
 
 goog.require('Blockly.Block');
-goog.require('goog.asserts');
 
 
 /**
@@ -99,7 +98,7 @@ Blockly.Generator.prototype.workspaceToCode = function(workspace) {
   var blocks = workspace.getTopBlocks(true);
   for (var x = 0, block; block = blocks[x]; x++) {
     var line = this.blockToCode(block);
-    if (goog.isArray(line)) {
+    if (Array.isArray(line)) {
       // Value blocks return tuples of code and operator order.
       // Top-level blocks don't care about operator order.
       line = line[0];
@@ -173,31 +172,32 @@ Blockly.Generator.prototype.blockToCode = function(block) {
   }
 
   var func = this[block.type];
-  goog.asserts.assertFunction(func,
-      'Language "%s" does not know how to generate code for block type "%s".',
-      this.name_, block.type);
+  if (typeof func != 'function') {
+    throw Error('Language "' + this.name_ + '" does not know how to generate ' +
+        ' code for block type "' + block.type + '".');
+  }
   // First argument to func.call is the value of 'this' in the generator.
   // Prior to 24 September 2013 'this' was the only way to access the block.
   // The current prefered method of accessing the block is through the second
   // argument to func.call, which becomes the first parameter to the generator.
   var code = func.call(block, block);
-  if (goog.isArray(code)) {
+  if (Array.isArray(code)) {
     // Value blocks return tuples of code and operator order.
-    goog.asserts.assert(block.outputConnection,
-        'Expecting string from statement block "%s".', block.type);
+    if (!block.outputConnection) {
+      throw TypeError('Expecting string from statement block: ' + block.type);
+    }
     return [this.scrub_(block, code[0]), code[1]];
-  } else if (goog.isString(code)) {
+  } else if (typeof code == 'string') {
     var id = block.id.replace(/\$/g, '$$$$');  // Issue 251.
     if (this.STATEMENT_PREFIX) {
-      code = this.STATEMENT_PREFIX.replace(/%1/g, '\'' + id + '\'') +
-          code;
+      code = this.STATEMENT_PREFIX.replace(/%1/g, '\'' + id + '\'') + code;
     }
     return this.scrub_(block, code);
   } else if (code === null) {
     // Block has handled code generation itself.
     return '';
   } else {
-    goog.asserts.fail('Invalid code generated: %s', code);
+    throw SyntaxError('Invalid code generated: ' + code);
   }
 };
 
@@ -212,7 +212,7 @@ Blockly.Generator.prototype.blockToCode = function(block) {
  */
 Blockly.Generator.prototype.valueToCode = function(block, name, outerOrder) {
   if (isNaN(outerOrder)) {
-    goog.asserts.fail('Expecting valid order from block "%s".', block.type);
+    throw TypeError('Expecting valid order from block: ' + block.type);
   }
   var targetBlock = block.getInputTargetBlock(name);
   if (!targetBlock) {
@@ -225,12 +225,13 @@ Blockly.Generator.prototype.valueToCode = function(block, name, outerOrder) {
   }
   // Value blocks must return code and order of operations info.
   // Statement blocks must only return code.
-  goog.asserts.assertArray(tuple, 'Expecting tuple from value block "%s".',
-      targetBlock.type);
+  if (!Array.isArray(tuple)) {
+    throw TypeError('Expecting tuple from value block: ' + targetBlock.type);
+  }
   var code = tuple[0];
   var innerOrder = tuple[1];
   if (isNaN(innerOrder)) {
-    goog.asserts.fail('Expecting valid order from value block "%s".',
+    throw TypeError('Expecting valid order from value block: ' +
         targetBlock.type);
   }
   if (!code) {
@@ -282,8 +283,10 @@ Blockly.Generator.prototype.statementToCode = function(block, name) {
   var code = this.blockToCode(targetBlock);
   // Value blocks must return code and order of operations info.
   // Statement blocks must only return code.
-  goog.asserts.assertString(code, 'Expecting code from statement block "%s".',
-      targetBlock && targetBlock.type);
+  if (typeof code != 'string') {
+    throw TypeError('Expecting code from statement block: ' +
+        (targetBlock && targetBlock.type));
+  }
   if (code) {
     code = this.prefixLines(/** @type {string} */ (code), this.INDENT);
   }

--- a/core/gesture.js
+++ b/core/gesture.js
@@ -38,7 +38,6 @@ goog.require('Blockly.Tooltip');
 goog.require('Blockly.Touch');
 goog.require('Blockly.WorkspaceDragger');
 
-goog.require('goog.asserts');
 goog.require('goog.math.Coordinate');
 
 
@@ -431,8 +430,9 @@ Blockly.Gesture.prototype.updateIsDraggingWorkspace_ = function() {
  */
 Blockly.Gesture.prototype.updateIsDragging_ = function() {
   // Sanity check.
-  goog.asserts.assert(!this.calledUpdateIsDragging_,
-      'updateIsDragging_ should only be called once per gesture.');
+  if (this.calledUpdateIsDragging_) {
+    throw Error('updateIsDragging_ should only be called once per gesture.');
+  }
   this.calledUpdateIsDragging_ = true;
 
   // First check if it was a bubble drag.  Bubbles always sit on top of blocks.
@@ -510,7 +510,7 @@ Blockly.Gesture.prototype.doStart = function(e) {
     return;
   }
 
-  if (goog.string.caseInsensitiveEquals(e.type, 'touchstart')) {
+  if (e.type.toLowerCase() == 'touchstart') {
     Blockly.longStart_(e, this);
   }
 
@@ -659,9 +659,10 @@ Blockly.Gesture.prototype.handleRightClick = function(e) {
  * @package
  */
 Blockly.Gesture.prototype.handleWsStart = function(e, ws) {
-  goog.asserts.assert(!this.hasStarted_,
-      'Tried to call gesture.handleWsStart, but the gesture had already been ' +
-      'started.');
+  if (this.hasStarted_) {
+    throw Error('Tried to call gesture.handleWsStart, ' +
+        'but the gesture had already been started.');
+  }
   this.setStartWorkspace_(ws);
   this.mostRecentEvent_ = e;
   this.doStart(e);
@@ -674,9 +675,10 @@ Blockly.Gesture.prototype.handleWsStart = function(e, ws) {
  * @package
  */
 Blockly.Gesture.prototype.handleFlyoutStart = function(e, flyout) {
-  goog.asserts.assert(!this.hasStarted_,
-      'Tried to call gesture.handleFlyoutStart, but the gesture had already ' +
-      'been started.');
+  if (this.hasStarted_) {
+    throw Error('Tried to call gesture.handleFlyoutStart, ' +
+        'but the gesture had already been started.');
+  }
   this.setStartFlyout_(flyout);
   this.handleWsStart(e, flyout.getWorkspace());
 };
@@ -688,9 +690,10 @@ Blockly.Gesture.prototype.handleFlyoutStart = function(e, flyout) {
  * @package
  */
 Blockly.Gesture.prototype.handleBlockStart = function(e, block) {
-  goog.asserts.assert(!this.hasStarted_,
-      'Tried to call gesture.handleBlockStart, but the gesture had already ' +
-      'been started.');
+  if (this.hasStarted_) {
+    throw Error('Tried to call gesture.handleBlockStart, ' +
+        'but the gesture had already been started.');
+  }
   this.setStartBlock(block);
   this.mostRecentEvent_ = e;
 };
@@ -702,9 +705,10 @@ Blockly.Gesture.prototype.handleBlockStart = function(e, block) {
  * @package
  */
 Blockly.Gesture.prototype.handleBubbleStart = function(e, bubble) {
-  goog.asserts.assert(!this.hasStarted_,
-      'Tried to call gesture.handleBubbleStart, but the gesture had already ' +
-      'been started.');
+  if (this.hasStarted_) {
+    throw Error('Tried to call gesture.handleBubbleStart, ' +
+        'but the gesture had already been started.');
+  }
   this.setStartBubble(bubble);
   this.mostRecentEvent_ = e;
 };
@@ -799,9 +803,10 @@ Blockly.Gesture.prototype.bringBlockToFront_ = function() {
  * @package
  */
 Blockly.Gesture.prototype.setStartField = function(field) {
-  goog.asserts.assert(!this.hasStarted_,
-      'Tried to call gesture.setStartField, but the gesture had already been ' +
-      'started.');
+  if (this.hasStarted_) {
+    throw Error('Tried to call gesture.setStartField, ' +
+        'but the gesture had already been started.');
+  }
   if (!this.startField_) {
     this.startField_ = field;
   }

--- a/core/input.js
+++ b/core/input.js
@@ -28,7 +28,6 @@ goog.provide('Blockly.Input');
 
 goog.require('Blockly.Connection');
 goog.require('Blockly.FieldLabel');
-goog.require('goog.asserts');
 
 
 /**
@@ -42,7 +41,7 @@ goog.require('goog.asserts');
  */
 Blockly.Input = function(type, name, block, connection) {
   if (type != Blockly.DUMMY_INPUT && !name) {
-    throw 'Value inputs and statement inputs must have non-empty name.';
+    throw Error('Value inputs and statement inputs must have non-empty name.');
   }
   /** @type {number} */
   this.type = type;
@@ -111,7 +110,7 @@ Blockly.Input.prototype.insertFieldAt = function(index, field, opt_name) {
     return this;
   }
   // Generate a FieldLabel when given a plain text field.
-  if (goog.isString(field)) {
+  if (typeof field == 'string') {
     field = new Blockly.FieldLabel(/** @type {string} */ (field));
   }
   field.setSourceBlock(this.sourceBlock_);
@@ -143,7 +142,7 @@ Blockly.Input.prototype.insertFieldAt = function(index, field, opt_name) {
 /**
  * Remove a field from this input.
  * @param {string} name The name of the field.
- * @throws {goog.asserts.AssertionError} if the field is not present.
+ * @throws {Error} if the field is not present.
  */
 Blockly.Input.prototype.removeField = function(name) {
   for (var i = 0, field; field = this.fieldRow[i]; i++) {
@@ -158,7 +157,7 @@ Blockly.Input.prototype.removeField = function(name) {
       return;
     }
   }
-  goog.asserts.fail('Field "%s" not found.', name);
+  throw Error('Field "%s" not found.', name);
 };
 
 /**
@@ -212,7 +211,7 @@ Blockly.Input.prototype.setVisible = function(visible) {
  */
 Blockly.Input.prototype.setCheck = function(check) {
   if (!this.connection) {
-    throw 'This input does not have a connection.';
+    throw Error('This input does not have a connection.');
   }
   this.connection.setCheck(check);
   return this;

--- a/core/rendered_connection.js
+++ b/core/rendered_connection.js
@@ -166,7 +166,7 @@ Blockly.RenderedConnection.prototype.tighten_ = function() {
     var block = this.targetBlock();
     var svgRoot = block.getSvgRoot();
     if (!svgRoot) {
-      throw 'block is not rendered.';
+      throw Error('block is not rendered.');
     }
     // Workspace coordinates.
     var xy = Blockly.utils.getRelativeXY(svgRoot);
@@ -347,7 +347,7 @@ Blockly.RenderedConnection.prototype.respawnShadow_ = function() {
     Blockly.RenderedConnection.superClass_.respawnShadow_.call(this);
     var blockShadow = this.targetBlock();
     if (!blockShadow) {
-      throw 'Couldn\'t respawn the shadow block that should exist here.';
+      throw Error('Couldn\'t respawn the shadow block that should exist here.');
     }
     blockShadow.initSvg();
     blockShadow.render(false);

--- a/core/scrollbar.js
+++ b/core/scrollbar.js
@@ -662,7 +662,7 @@ Blockly.Scrollbar.prototype.setVisible = function(visible) {
   // Ideally this would also apply to scrollbar pairs, but that's a bigger
   // headache (due to interactions with the corner square).
   if (this.pair_) {
-    throw 'Unable to toggle visibility of paired scrollbars.';
+    throw Error('Unable to toggle visibility of paired scrollbars.');
   }
   this.isVisible_ = visible;
   if (visibilityChanged) {

--- a/core/tooltip.js
+++ b/core/tooltip.js
@@ -167,7 +167,8 @@ Blockly.Tooltip.onMouseOver_ = function(e) {
   // If the tooltip is an object, treat it as a pointer to the next object in
   // the chain to look at.  Terminate when a string or function is found.
   var element = e.target;
-  while (!goog.isString(element.tooltip) && !goog.isFunction(element.tooltip)) {
+  while ((typeof element.tooltip != 'string') &&
+         (typeof element.tooltip != 'function')) {
     element = element.tooltip;
   }
   if (Blockly.Tooltip.element_ != element) {
@@ -289,7 +290,7 @@ Blockly.Tooltip.show_ = function() {
   goog.dom.removeChildren(/** @type {!Element} */ (Blockly.Tooltip.DIV));
   // Get the new text.
   var tip = Blockly.Tooltip.element_.tooltip;
-  while (goog.isFunction(tip)) {
+  while (typeof tip == 'function') {
     tip = tip();
   }
   tip = Blockly.utils.wrap(tip, Blockly.Tooltip.LIMIT);

--- a/core/utils.js
+++ b/core/utils.js
@@ -445,7 +445,7 @@ Blockly.utils.tokenizeInterpolation = function(message) {
  * @return {!string} String with message references replaced.
  */
 Blockly.utils.replaceMessageReferences = function(message) {
-  if (!goog.isString(message)) {
+  if (typeof message != 'string') {
     return message;
   }
   var interpolatedResult = Blockly.utils.tokenizeInterpolation_(message, false);
@@ -560,11 +560,11 @@ Blockly.utils.tokenizeInterpolation_ = function(message,
           // BKY_ is the prefix used to namespace the strings used in Blockly
           // core files and the predefined blocks in ../blocks/. These strings
           // are defined in ../msgs/ files.
-          var bklyKey = goog.string.startsWith(keyUpper, 'BKY_') ?
+          var bklyKey = Blockly.utils.startsWith(keyUpper, 'BKY_') ?
               keyUpper.substring(4) : null;
           if (bklyKey && bklyKey in Blockly.Msg) {
             var rawValue = Blockly.Msg[bklyKey];
-            if (goog.isString(rawValue)) {
+            if (typeof rawValue == 'string') {
               // Attempt to dereference substrings, too, appending to the end.
               Array.prototype.push.apply(tokens,
                   Blockly.utils.tokenizeInterpolation(rawValue));
@@ -873,7 +873,7 @@ Blockly.utils.insertAfter_ = function(newNode, refNode) {
   var siblingNode = refNode.nextSibling;
   var parentNode = refNode.parentNode;
   if (!parentNode) {
-    throw 'Reference node has no parent.';
+    throw Error('Reference node has no parent.');
   }
   if (siblingNode) {
     parentNode.insertBefore(newNode, siblingNode);
@@ -934,4 +934,51 @@ Blockly.utils.getViewportBBox = function() {
     top: scrollOffset.y,
     left: scrollOffset.x
   };
+};
+
+/**
+ * Fast prefix-checker.
+ * Copied from Closure's goog.string.startsWith.
+ * @param {string} str The string to check.
+ * @param {string} prefix A string to look for at the start of `str`.
+ * @return {boolean} True if `str` begins with `prefix`.
+ */
+Blockly.utils.startsWith = function(str, prefix) {
+  return str.lastIndexOf(prefix, 0) == 0;
+};
+
+/**
+ * Removes the first occurrence of a particular value from an array.
+ * @param {!Array} arr Array from which to remove
+ *     value.
+ * @param {*} obj Object to remove.
+ * @return {boolean} True if an element was removed.
+ */
+Blockly.utils.arrayRemove = function(arr, obj) {
+  var i = arr.indexOf(obj);
+  if (i == -1) {
+    return false;
+  }
+  arr.splice(i, 1);
+  return true;
+};
+
+/**
+ * Converts degrees to radians.
+ * Copied from Closure's goog.math.toRadians.
+ * @param {number} angleDegrees Angle in degrees.
+ * @return {number} Angle in radians.
+ */
+Blockly.utils.toRadians = function(angleDegrees) {
+  return angleDegrees * Math.PI / 180;
+};
+
+/**
+ * Converts radians to degrees.
+ * Copied from Closure's goog.math.toDegrees.
+ * @param {number} angleRadians Angle in radians.
+ * @return {number} Angle in degrees.
+ */
+Blockly.utils.toDegrees = function(angleRadians) {
+  return angleRadians * 180 / Math.PI;
 };

--- a/core/workspace.js
+++ b/core/workspace.js
@@ -176,8 +176,8 @@ Blockly.Workspace.prototype.addTopBlock = function(block) {
  * @param {!Blockly.Block} block Block to remove.
  */
 Blockly.Workspace.prototype.removeTopBlock = function(block) {
-  if (!goog.array.remove(this.topBlocks_, block)) {
-    throw 'Block not present in workspace\'s list of top-most blocks.';
+  if (!Blockly.utils.arrayRemove(this.topBlocks_, block)) {
+    throw Error('Block not present in workspace\'s list of top-most blocks.');
   }
 };
 
@@ -191,7 +191,8 @@ Blockly.Workspace.prototype.getTopBlocks = function(ordered) {
   // Copy the topBlocks_ list.
   var blocks = [].concat(this.topBlocks_);
   if (ordered && blocks.length > 1) {
-    var offset = Math.sin(goog.math.toRadians(Blockly.Workspace.SCAN_ANGLE));
+    var offset =
+        Math.sin(Blockly.utils.toRadians(Blockly.Workspace.SCAN_ANGLE));
     if (this.RTL) {
       offset *= -1;
     }
@@ -227,8 +228,9 @@ Blockly.Workspace.prototype.addTopComment = function(comment) {
  * @package
  */
 Blockly.Workspace.prototype.removeTopComment = function(comment) {
-  if (!goog.array.remove(this.topComments_, comment)) {
-    throw 'Comment not present in workspace\'s list of top-most comments.';
+  if (!Blockly.utils.arrayRemove(this.topComments_, comment)) {
+    throw Error('Comment not present in workspace\'s list of top-most ' +
+        'comments.');
   }
   // Note: If the comment database starts to hold block comments, this may need
   // to move to a separate function.
@@ -246,7 +248,8 @@ Blockly.Workspace.prototype.getTopComments = function(ordered) {
   // Copy the topComments_ list.
   var comments = [].concat(this.topComments_);
   if (ordered && comments.length > 1) {
-    var offset = Math.sin(goog.math.toRadians(Blockly.Workspace.SCAN_ANGLE));
+    var offset =
+        Math.sin(Blockly.utils.toRadians(Blockly.Workspace.SCAN_ANGLE));
     if (this.RTL) {
       offset *= -1;
     }
@@ -547,7 +550,7 @@ Blockly.Workspace.prototype.addChangeListener = function(func) {
  * @param {Function} func Function to stop calling.
  */
 Blockly.Workspace.prototype.removeChangeListener = function(func) {
-  goog.array.remove(this.listeners_, func);
+  Blockly.utils.arrayRemove(this.listeners_, func);
 };
 
 /**

--- a/core/workspace_comment_svg.js
+++ b/core/workspace_comment_svg.js
@@ -134,7 +134,9 @@ Blockly.WorkspaceCommentSvg.prototype.dispose = function() {
  * @package
  */
 Blockly.WorkspaceCommentSvg.prototype.initSvg = function() {
-  goog.asserts.assert(this.workspace.rendered, 'Workspace is headless.');
+  if (!this.workspace.rendered) {
+    throw TypeError('Workspace is headless.');
+  }
   if (!this.workspace.options.readOnly && !this.eventsInit_) {
     Blockly.bindEventWithChecks_(
         this.svgRectTarget_, 'mousedown', this, this.pathMouseDown_);

--- a/core/workspace_drag_surface_svg.js
+++ b/core/workspace_drag_surface_svg.js
@@ -32,7 +32,6 @@ goog.provide('Blockly.WorkspaceDragSurfaceSvg');
 
 goog.require('Blockly.utils');
 
-goog.require('goog.asserts');
 goog.require('goog.math.Coordinate');
 
 
@@ -138,14 +137,16 @@ Blockly.WorkspaceDragSurfaceSvg.prototype.getSurfaceTranslation = function() {
  */
 Blockly.WorkspaceDragSurfaceSvg.prototype.clearAndHide = function(newSurface) {
   if (!newSurface) {
-    throw 'Couldn\'t clear and hide the drag surface: missing new surface.';
+    throw Error('Couldn\'t clear and hide the drag surface: missing ' +
+        'new surface.');
   }
   var blockCanvas = this.SVG_.childNodes[0];
   var bubbleCanvas = this.SVG_.childNodes[1];
   if (!blockCanvas || !bubbleCanvas ||
       !Blockly.utils.hasClass(blockCanvas, 'blocklyBlockCanvas') ||
       !Blockly.utils.hasClass(bubbleCanvas, 'blocklyBubbleCanvas')) {
-    throw 'Couldn\'t clear and hide the drag surface.  A node was missing.';
+    throw Error('Couldn\'t clear and hide the drag surface. ' +
+        'A node was missing.');
   }
 
   // If there is a previous sibling, put the blockCanvas back right afterwards,
@@ -160,8 +161,9 @@ Blockly.WorkspaceDragSurfaceSvg.prototype.clearAndHide = function(newSurface) {
   Blockly.utils.insertAfter_(bubbleCanvas, blockCanvas);
   // Hide the drag surface.
   this.SVG_.style.display = 'none';
-  goog.asserts.assert(
-      this.SVG_.childNodes.length == 0, 'Drag surface was not cleared.');
+  if (this.SVG_.childNodes.length) {
+    throw Error('Drag surface was not cleared.');
+  }
   Blockly.utils.setCssTransform(this.SVG_, '');
   this.previousSibling_ = null;
 };
@@ -180,8 +182,9 @@ Blockly.WorkspaceDragSurfaceSvg.prototype.clearAndHide = function(newSurface) {
  */
 Blockly.WorkspaceDragSurfaceSvg.prototype.setContentsAndShow = function(
     blockCanvas, bubbleCanvas, previousSibling, width, height, scale) {
-  goog.asserts.assert(
-      this.SVG_.childNodes.length == 0, 'Already dragging a block.');
+  if (this.SVG_.childNodes.length) {
+    throw Error('Already dragging a block.');
+  }
   this.previousSibling_ = previousSibling;
   // Make sure the blocks and bubble canvas are scaled appropriately.
   blockCanvas.setAttribute('transform', 'translate(0, 0) scale(' + scale + ')');

--- a/core/workspace_dragger.js
+++ b/core/workspace_dragger.js
@@ -27,7 +27,6 @@
 goog.provide('Blockly.WorkspaceDragger');
 
 goog.require('goog.math.Coordinate');
-goog.require('goog.asserts');
 
 
 /**

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -912,7 +912,7 @@ Blockly.WorkspaceSvg.prototype.highlightBlock = function(id, opt_state) {
     var state = (opt_state === undefined) || opt_state;
     // Using Set here would be great, but at the cost of IE10 support.
     if (!state) {
-      goog.array.remove(this.highlightedBlocks_, block);
+      Blockly.utils.arrayRemove(this.highlightedBlocks_, block);
     } else if (this.highlightedBlocks_.indexOf(block) == -1) {
       this.highlightedBlocks_.push(block);
     }
@@ -1526,23 +1526,23 @@ Blockly.WorkspaceSvg.prototype.updateToolbox = function(tree) {
   tree = Blockly.Options.parseToolboxTree(tree);
   if (!tree) {
     if (this.options.languageTree) {
-      throw 'Can\'t nullify an existing toolbox.';
+      throw Error('Can\'t nullify an existing toolbox.');
     }
     return;  // No change (null to null).
   }
   if (!this.options.languageTree) {
-    throw 'Existing toolbox is null.  Can\'t create new toolbox.';
+    throw Error('Existing toolbox is null.  Can\'t create new toolbox.');
   }
   if (tree.getElementsByTagName('category').length) {
     if (!this.toolbox_) {
-      throw 'Existing toolbox has no categories.  Can\'t change mode.';
+      throw Error('Existing toolbox has no categories.  Can\'t change mode.');
     }
     this.options.languageTree = tree;
     this.toolbox_.populate_(tree);
     this.toolbox_.position();
   } else {
     if (!this.flyout_) {
-      throw 'Existing toolbox has categories.  Can\'t change mode.';
+      throw Error('Existing toolbox has categories.  Can\'t change mode.');
     }
     this.options.languageTree = tree;
     this.flyout_.show(tree.childNodes);
@@ -1577,7 +1577,7 @@ Blockly.WorkspaceSvg.prototype.setBrowserFocus = function() {
   try {
     // Focus the workspace SVG - this is for Chrome and Firefox.
     this.getParentSvg().focus();
-  }  catch (e) {
+  } catch (e) {
     // IE and Edge do not support focus on SVG elements. When that fails
     // above, get the injectionDiv (the workspace's parent) and focus that
     // instead.  This doesn't work in Chrome.
@@ -2018,13 +2018,14 @@ Blockly.WorkspaceSvg.getTopLevelWorkspaceMetrics_ = function() {
  */
 Blockly.WorkspaceSvg.setTopLevelWorkspaceMetrics_ = function(xyRatio) {
   if (!this.scrollbar) {
-    throw 'Attempt to set top level workspace scroll without scrollbars.';
+    throw Error('Attempt to set top level workspace scroll without ' +
+        'scrollbars.');
   }
   var metrics = this.getMetrics();
-  if (goog.isNumber(xyRatio.x)) {
+  if (typeof xyRatio.x == 'number') {
     this.scrollX = -metrics.contentWidth * xyRatio.x - metrics.contentLeft;
   }
-  if (goog.isNumber(xyRatio.y)) {
+  if (typeof xyRatio.y == 'number') {
     this.scrollY = -metrics.contentHeight * xyRatio.y - metrics.contentTop;
   }
   var x = this.scrollX + metrics.absoluteLeft;
@@ -2089,8 +2090,9 @@ Blockly.WorkspaceSvg.prototype.clear = function() {
  *     given button is clicked.
  */
 Blockly.WorkspaceSvg.prototype.registerButtonCallback = function(key, func) {
-  goog.asserts.assert(goog.isFunction(func),
-      'Button callbacks must be functions.');
+  if (typeof func != 'function') {
+    throw TypeError('Button callbacks must be functions.');
+  }
   this.flyoutButtonCallbacks_[key] = func;
 };
 
@@ -2124,8 +2126,9 @@ Blockly.WorkspaceSvg.prototype.removeButtonCallback = function(key) {
  */
 Blockly.WorkspaceSvg.prototype.registerToolboxCategoryCallback = function(key,
     func) {
-  goog.asserts.assert(goog.isFunction(func),
-      'Toolbox category callbacks must be functions.');
+  if (typeof func != 'function') {
+    throw TypeError('Toolbox category callbacks must be functions.');
+  }
   this.toolboxCategoryCallbacks_[key] = func;
 };
 

--- a/core/xml.js
+++ b/core/xml.js
@@ -33,7 +33,6 @@ goog.provide('Blockly.Xml');
 goog.require('Blockly.Events.BlockCreate');
 goog.require('Blockly.Events.VarCreate');
 
-goog.require('goog.asserts');
 goog.require('goog.dom');
 
 
@@ -465,8 +464,7 @@ Blockly.Xml.domToWorkspace = function(xml, workspace) {
         }
         variablesFirst = false;
       } else if (name == 'shadow') {
-        goog.asserts.fail('Shadow block cannot be a top-level block.');
-        variablesFirst = false;
+        throw TypeError('Shadow block cannot be a top-level block.');
       } else if (name == 'comment') {
         if (workspace.rendered) {
           Blockly.WorkspaceCommentSvg.fromXml(xmlChild, workspace, width);
@@ -650,8 +648,9 @@ Blockly.Xml.domToVariables = function(xmlVariables, workspace) {
 Blockly.Xml.domToBlockHeadless_ = function(xmlBlock, workspace) {
   var block = null;
   var prototypeName = xmlBlock.getAttribute('type');
-  goog.asserts.assert(
-      prototypeName, 'Block type unspecified: %s', xmlBlock.outerHTML);
+  if (!prototypeName) {
+    throw TypeError('Block type unspecified: ' + xmlBlock.outerHTML);
+  }
   var id = xmlBlock.getAttribute('id');
   block = workspace.newBlock(prototypeName, id);
 
@@ -752,7 +751,7 @@ Blockly.Xml.domToBlockHeadless_ = function(xmlBlock, workspace) {
           } else if (blockChild.previousConnection) {
             input.connection.connect(blockChild.previousConnection);
           } else {
-            goog.asserts.fail(
+            throw TypeError(
                 'Child block does not have output or previous statement.');
           }
         }
@@ -762,15 +761,18 @@ Blockly.Xml.domToBlockHeadless_ = function(xmlBlock, workspace) {
           block.nextConnection.setShadowDom(childShadowElement);
         }
         if (childBlockElement) {
-          goog.asserts.assert(block.nextConnection,
-              'Next statement does not exist.');
+          if (!block.nextConnection) {
+            throw TypeError('Next statement does not exist.');
+          }
           // If there is more than one XML 'next' tag.
-          goog.asserts.assert(!block.nextConnection.isConnected(),
-              'Next statement is already connected.');
+          if (block.nextConnection.isConnected()) {
+            throw TypeError('Next statement is already connected.');
+          }
           blockChild = Blockly.Xml.domToBlockHeadless_(childBlockElement,
               workspace);
-          goog.asserts.assert(blockChild.previousConnection,
-              'Next block does not have previous statement.');
+          if (!blockChild.previousConnection) {
+            throw TypeError('Next block does not have previous statement.');
+          }
           block.nextConnection.connect(blockChild.previousConnection);
         }
         break;
@@ -808,8 +810,9 @@ Blockly.Xml.domToBlockHeadless_ = function(xmlBlock, workspace) {
     // Ensure all children are also shadows.
     var children = block.getChildren(false);
     for (var i = 0, child; child = children[i]; i++) {
-      goog.asserts.assert(
-          child.isShadow(), 'Shadow block not allowed non-shadow child.');
+      if (!child.isShadow()) {
+        throw TypeError('Shadow block not allowed non-shadow child.');
+      }
     }
     block.setShadow(true);
   }


### PR DESCRIPTION
Not urgent to review or merge this week.

### Resolves

None

### Proposed Changes

Mostly just pulling in these changes: https://github.com/google/blockly/commit/3909bd420a22fec4cc830b0d7a31e75c5d0ff244

### Reason for Changes

Blockly is moving away from using closure library code where possible.  We're starting with the easy cases/places where modern browsers standardized so there's no need to hide special casing behind function calls.  The eventual goal is to remove the UI widgets and all other dependencies as well.

This change keeps scratch blocks in line with some of the recent blockly work.  There will be other related changes.

### Test Coverage

I built and played with the vertical playground.