### PR TITLE
Make extension status button clickable on Windows Edge

### DIFF
--- a/core/css.js
+++ b/core/css.js
@@ -488,15 +488,10 @@ Blockly.Css.CONTENT = [
   '.blocklyBubbleText {',
     'fill: $colour_text;',
   '}',
-
   '.blocklyFlyout {',
     'position: absolute;',
     'z-index: 20;',
-  '}',
-
-  '.blocklyFlyout {',
-    'position: absolute;',
-    'z-index: 20;',
+    'pointer-events: all;',
   '}',
   '.blocklyFlyoutButton {',
     'fill: none;',

--- a/core/css.js
+++ b/core/css.js
@@ -491,10 +491,10 @@ Blockly.Css.CONTENT = [
   '.blocklyFlyout {',
     'position: absolute;',
     'z-index: 20;',
-    'pointer-events: all;',
   '}',
   '.blocklyFlyoutButton {',
     'fill: none;',
+    'pointer-events: all;',
   '}',
 
   '.blocklyFlyoutButtonBackground {',


### PR DESCRIPTION
### Resolves

Resolves https://github.com/LLK/scratch-blocks/issues/1660

### Proposed Changes

Add `pointer-events: all` to the flyout.

Also, remove a duplicate css class. 

### Reason for Changes

The extension status button was not clickable on windows edge, because it was not receiving pointer events. 

This change makes it work, and as far as I can tell does not have any other side effects (based on some quick testing on windows edge/chrome/firefox and mac chrome/firefox/safari).

Thanks to @technoboy10 and @kchadha for the help so far!

I'm not confident that this is the best fix (it would be great to make a more localized change). I'd love to have others have a look (e.g. @rachel-fenichel @paulkaplan).