### PR TITLE
Don't break on a null mutation

### DIFF
--- a/core/insertion_marker_manager.js
+++ b/core/insertion_marker_manager.js
@@ -257,7 +257,9 @@ Blockly.InsertionMarkerManager.prototype.createMarkerBlock_ = function(sourceBlo
     result.setInsertionMarker(true, sourceBlock.width);
     if (sourceBlock.mutationToDom) {
       var oldMutationDom = sourceBlock.mutationToDom();
-      result.domToMutation(oldMutationDom);
+      if (oldMutationDom) {
+        result.domToMutation(oldMutationDom);
+      }
     }
     result.initSvg();
   } finally {


### PR DESCRIPTION
### Resolves

No bug number, but this fixes the case when the dragging block has a null mutation.  Previously it would get stuck in a dragging state.  Found while working on Blockly, where null mutations happen more frequently.

### Proposed Changes

Don't call `domToMutation` if the mutation is null.

