### PR TITLE
Only take keypresses when visible

### DIFF
--- a/core/blockly.js
+++ b/core/blockly.js
@@ -179,10 +179,10 @@ Blockly.svgResize = function(workspace) {
  * @param {!Event} e Key down event.
  * @private
  */
- // TODO (https://github.com/google/blockly/issues/1998) handle cases where there are multiple workspaces
- // and non-main workspaces are able to accept input.
+// TODO (https://github.com/google/blockly/issues/1998) handle cases where there are multiple workspaces
+// and non-main workspaces are able to accept input.
 Blockly.onKeyDown_ = function(e) {
-    if (Blockly.mainWorkspace.options.readOnly || Blockly.utils.isTargetInput(e)
+  if (Blockly.mainWorkspace.options.readOnly || Blockly.utils.isTargetInput(e)
       || (Blockly.mainWorkspace.rendered && !Blockly.mainWorkspace.isVisible())) {
     // No key actions on readonly workspaces.
     // When focused on an HTML text input widget, don't trap any keys.

--- a/core/blockly.js
+++ b/core/blockly.js
@@ -179,11 +179,11 @@ Blockly.svgResize = function(workspace) {
  * @param {!Event} e Key down event.
  * @private
  */
- // TODO handle cases where there are multiple workspaces and non-main workspaces are able to accept
- // input.
+ // TODO (https://github.com/google/blockly/issues/1998) handle cases where there are multiple workspaces
+ // and non-main workspaces are able to accept input.
 Blockly.onKeyDown_ = function(e) {
     if (Blockly.mainWorkspace.options.readOnly || Blockly.utils.isTargetInput(e)
-      || (Blockly.mainWorkspace.rendered && !Blockly.mainWorkspace.isVisible)) {
+      || (Blockly.mainWorkspace.rendered && !Blockly.mainWorkspace.isVisible())) {
     // No key actions on readonly workspaces.
     // When focused on an HTML text input widget, don't trap any keys.
     // Ignore keypresses on rendered workspaces that have been explicitly

--- a/core/blockly.js
+++ b/core/blockly.js
@@ -175,14 +175,19 @@ Blockly.svgResize = function(workspace) {
 };
 
 /**
- * Handle a key-down on SVG drawing surface.
+ * Handle a key-down on SVG drawing surface. Does nothing if the main workspace is not visible.
  * @param {!Event} e Key down event.
  * @private
  */
+ // TODO handle cases where there are multiple workspaces and non-main workspaces are able to accept
+ // input.
 Blockly.onKeyDown_ = function(e) {
-  if (Blockly.mainWorkspace.options.readOnly || Blockly.utils.isTargetInput(e)) {
+    if (Blockly.mainWorkspace.options.readOnly || Blockly.utils.isTargetInput(e)
+      || (Blockly.mainWorkspace.rendered && !Blockly.mainWorkspace.isVisible)) {
     // No key actions on readonly workspaces.
     // When focused on an HTML text input widget, don't trap any keys.
+    // Ignore keypresses on rendered workspaces that have been explicitly
+    // hidden.
     return;
   }
   var deleteBlock = false;

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -127,11 +127,19 @@ Blockly.WorkspaceSvg.prototype.resizeHandlerWrapper_ = null;
 
 /**
  * The render status of an SVG workspace.
- * Returns `true` for visible workspaces and `false` for non-visible,
- * or headless, workspaces.
+ * Returns `false` for headless workspaces and true for instances of
+ * `Blockly.WorkspaceSvg`.
  * @type {boolean}
  */
 Blockly.WorkspaceSvg.prototype.rendered = true;
+
+/**
+ * Whether the workspace is visible.  False if the workspace has been hidden
+ * by calling `setVisisble(false)`.
+ * @type {boolean}
+ * @package
+ */
+Blockly.WorkspaceSvg.prototype.isVisible = true;
 
 /**
  * Is this workspace the surface for a flyout?
@@ -865,6 +873,7 @@ Blockly.WorkspaceSvg.prototype.setVisible = function(isVisible) {
     Blockly.hideChaff(true);
     Blockly.DropDownDiv.hideWithoutAnimation();
   }
+  this.isVisible = isVisible;
 };
 
 /**

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -135,11 +135,11 @@ Blockly.WorkspaceSvg.prototype.rendered = true;
 
 /**
  * Whether the workspace is visible.  False if the workspace has been hidden
- * by calling `setVisisble(false)`.
+ * by calling `setVisible(false)`.
  * @type {boolean}
- * @package
+ * @private
  */
-Blockly.WorkspaceSvg.prototype.isVisible = true;
+Blockly.WorkspaceSvg.prototype.isVisible_ = true;
 
 /**
  * Is this workspace the surface for a flyout?
@@ -322,6 +322,15 @@ Blockly.WorkspaceSvg.prototype.getInverseScreenCTM = function() {
   }
 
   return this.inverseScreenCTM_;
+};
+
+/**
+ * Getter for isVisible
+ * @return {boolean} Whether the workspace is visible.  False if the workspace has been hidden
+ * by calling `setVisible(false)`.
+ */
+Blockly.WorkspaceSvg.prototype.isVisible = function() {
+  return this.isVisible_;
 };
 
 /**
@@ -873,7 +882,7 @@ Blockly.WorkspaceSvg.prototype.setVisible = function(isVisible) {
     Blockly.hideChaff(true);
     Blockly.DropDownDiv.hideWithoutAnimation();
   }
-  this.isVisible = isVisible;
+  this.isVisible_ = isVisible;
 };
 
 /**


### PR DESCRIPTION
### Resolves
Fixes https://github.com/LLK/scratch-blocks/issues/1019

### Proposed Changes
This change mirrors
https://github.com/google/blockly/pull/1996
from Blockly

### Reason for Changes
Keyboard shortcuts can't be implemented in other tabs as long as the blocks tab is responding to them

### Test Coverage
Tested in integration with GUI by using ctrl Z, C, and V while in other tabs
