### PR TITLE
Place newly-created custom blocks in the top left of the visible workspace

### DIFF
--- a/core/procedures.js
+++ b/core/procedures.js
@@ -417,7 +417,8 @@ Blockly.Procedures.createProcedureCallbackFactory_ = function(workspace) {
       var blockDom = Blockly.Xml.textToDom(blockText).firstChild;
       Blockly.Events.setGroup(true);
       var block = Blockly.Xml.domToBlock(blockDom, workspace);
-      block.moveBy(30, 30);
+      var scale = workspace.scale; // To convert from pixel units to workspace units
+      block.moveBy((-workspace.scrollX + 30) / scale, (-workspace.scrollY + 30) / scale);
       block.scheduleSnapAndBump();
       Blockly.Events.setGroup(false);
     }

--- a/core/procedures.js
+++ b/core/procedures.js
@@ -418,8 +418,15 @@ Blockly.Procedures.createProcedureCallbackFactory_ = function(workspace) {
       Blockly.Events.setGroup(true);
       var block = Blockly.Xml.domToBlock(blockDom, workspace);
       var scale = workspace.scale; // To convert from pixel units to workspace units
-      // Position the block so that it is at the top left of the visible workspace.
-      block.moveBy((-workspace.scrollX + 30) / scale, (-workspace.scrollY + 30) / scale);
+      // Position the block so that it is at the top left of the visible workspace,
+      // padded from the edge by 30 units. Position in the top right if RTL.
+      var posX = -workspace.scrollX;
+      if (workspace.RTL) {
+        posX += workspace.getMetrics().contentWidth - 30;
+      } else {
+        posX += 30;
+      }
+      block.moveBy(posX / scale, (-workspace.scrollY + 30) / scale);
       block.scheduleSnapAndBump();
       Blockly.Events.setGroup(false);
     }

--- a/core/procedures.js
+++ b/core/procedures.js
@@ -418,6 +418,7 @@ Blockly.Procedures.createProcedureCallbackFactory_ = function(workspace) {
       Blockly.Events.setGroup(true);
       var block = Blockly.Xml.domToBlock(blockDom, workspace);
       var scale = workspace.scale; // To convert from pixel units to workspace units
+      // Position the block so that it is at the top left of the visible workspace.
       block.moveBy((-workspace.scrollX + 30) / scale, (-workspace.scrollY + 30) / scale);
       block.scheduleSnapAndBump();
       Blockly.Events.setGroup(false);


### PR DESCRIPTION
### Resolves

Resolves #1334.

### Proposed Changes

Places newly-created custom blocks in the top left of the visible workspace.

AFAIK a good follow-up (which I really wouldn't know where to begin with testing) is to make this go to the top-*right* corner in RTL mode, if that's something that is wanted.

### Reason for Changes

Convenience: without this PR, new custom blocks are placed somewhere else in the workspace, which is both somewhat unpredictable (it's presumably the top left of the "absolute workspace"), and annoying, because you have to scroll all the way there to grab it and pull it where you want it to go.

### Test Coverage

Manually tested at several different zoom levels and scroll positions.
