### PR TITLE
RTL positioning for category labels and buttons in the flyout.

### DIFF
--- a/core/flyout_extension_category_header.js
+++ b/core/flyout_extension_category_header.js
@@ -81,7 +81,8 @@ Blockly.FlyoutExtensionCategoryHeader.prototype.createDom = function() {
   var marginX = 15;
   var marginY = 10;
 
-  var statusButtonX = (this.flyoutWidth_ - statusButtonWidth - marginX) / this.workspace_.scale;
+  var statusButtonX = this.workspace_.RTL ? (marginX - this.flyoutWidth_ + statusButtonWidth) :
+      (this.flyoutWidth_ - statusButtonWidth - marginX) / this.workspace_.scale;
 
   if (this.imageSrc_) {
     /** @type {SVGElement} */

--- a/core/flyout_vertical.js
+++ b/core/flyout_vertical.js
@@ -490,7 +490,11 @@ Blockly.VerticalFlyout.prototype.layout_ = function(contents, gaps) {
     } else if (item.type == 'button') {
       var button = item.button;
       var buttonSvg = button.createDom();
-      button.moveTo(cursorX, cursorY);
+      if (this.RTL) {
+        button.moveTo(flyoutWidth - this.MARGIN - button.width, cursorY);
+      } else {
+        button.moveTo(cursorX, cursorY);
+      }
       button.show();
       // Clicking on a flyout button or label is a lot like clicking on the
       // flyout background.


### PR DESCRIPTION
### Resolves

Resolves #1584

### Proposed Changes

Re-position category labels and buttons (including extension status button) in the toolbox when in RTL mode.

### Reason for Changes

Localization.

### Test Coverage

Manual testing in the vertical_playground as well as scratch-gui.

/cc @rachel-fenichel @AnmAtAnm 