### PR TITLE
Avoid dragging comment's line

### DIFF
--- a/core/scratch_bubble.js
+++ b/core/scratch_bubble.js
@@ -99,7 +99,9 @@ Blockly.ScratchBubble = function(comment, workspace, content, anchorXY,
     Blockly.bindEventWithChecks_(
         this.deleteIcon_, 'mouseup', this, this.deleteMouseUp_);
     Blockly.bindEventWithChecks_(
-        this.bubbleGroup_, 'mousedown', this, this.bubbleMouseDown_);
+        this.commentTopBar_, 'mousedown', this, this.bubbleMouseDown_);
+    Blockly.bindEventWithChecks_(
+        this.bubbleBack_, 'mousedown', this, this.bubbleMouseDown_);
     if (this.resizeGroup_) {
       Blockly.bindEventWithChecks_(
           this.resizeGroup_, 'mousedown', this, this.resizeMouseDown_);


### PR DESCRIPTION
### Resolves

Resolves [LLK/scratch-gui#2477](https://github.com/LLK/scratch-gui/issues/2477).

### Proposed Changes

Binds ```mousedown``` event handler to ```this.commentTopBar_``` and ```this.bubbleBack_``` instead of ```this.bubbleGroup_```.

### Reason for Changes

Dragging a bubble was triggered by handling mouse down event at ```this.bubbleGroup_``` which contains ```this.bubbleArrow_``` as its line. This makes an odd behavior as [LLK/scratch-gui#2477](https://github.com/LLK/scratch-gui/issues/2477) describes.

### Test Coverage

Tested locally on Chrome, Firefox and Safari on Mac.
