### PR TITLE
Remove uses of goog.dom.removeNode from the codebase

### DIFF
--- a/core/block_animations.js
+++ b/core/block_animations.js
@@ -65,7 +65,7 @@ Blockly.BlockAnimations.disposeUiStep_ = function(clone, rtl, start,
   var ms = new Date - start;
   var percent = ms / 150;
   if (percent > 1) {
-    goog.dom.removeNode(clone);
+    clone.parentNode.removeChild(clone);
   } else {
     var x = clone.translateX_ +
         (rtl ? -1 : 1) * clone.bBox_.width * workspaceScale / 2 * percent;

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -39,7 +39,6 @@ goog.require('Blockly.Touch');
 goog.require('Blockly.utils');
 
 goog.require('goog.Timer');
-goog.require('goog.dom');
 goog.require('goog.math.Coordinate');
 
 
@@ -948,7 +947,7 @@ Blockly.BlockSvg.prototype.dispose = function(healStack, animate) {
   }
   Blockly.BlockSvg.superClass_.dispose.call(this, healStack);
 
-  goog.dom.removeNode(this.svgGroup_);
+  this.svgGroup_.parentNode.removeChild(this.svgGroup_);
   blockWorkspace.resizeContents();
   // Sever JavaScript to DOM connections.
   this.svgGroup_ = null;

--- a/core/bubble.js
+++ b/core/bubble.js
@@ -28,7 +28,6 @@ goog.provide('Blockly.Bubble');
 
 goog.require('Blockly.Touch');
 goog.require('Blockly.Workspace');
-goog.require('goog.dom');
 goog.require('goog.math');
 goog.require('goog.math.Coordinate');
 goog.require('goog.userAgent');
@@ -606,7 +605,7 @@ Blockly.Bubble.prototype.setColour = function(hexColour) {
 Blockly.Bubble.prototype.dispose = function() {
   Blockly.Bubble.unbindDragEvents_();
   // Dispose of and unlink the bubble.
-  goog.dom.removeNode(this.bubbleGroup_);
+  this.bubbleGroup_.parentNode.removeChild(this.bubbleGroup_);
   this.bubbleGroup_ = null;
   this.bubbleArrow_ = null;
   this.bubbleBack_ = null;

--- a/core/field.js
+++ b/core/field.js
@@ -272,8 +272,10 @@ Blockly.Field.prototype.dispose = function() {
     this.mouseDownWrapper_ = null;
   }
   this.sourceBlock_ = null;
-  goog.dom.removeNode(this.fieldGroup_);
-  this.fieldGroup_ = null;
+  if (this.fieldGroup_) {
+    this.fieldGroup_.parentNode.removeChild(this.fieldGroup_);
+    this.fieldGroup_ = null;
+  }
   this.textElement_ = null;
   this.validator_ = null;
 };

--- a/core/field_image.js
+++ b/core/field_image.js
@@ -27,7 +27,6 @@
 goog.provide('Blockly.FieldImage');
 
 goog.require('Blockly.Field');
-goog.require('goog.dom');
 goog.require('goog.math.Size');
 goog.require('goog.userAgent');
 
@@ -113,8 +112,10 @@ Blockly.FieldImage.prototype.init = function() {
  * Dispose of all DOM objects belonging to this text.
  */
 Blockly.FieldImage.prototype.dispose = function() {
-  goog.dom.removeNode(this.fieldGroup_);
-  this.fieldGroup_ = null;
+  if (this.fieldGroup_) {
+    this.fieldGroup_.parentNode.removeChild(this.fieldGroup_);
+    this.fieldGroup_ = null;
+  }
   this.imageElement_ = null;
 };
 

--- a/core/field_label.js
+++ b/core/field_label.js
@@ -28,7 +28,6 @@ goog.provide('Blockly.FieldLabel');
 
 goog.require('Blockly.Field');
 goog.require('Blockly.Tooltip');
-goog.require('goog.dom');
 goog.require('goog.math.Size');
 goog.require('goog.userAgent');
 
@@ -111,8 +110,10 @@ Blockly.FieldLabel.prototype.init = function() {
  * Dispose of all DOM objects belonging to this text.
  */
 Blockly.FieldLabel.prototype.dispose = function() {
-  goog.dom.removeNode(this.textElement_);
-  this.textElement_ = null;
+  if (this.textElement_) {
+    this.textElement_.parentNode.removeChild(this.textElement_);
+    this.textElement_ = null;
+  }
 };
 
 /**

--- a/core/field_vertical_separator.js
+++ b/core/field_vertical_separator.js
@@ -27,7 +27,6 @@
 goog.provide('Blockly.FieldVerticalSeparator');
 
 goog.require('Blockly.Field');
-goog.require('goog.dom');
 goog.require('goog.math.Size');
 
 
@@ -105,8 +104,10 @@ Blockly.FieldVerticalSeparator.prototype.setLineHeight = function(newHeight) {
  * Dispose of all DOM objects belonging to this text.
  */
 Blockly.FieldVerticalSeparator.prototype.dispose = function() {
-  goog.dom.removeNode(this.fieldGroup_);
-  this.fieldGroup_ = null;
+  if (this.fieldGroup_) {
+    this.fieldGroup_.parentNode.removeChild(this.fieldGroup_);
+    this.fieldGroup_ = null;
+  }
   this.lineElement_ = null;
 };
 

--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -36,7 +36,6 @@ goog.require('Blockly.FlyoutExtensionCategoryHeader');
 goog.require('Blockly.Gesture');
 goog.require('Blockly.Touch');
 goog.require('Blockly.WorkspaceSvg');
-goog.require('goog.dom');
 goog.require('goog.events');
 goog.require('goog.math.Rect');
 goog.require('goog.userAgent');
@@ -346,7 +345,7 @@ Blockly.Flyout.prototype.dispose = function() {
     this.workspace_ = null;
   }
   if (this.svgGroup_) {
-    goog.dom.removeNode(this.svgGroup_);
+    this.svgGroup_.parentNode.removeChild(this.svgGroup_);
     this.svgGroup_ = null;
   }
   this.parentToolbox_ = null;
@@ -722,7 +721,9 @@ Blockly.Flyout.prototype.clearOldBlocks_ = function() {
   // Delete any background buttons from a previous showing.
   for (var j = 0; j < this.backgroundButtons_.length; j++) {
     var rect = this.backgroundButtons_[j];
-    if (rect) goog.dom.removeNode(rect);
+    if (rect) {
+      rect.parentNode.removeChild(rect);
+    }
   }
   this.backgroundButtons_.length = 0;
 

--- a/core/flyout_button.js
+++ b/core/flyout_button.js
@@ -292,7 +292,7 @@ Blockly.FlyoutButton.prototype.dispose = function() {
     Blockly.unbindEvent_(this.onMouseUpWrapper_);
   }
   if (this.svgGroup_) {
-    goog.dom.removeNode(this.svgGroup_);
+    this.svgGroup_.parentNode.removeChild(this.svgGroup_);
     this.svgGroup_ = null;
   }
   this.workspace_ = null;

--- a/core/flyout_vertical.js
+++ b/core/flyout_vertical.js
@@ -33,7 +33,6 @@ goog.require('Blockly.Flyout');
 goog.require('Blockly.FlyoutButton');
 goog.require('Blockly.utils');
 goog.require('Blockly.WorkspaceSvg');
-goog.require('goog.dom');
 goog.require('goog.dom.animationFrame.polyfill');
 goog.require('goog.events');
 goog.require('goog.math.Rect');
@@ -414,7 +413,7 @@ Blockly.VerticalFlyout.prototype.clearOldBlocks_ = function() {
   // Do the same for checkboxes.
   for (var i = 0, elem; elem = this.checkboxes_[i]; i++) {
     elem.block.flyoutCheckbox = null;
-    goog.dom.removeNode(elem.svgRoot);
+    elem.svgRoot.parentNode.removeChild(elem.svgRoot);
   }
   this.checkboxes_ = [];
 };

--- a/core/icon.js
+++ b/core/icon.js
@@ -26,7 +26,6 @@
 
 goog.provide('Blockly.Icon');
 
-goog.require('goog.dom');
 goog.require('goog.math.Coordinate');
 
 
@@ -95,7 +94,7 @@ Blockly.Icon.prototype.createIcon = function() {
  */
 Blockly.Icon.prototype.dispose = function() {
   // Dispose of and unlink the icon.
-  goog.dom.removeNode(this.iconGroup_);
+  this.iconGroup_.parentNode.removeChild(this.iconGroup_);
   this.iconGroup_ = null;
   // Dispose of and unlink the bubble.
   this.setVisible(false);

--- a/core/input.js
+++ b/core/input.js
@@ -248,7 +248,7 @@ Blockly.Input.prototype.init = function() {
  */
 Blockly.Input.prototype.dispose = function() {
   if (this.outlinePath) {
-    goog.dom.removeNode(this.outlinePath);
+    this.outlinePath.parentNode.removeChild(this.outlinePath);
   }
   for (var i = 0, field; field = this.fieldRow[i]; i++) {
     field.dispose();

--- a/core/rendered_connection.js
+++ b/core/rendered_connection.js
@@ -255,7 +255,8 @@ Blockly.RenderedConnection.prototype.unhideAll = function() {
  * Remove the highlighting around this connection.
  */
 Blockly.RenderedConnection.prototype.unhighlight = function() {
-  goog.dom.removeNode(Blockly.Connection.highlightedPath_);
+  var path = Blockly.Connection.highlightedPath_;
+  path.parentNode.removeChild(path);
   delete Blockly.Connection.highlightedPath_;
 };
 

--- a/core/scrollbar.js
+++ b/core/scrollbar.js
@@ -27,7 +27,6 @@
 goog.provide('Blockly.Scrollbar');
 goog.provide('Blockly.ScrollbarPair');
 
-goog.require('goog.dom');
 goog.require('goog.events');
 
 
@@ -70,7 +69,7 @@ Blockly.ScrollbarPair.prototype.oldHostMetrics_ = null;
  * Unlink from all DOM elements to prevent memory leaks.
  */
 Blockly.ScrollbarPair.prototype.dispose = function() {
-  goog.dom.removeNode(this.corner_);
+  this.corner_.parentNode.removeChild(this.corner_);
   this.corner_ = null;
   this.workspace_ = null;
   this.oldHostMetrics_ = null;
@@ -343,7 +342,7 @@ Blockly.Scrollbar.prototype.dispose = function() {
   Blockly.unbindEvent_(this.onMouseDownHandleWrapper_);
   this.onMouseDownHandleWrapper_ = null;
 
-  goog.dom.removeNode(this.outerSvg_);
+  this.outerSvg_.parentNode.removeChild(this.outerSvg_);
   this.outerSvg_ = null;
   this.svgGroup_ = null;
   this.svgBackground_ = null;

--- a/core/toolbox.js
+++ b/core/toolbox.js
@@ -143,7 +143,7 @@ Blockly.Toolbox.prototype.dispose = function() {
   this.flyout_.dispose();
   this.categoryMenu_.dispose();
   this.categoryMenu_ = null;
-  goog.dom.removeNode(this.HtmlDiv);
+  this.HtmlDiv.parentNode.removeChild(this.HtmlDiv);
   this.workspace_ = null;
   this.lastCategory_ = null;
 };
@@ -640,7 +640,7 @@ Blockly.Toolbox.CategoryMenu.prototype.dispose = function() {
   }
   this.categories_ = [];
   if (this.table) {
-    goog.dom.removeNode(this.table);
+    this.table.parentNode.removeChild(this.table);
     this.table = null;
   }
 };
@@ -676,7 +676,7 @@ Blockly.Toolbox.Category = function(parent, parentHtml, domTree) {
  */
 Blockly.Toolbox.Category.prototype.dispose = function() {
   if (this.item_) {
-    goog.dom.removeNode(this.item_);
+    this.item_.parentNode.removeChild(this.item_);
     this.item = null;
   }
   this.parent_ = null;

--- a/core/trashcan.js
+++ b/core/trashcan.js
@@ -26,7 +26,6 @@
 
 goog.provide('Blockly.Trashcan');
 
-goog.require('goog.dom');
 goog.require('goog.math');
 goog.require('goog.math.Rect');
 
@@ -228,7 +227,7 @@ Blockly.Trashcan.prototype.init = function(bottom) {
  */
 Blockly.Trashcan.prototype.dispose = function() {
   if (this.svgGroup_) {
-    goog.dom.removeNode(this.svgGroup_);
+    this.svgGroup_.parentNode.removeChild(this.svgGroup_);
     this.svgGroup_ = null;
   }
   this.svgLid_ = null;

--- a/core/workspace_comment_svg.js
+++ b/core/workspace_comment_svg.js
@@ -116,7 +116,7 @@ Blockly.WorkspaceCommentSvg.prototype.dispose = function() {
     Blockly.Events.fire(new Blockly.Events.CommentDelete(this));
   }
 
-  goog.dom.removeNode(this.svgGroup_);
+  this.svgGroup_.parentNode.removeChild(this.svgGroup_);
   // Sever JavaScript to DOM connections.
   this.svgGroup_ = null;
   this.svgRect_ = null;

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -500,7 +500,7 @@ Blockly.WorkspaceSvg.prototype.dispose = function() {
   }
   Blockly.WorkspaceSvg.superClass_.dispose.call(this);
   if (this.svgGroup_) {
-    goog.dom.removeNode(this.svgGroup_);
+    this.svgGroup_.parentNode.removeChild(this.svgGroup_);
     this.svgGroup_ = null;
   }
   this.svgBlockCanvas_ = null;
@@ -545,7 +545,8 @@ Blockly.WorkspaceSvg.prototype.dispose = function() {
   if (!this.options.parentWorkspace) {
     // Top-most workspace.  Dispose of the div that the
     // SVG is injected into (i.e. injectionDiv).
-    goog.dom.removeNode(this.getParentSvg().parentNode);
+    var toRemove = this.getParentSvg().parentNode;
+    toRemove.parentNode.removeChild(toRemove);
   }
   if (this.resizeHandlerWrapper_) {
     Blockly.unbindEvent_(this.resizeHandlerWrapper_);

--- a/core/xml.js
+++ b/core/xml.js
@@ -316,7 +316,7 @@ Blockly.Xml.cloneShadow_ = function(shadow) {
         if (textNode.nodeType == 3 && textNode.data.trim() == '' &&
             node.firstChild != textNode) {
           // Prune whitespace after a tag.
-          goog.dom.removeNode(textNode);
+          textNode.parentNode.removeChild(textNode);
         }
       }
       if (node) {
@@ -324,7 +324,7 @@ Blockly.Xml.cloneShadow_ = function(shadow) {
         node = node.nextSibling;
         if (textNode.nodeType == 3 && textNode.data.trim() == '') {
           // Prune whitespace before a tag.
-          goog.dom.removeNode(textNode);
+          textNode.parentNode.removeChild(textNode);
         }
       }
     }

--- a/core/zoom_controls.js
+++ b/core/zoom_controls.js
@@ -27,7 +27,6 @@
 goog.provide('Blockly.ZoomControls');
 
 goog.require('Blockly.Touch');
-goog.require('goog.dom');
 
 
 /**
@@ -145,7 +144,7 @@ Blockly.ZoomControls.prototype.init = function(bottom) {
  */
 Blockly.ZoomControls.prototype.dispose = function() {
   if (this.svgGroup_) {
-    goog.dom.removeNode(this.svgGroup_);
+    this.svgGroup_.parentNode.removeChild(this.svgGroup_);
     this.svgGroup_ = null;
   }
   this.workspace_ = null;


### PR DESCRIPTION
### Resolves

Reducing use of the closure library in scratch-blocks and blockly, with an eventual goal of removing the library entirely.

### Proposed Changes

Replace calls to `goog.dom.removeNode(thing)` with `this.parentNode.removeChild(thing)`.
