### PR TITLE
Make holding shift to scroll work on Firefox

### DIFF
--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1320,6 +1320,14 @@ Blockly.WorkspaceSvg.prototype.onMouseWheel_ = function(e) {
     var x = this.scrollX - e.deltaX * multiplier;
     var y = this.scrollY - e.deltaY * multiplier;
 
+    if (e.shiftKey && e.deltaX === 0) {
+      // Scroll horizontally (based on vertical scroll delta)
+      // This is needed as for some browser/system combinations which do not
+      // set deltaX. See #1662.
+      x = this.scrollX - e.deltaY * multiplier;
+      y = this.scrollY; // Don't scroll vertically
+    }
+
     this.startDragMetrics = this.getMetrics();
     this.scroll(x, y);
   }


### PR DESCRIPTION
### Resolves

Fixes #1662.

### Proposed Changes

Copied from LLK/scratch-paint#263:

>This is a "workaround" for browsers which do not automatically set deltaX when the shift key is held (seen on Firefox-Linux and Chrome-Windows, but not Chrome-Mac). This PR makes it so that when the shift key is held while scrolling, deltaX is ignored, and the distance scrolled horizontally is set to deltaY.

### Reason for Changes

Support for horizontal scrolling with the scroll wheel by holding shift on Firefox.

### Test Coverage

Tested locally on Firefox/Linux. Functionally-identical code reviewed and tweaked in discussion with @fsih in the above scratch-paint PR.