### PR TITLE
Move code for pasing colour options into colours.js

### DIFF
--- a/core/colours.js
+++ b/core/colours.js
@@ -112,3 +112,36 @@ Blockly.Colours = {
   "valueReportBackground": "#FFFFFF",
   "valueReportBorder": "#AAAAAA"
 };
+
+/**
+ * Override the colours in Blockly.Colours with new values basded on the
+ * given dictionary.
+ * @param {!Object} colours Dictionary of colour properties and new values.
+ * @package
+ */
+Blockly.Colours.overrideColours = function(colours) {
+  // Colour overrides provided by the injection
+  if (colours) {
+    for (var colourProperty in colours) {
+      if (colours.hasOwnProperty(colourProperty) &&
+          Blockly.Colours.hasOwnProperty(colourProperty)) {
+        // If a property is in both colours option and Blockly.Colours,
+        // set the Blockly.Colours value to the override.
+        // Override Blockly category color object properties with those
+        // provided.
+        var colourPropertyValue = colours[colourProperty];
+        if (goog.isObject(colourPropertyValue)) {
+          for (var colourSequence in colourPropertyValue) {
+            if (colourPropertyValue.hasOwnProperty(colourSequence) &&
+              Blockly.Colours[colourProperty].hasOwnProperty(colourSequence)) {
+              Blockly.Colours[colourProperty][colourSequence] =
+                  colourPropertyValue[colourSequence];
+            }
+          }
+        } else {
+          Blockly.Colours[colourProperty] = colourPropertyValue;
+        }
+      }
+    }
+  }
+};

--- a/core/options.js
+++ b/core/options.js
@@ -119,30 +119,7 @@ Blockly.Options = function(options) {
   var enableRealtime = !!options['realtime'];
   var realtimeOptions = enableRealtime ? options['realtimeOptions'] : undefined;
 
-  // Colour overrides provided by the injection
-  var colours = options['colours'];
-  if (colours) {
-    for (var colourProperty in colours) {
-      if (colours.hasOwnProperty(colourProperty) &&
-          Blockly.Colours.hasOwnProperty(colourProperty)) {
-        // If a property is in both colours option and Blockly.Colours,
-        // set the Blockly.Colours value to the override.
-        // Override Blockly category color object properties with those
-        // provided.
-        var colourPropertyValue = colours[colourProperty];
-        if (goog.isObject(colourPropertyValue)) {
-          for (var colourSequence in colourPropertyValue) {
-            if (colourPropertyValue.hasOwnProperty(colourSequence) &&
-              Blockly.Colours[colourProperty].hasOwnProperty(colourSequence)) {
-              Blockly.Colours[colourProperty][colourSequence] = colourPropertyValue[colourSequence];
-            }
-          }
-        } else {
-          Blockly.Colours[colourProperty] = colourPropertyValue;
-        }
-      }
-    }
-  }
+  Blockly.Colours.overrideColours(options['colours']);
 
   this.RTL = rtl;
   this.oneBasedIndex = oneBasedIndex;


### PR DESCRIPTION
### Resolves

None

### Proposed Changes

Moves a chunk of scratch-specific colour code out of options.js

### Reason for Changes

Separate scratch-specific code from general code, to improve merges.

### Additional Information
Scratch and Blockly do colours slightly differently (primary, secondary, tertiary vs. single colour).  We'd eventually like to move to a better way of doing colours in Blockly, but it's not high priority.  In the meantime, this is code that will continue to be different between the two repos, so I'm going to consider colours.js to be a file where we always use the scratch version during a merge, and try to move colour-related code there in both repositories.  (The file doesn't exist yet in Blockly, but I will make it as I move things there).

If we reach a point where our colour handling is essentially the same, I will be able to later handle merges between the two different versions of colours.js.  If we stay divergent, this will at least be cleaner.
