### PR TITLE
Revert "Throw Errors instead of using goog.asserts"

### DIFF
--- a/core/block_drag_surface.js
+++ b/core/block_drag_surface.js
@@ -31,6 +31,7 @@
 
 goog.provide('Blockly.BlockDragSurfaceSvg');
 goog.require('Blockly.utils');
+goog.require('goog.asserts');
 goog.require('goog.math.Coordinate');
 
 
@@ -178,9 +179,8 @@ Blockly.BlockDragSurfaceSvg.prototype.createDropShadowDom_ = function(defs) {
  * surface.
  */
 Blockly.BlockDragSurfaceSvg.prototype.setBlocksAndShow = function(blocks) {
-  if (this.dragGroup_.childNodes.length) {
-    throw Error('Already dragging a block.');
-  }
+  goog.asserts.assert(
+      this.dragGroup_.childNodes.length == 0, 'Already dragging a block.');
   // appendChild removes the blocks from the previous parent
   this.dragGroup_.appendChild(blocks);
   this.SVG_.style.display = 'block';
@@ -286,9 +286,8 @@ Blockly.BlockDragSurfaceSvg.prototype.clearAndHide = function(opt_newSurface) {
     this.dragGroup_.removeChild(this.getCurrentBlock());
   }
   this.SVG_.style.display = 'none';
-  if (this.dragGroup_.childNodes.length) {
-    throw Error('Drag group was not cleared.');
-  }
+  goog.asserts.assert(
+      this.dragGroup_.childNodes.length == 0, 'Drag group was not cleared.');
   this.surfaceXY_ = null;
 
   // Reset the overflow property back to hidden so that nothing appears outside

--- a/core/block_dragger.js
+++ b/core/block_dragger.js
@@ -33,6 +33,7 @@ goog.require('Blockly.Events.EndBlockDrag');
 goog.require('Blockly.InsertionMarkerManager');
 
 goog.require('goog.math.Coordinate');
+goog.require('goog.asserts');
 
 
 /**

--- a/core/block_events.js
+++ b/core/block_events.js
@@ -300,7 +300,7 @@ Blockly.Events.Delete = function(block) {
     return;  // Blank event to be populated by fromJson.
   }
   if (block.getParent()) {
-    throw Error('Connected blocks cannot be deleted.');
+    throw 'Connected blocks cannot be deleted.';
   }
   Blockly.Events.Delete.superClass_.constructor.call(this, block);
 

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -39,6 +39,7 @@ goog.require('Blockly.Touch');
 goog.require('Blockly.utils');
 
 goog.require('goog.Timer');
+goog.require('goog.asserts');
 goog.require('goog.dom');
 goog.require('goog.math.Coordinate');
 
@@ -143,9 +144,7 @@ Blockly.BlockSvg.INLINE = -1;
  * May be called more than once.
  */
 Blockly.BlockSvg.prototype.initSvg = function() {
-  if (!this.workspace.rendered) {
-    throw TypeError('Workspace is headless.');
-  }
+  goog.asserts.assert(this.workspace.rendered, 'Workspace is headless.');
   if (!this.isInsertionMarker()) { // Insertion markers not allowed to have inputs or icons
     // Input shapes are empty holes drawn when a value input is not connected.
     for (var i = 0, input; input = this.inputList[i]; i++) {
@@ -363,9 +362,7 @@ Blockly.BlockSvg.prototype.getRelativeToSurfaceXY = function() {
  * @param {number} dy Vertical offset in workspace units.
  */
 Blockly.BlockSvg.prototype.moveBy = function(dx, dy) {
-  if (this.parentBlock_) {
-    throw Error('Block has parent.');
-  }
+  goog.asserts.assert(!this.parentBlock_, 'Block has parent.');
   var eventsEnabled = Blockly.Events.isEnabled();
   if (eventsEnabled) {
     var event = new Blockly.Events.BlockMove(this);
@@ -651,7 +648,7 @@ Blockly.BlockSvg.prototype.onMouseDown_ = function(e) {
  * @private
  */
 Blockly.BlockSvg.prototype.showHelp_ = function() {
-  var url = (typeof this.helpUrl == 'function') ? this.helpUrl() : this.helpUrl;
+  var url = goog.isFunction(this.helpUrl) ? this.helpUrl() : this.helpUrl;
   if (url) {
     // @todo rewrite
     alert(url);
@@ -892,7 +889,7 @@ Blockly.BlockSvg.prototype.getCommentText = function() {
 Blockly.BlockSvg.prototype.setCommentText = function(text, commentId,
     commentX, commentY, minimized) {
   var changedState = false;
-  if (typeof text == 'string') {
+  if (goog.isString(text)) {
     if (!this.comment) {
       this.comment = new Blockly.ScratchBlockComment(this, text, commentId,
           commentX, commentY, minimized);
@@ -908,7 +905,7 @@ Blockly.BlockSvg.prototype.setCommentText = function(text, commentId,
   }
   if (changedState && this.rendered) {
     this.render();
-    if (typeof text == 'string') {
+    if (goog.isString(text)) {
       this.comment.setVisible(true);
     }
     // Adding or removing a comment icon will cause the block to change shape.
@@ -957,7 +954,7 @@ Blockly.BlockSvg.prototype.setWarningText = function(text, opt_id) {
   }
 
   var changedState = false;
-  if (typeof text == 'string') {
+  if (goog.isString(text)) {
     if (!this.warning) {
       this.warning = new Blockly.Warning(this);
       changedState = true;

--- a/core/bubble_dragger.js
+++ b/core/bubble_dragger.js
@@ -31,6 +31,7 @@ goog.require('Blockly.Events.CommentMove');
 goog.require('Blockly.WorkspaceCommentSvg');
 
 goog.require('goog.math.Coordinate');
+goog.require('goog.asserts');
 
 
 /**

--- a/core/connection.js
+++ b/core/connection.js
@@ -28,6 +28,7 @@ goog.provide('Blockly.Connection');
 
 goog.require('Blockly.Events.BlockMove');
 
+goog.require('goog.asserts');
 goog.require('goog.dom');
 
 
@@ -172,7 +173,7 @@ Blockly.Connection.prototype.connect_ = function(childConnection) {
       // Statement blocks may be inserted into the middle of a stack.
       // Split the stack.
       if (!orphanBlock.previousConnection) {
-        throw Error('Orphan block does not have a previous connection.');
+        throw 'Orphan block does not have a previous connection.';
       }
       // Attempt to reattach the orphan at the bottom of the newly inserted
       // block.  Since this block may be a stack, walk down to the end.
@@ -238,7 +239,7 @@ Blockly.Connection.prototype.connect_ = function(childConnection) {
  */
 Blockly.Connection.prototype.dispose = function() {
   if (this.isConnected()) {
-    throw Error('Disconnect connection before disposing of it.');
+    throw 'Disconnect connection before disposing of it.';
   }
   if (this.inDB_) {
     this.db_.removeConnection_(this);
@@ -333,24 +334,24 @@ Blockly.Connection.prototype.checkConnection_ = function(target) {
     case Blockly.Connection.CAN_CONNECT:
       break;
     case Blockly.Connection.REASON_SELF_CONNECTION:
-      throw Error('Attempted to connect a block to itself.');
+      throw 'Attempted to connect a block to itself.';
     case Blockly.Connection.REASON_DIFFERENT_WORKSPACES:
       // Usually this means one block has been deleted.
-      throw Error('Blocks not on same workspace.');
+      throw 'Blocks not on same workspace.';
     case Blockly.Connection.REASON_WRONG_TYPE:
-      throw Error('Attempt to connect incompatible types.');
+      throw 'Attempt to connect incompatible types.';
     case Blockly.Connection.REASON_TARGET_NULL:
-      throw Error('Target connection is null.');
+      throw 'Target connection is null.';
     case Blockly.Connection.REASON_CHECKS_FAILED:
       var msg = 'Connection checks failed. ';
       msg += this + ' expected '  + this.check_ + ', found ' + target.check_;
-      throw Error(msg);
+      throw msg;
     case Blockly.Connection.REASON_SHADOW_PARENT:
-      throw Error('Connecting non-shadow to shadow block.');
+      throw 'Connecting non-shadow to shadow block.';
     case Blockly.Connection.REASON_CUSTOM_PROCEDURE:
       throw 'Trying to replace a shadow on a custom procedure definition.';
     default:
-      throw Error('Unknown connection failure: this should never happen!');
+      throw 'Unknown connection failure: this should never happen!';
   }
 };
 
@@ -479,7 +480,7 @@ Blockly.Connection.prototype.isConnectionAllowed = function(candidate) {
       break;
     }
     default:
-      throw Error('Unknown connection type in isConnectionAllowed');
+      throw 'Unknown connection type in isConnectionAllowed';
   }
 
   // Don't let blocks try to connect to themselves or ones they nest.
@@ -517,9 +518,7 @@ Blockly.Connection.prototype.connect = function(otherConnection) {
  * @private
  */
 Blockly.Connection.connectReciprocally_ = function(first, second) {
-  if (!first || !second) {
-    throw Error('Cannot connect null connections.');
-  }
+  goog.asserts.assert(first && second, 'Cannot connect null connections.');
   first.targetConnection = second;
   second.targetConnection = first;
 };
@@ -553,12 +552,10 @@ Blockly.Connection.singleConnection_ = function(block, orphanBlock) {
  */
 Blockly.Connection.prototype.disconnect = function() {
   var otherConnection = this.targetConnection;
-  if (!otherConnection) {
-    throw Error('Source connection not connected.');
-  }
-  if (otherConnection.targetConnection != this) {
-    throw Error('Target connection not connected to source connection.');
-  }
+  goog.asserts.assert(otherConnection, 'Source connection not connected.');
+  goog.asserts.assert(otherConnection.targetConnection == this,
+      'Target connection not connected to source connection.');
+
   var parentBlock, childBlock, parentConnection;
   if (this.isSuperior()) {
     // Superior block.
@@ -612,7 +609,7 @@ Blockly.Connection.prototype.respawnShadow_ = function() {
     } else if (blockShadow.previousConnection) {
       this.connect(blockShadow.previousConnection);
     } else {
-      throw Error('Child block does not have output or previous statement.');
+      throw 'Child block does not have output or previous statement.';
     }
   }
 };
@@ -672,7 +669,7 @@ Blockly.Connection.prototype.onCheckChanged_ = function() {
 Blockly.Connection.prototype.setCheck = function(check) {
   if (check) {
     // Ensure that check is in an array.
-    if (!Array.isArray(check)) {
+    if (!goog.isArray(check)) {
       check = [check];
     }
     this.check_ = check;

--- a/core/connection_db.js
+++ b/core/connection_db.js
@@ -51,7 +51,7 @@ Blockly.ConnectionDB.constructor = Blockly.ConnectionDB;
  */
 Blockly.ConnectionDB.prototype.addConnection = function(connection) {
   if (connection.inDB_) {
-    throw Error('Connection already in database.');
+    throw 'Connection already in database.';
   }
   if (connection.getSourceBlock().isInFlyout) {
     // Don't bother maintaining a database of connections in a flyout.
@@ -137,11 +137,11 @@ Blockly.ConnectionDB.prototype.findPositionForConnection_ = function(
  */
 Blockly.ConnectionDB.prototype.removeConnection_ = function(connection) {
   if (!connection.inDB_) {
-    throw Error('Connection not in database.');
+    throw 'Connection not in database.';
   }
   var removalIndex = this.findConnection(connection);
   if (removalIndex == -1) {
-    throw Error('Unable to find connection in connectionDB.');
+    throw 'Unable to find connection in connectionDB.';
   }
   connection.inDB_ = false;
   this.splice(removalIndex, 1);

--- a/core/contextmenu.js
+++ b/core/contextmenu.js
@@ -243,8 +243,7 @@ Blockly.ContextMenu.blockDeleteOption = function(block) {
  * @package
  */
 Blockly.ContextMenu.blockHelpOption = function(block) {
-  var url = (typeof block.helpUrl == 'function') ?
-      block.helpUrl() : block.helpUrl;
+  var url = goog.isFunction(block.helpUrl) ? block.helpUrl() : block.helpUrl;
   var helpOption = {
     enabled: !!url,
     text: Blockly.Msg.HELP,

--- a/core/events.js
+++ b/core/events.js
@@ -383,7 +383,7 @@ Blockly.Events.fromJson = function(json, workspace) {
       event = new Blockly.Events.EndBlockDrag(null, false);
       break;
     default:
-      throw Error('Unknown event type.');
+      throw 'Unknown event type.';
   }
   event.fromJson(json);
   event.workspaceId = workspace.id;

--- a/core/extensions.js
+++ b/core/extensions.js
@@ -36,6 +36,9 @@ goog.provide('Blockly.Extensions');
 goog.require('Blockly.Mutator');
 goog.require('Blockly.utils');
 
+goog.require('goog.string');
+
+
 /**
  * The set of all registered extensions, keyed by extension name/id.
  * @private
@@ -53,13 +56,13 @@ Blockly.Extensions.ALL_ = {};
  *     registered, or extensionFn is not a function.
  */
 Blockly.Extensions.register = function(name, initFn) {
-  if ((typeof name != 'string') || (name.trim() == '')) {
+  if (!goog.isString(name) || goog.string.isEmptyOrWhitespace(name)) {
     throw new Error('Error: Invalid extension name "' + name + '"');
   }
   if (Blockly.Extensions.ALL_[name]) {
     throw new Error('Error: Extension "' + name + '" is already registered.');
   }
-  if (typeof initFn != 'function') {
+  if (!goog.isFunction(initFn)) {
     throw new Error('Error: Extension "' + name + '" must be a function');
   }
   Blockly.Extensions.ALL_[name] = initFn;
@@ -73,7 +76,7 @@ Blockly.Extensions.register = function(name, initFn) {
  *     registered.
  */
 Blockly.Extensions.registerMixin = function(name, mixinObj) {
-  if (!mixinObj || typeof mixinObj != 'object'){
+  if (!goog.isObject(mixinObj)){
     throw new Error('Error: Mixin "' + name + '" must be a object');
   }
   Blockly.Extensions.register(name, function() {
@@ -107,7 +110,7 @@ Blockly.Extensions.registerMutator = function(name, mixinObj, opt_helperFn,
   var hasMutatorDialog =
       Blockly.Extensions.checkMutatorDialog_(mixinObj, errorPrefix);
 
-  if (opt_helperFn && (typeof opt_helperFn != 'function')) {
+  if (opt_helperFn && !goog.isFunction(opt_helperFn)) {
     throw new Error('Extension "' + name + '" is not a function');
   }
 
@@ -135,7 +138,7 @@ Blockly.Extensions.registerMutator = function(name, mixinObj, opt_helperFn,
  */
 Blockly.Extensions.apply = function(name, block, isMutator) {
   var extensionFn = Blockly.Extensions.ALL_[name];
-  if (typeof extensionFn != 'function') {
+  if (!goog.isFunction(extensionFn)) {
     throw new Error('Error: Extension "' + name + '" not found.');
   }
   if (isMutator) {
@@ -329,7 +332,7 @@ Blockly.Extensions.buildTooltipForDropdown = function(dropdownName,
   if (document) { // Relies on document.readyState
     Blockly.utils.runAfterPageLoad(function() {
       for (var key in lookupTable) {
-        // Will print warnings if reference is missing.
+        // Will print warnings is reference is missing.
         Blockly.utils.checkMessageReferences(lookupTable[key]);
       }
     });

--- a/core/field.js
+++ b/core/field.js
@@ -31,6 +31,7 @@ goog.provide('Blockly.Field');
 goog.require('Blockly.Events.BlockChange');
 goog.require('Blockly.Gesture');
 
+goog.require('goog.asserts');
 goog.require('goog.dom');
 goog.require('goog.math.Size');
 goog.require('goog.style');
@@ -80,10 +81,10 @@ Blockly.Field.TYPE_MAP_ = {};
  *     object containing a fromJson function.
  */
 Blockly.Field.register = function(type, fieldClass) {
-  if ((typeof type != 'string') || (type.trim() == '')) {
+  if (!goog.isString(type) || goog.string.isEmptyOrWhitespace(type)) {
     throw new Error('Invalid field type "' + type + '"');
   }
-  if (!fieldClass || (typeof fieldClass.fromJson != 'function')) {
+  if (!goog.isObject(fieldClass) || !goog.isFunction(fieldClass.fromJson)) {
     throw new Error('Field "' + fieldClass +
         '" must have a fromJson function');
   }
@@ -204,9 +205,7 @@ Blockly.Field.prototype.SERIALIZABLE = true;
  * @param {!Blockly.Block} block The block containing this field.
  */
 Blockly.Field.prototype.setSourceBlock = function(block) {
-  if (this.sourceBlock_) {
-    throw Error('Field already bound to a block.');
-  }
+  goog.asserts.assert(!this.sourceBlock_, 'Field already bound to a block.');
   this.sourceBlock_ = block;
 };
 

--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -317,7 +317,7 @@ Blockly.FieldDropdown.prototype.trimOptions_ = function() {
   this.prefixField = null;
   this.suffixField = null;
   var options = this.menuGenerator_;
-  if (!Array.isArray(options)) {
+  if (!goog.isArray(options)) {
     return;
   }
   var hasImages = false;
@@ -373,7 +373,7 @@ Blockly.FieldDropdown.prototype.trimOptions_ = function() {
  *     Otherwise false.
  */
 Blockly.FieldDropdown.prototype.isOptionListDynamic = function() {
-  return typeof this.menuGenerator_ == 'function';
+  return goog.isFunction(this.menuGenerator_);
 };
 
 /**

--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -33,6 +33,7 @@ goog.require('Blockly.Msg');
 goog.require('Blockly.scratchBlocksUtils');
 goog.require('Blockly.utils');
 
+goog.require('goog.asserts');
 goog.require('goog.dom');
 goog.require('goog.dom.TagName');
 goog.require('goog.userAgent');
@@ -428,9 +429,7 @@ Blockly.FieldTextInput.prototype.onHtmlInputChange_ = function(e) {
  */
 Blockly.FieldTextInput.prototype.validate_ = function() {
   var valid = true;
-  if (!Blockly.FieldTextInput.htmlInput_) {
-    throw Error('htmlInput not defined');
-  }
+  goog.asserts.assertObject(Blockly.FieldTextInput.htmlInput_);
   var htmlInput = Blockly.FieldTextInput.htmlInput_;
   if (this.sourceBlock_) {
     valid = this.callValidator(htmlInput.value);

--- a/core/field_variable.js
+++ b/core/field_variable.js
@@ -30,6 +30,7 @@ goog.require('Blockly.FieldDropdown');
 goog.require('Blockly.Msg');
 goog.require('Blockly.VariableModel');
 goog.require('Blockly.Variables');
+goog.require('goog.asserts');
 goog.require('goog.string');
 
 
@@ -158,9 +159,8 @@ Blockly.FieldVariable.dispose = function() {
  * @param {!Blockly.Block} block The block containing this field.
  */
 Blockly.FieldVariable.prototype.setSourceBlock = function(block) {
-  if (block.isShadow()) {
-    throw Error('Variable fields are not allowed to exist on shadow blocks.');
-  }
+  goog.asserts.assert(!block.isShadow(),
+      'Variable fields are not allowed to exist on shadow blocks.');
   Blockly.FieldVariable.superClass_.setSourceBlock.call(this, block);
 };
 

--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -860,7 +860,7 @@ Blockly.Flyout.prototype.placeNewBlock_ = function(oldBlock) {
   var targetWorkspace = this.targetWorkspace_;
   var svgRootOld = oldBlock.getSvgRoot();
   if (!svgRootOld) {
-    throw Error('oldBlock is not rendered.');
+    throw 'oldBlock is not rendered.';
   }
 
   // Create the new block by cloning the block in the flyout (via XML).
@@ -874,7 +874,7 @@ Blockly.Flyout.prototype.placeNewBlock_ = function(oldBlock) {
   var block = Blockly.Xml.domToBlock(xml, targetWorkspace);
   var svgRootNew = block.getSvgRoot();
   if (!svgRootNew) {
-    throw Error('block is not rendered.');
+    throw 'block is not rendered.';
   }
 
   // The offset in pixels between the main workspace's origin and the upper left

--- a/core/flyout_dragger.js
+++ b/core/flyout_dragger.js
@@ -28,6 +28,7 @@ goog.provide('Blockly.FlyoutDragger');
 
 goog.require('Blockly.WorkspaceDragger');
 
+goog.require('goog.asserts');
 goog.require('goog.math.Coordinate');
 
 

--- a/core/flyout_horizontal.js
+++ b/core/flyout_horizontal.js
@@ -128,7 +128,7 @@ Blockly.HorizontalFlyout.prototype.setMetrics_ = function(xyRatio) {
     return;
   }
 
-  if (typeof xyRatio.x == 'number') {
+  if (goog.isNumber(xyRatio.x)) {
     this.workspace_.scrollX = -metrics.contentWidth * xyRatio.x;
   }
 

--- a/core/flyout_vertical.js
+++ b/core/flyout_vertical.js
@@ -248,7 +248,7 @@ Blockly.VerticalFlyout.prototype.setMetrics_ = function(xyRatio) {
   if (!metrics) {
     return;
   }
-  if (typeof xyRatio.y == 'number') {
+  if (goog.isNumber(xyRatio.y)) {
     this.workspace_.scrollY = -metrics.contentHeight * xyRatio.y;
   }
   this.workspace_.translate(this.workspace_.scrollX + metrics.absoluteLeft,

--- a/core/generator.js
+++ b/core/generator.js
@@ -28,6 +28,7 @@
 goog.provide('Blockly.Generator');
 
 goog.require('Blockly.Block');
+goog.require('goog.asserts');
 
 
 /**
@@ -98,7 +99,7 @@ Blockly.Generator.prototype.workspaceToCode = function(workspace) {
   var blocks = workspace.getTopBlocks(true);
   for (var x = 0, block; block = blocks[x]; x++) {
     var line = this.blockToCode(block);
-    if (Array.isArray(line)) {
+    if (goog.isArray(line)) {
       // Value blocks return tuples of code and operator order.
       // Top-level blocks don't care about operator order.
       line = line[0];
@@ -172,32 +173,31 @@ Blockly.Generator.prototype.blockToCode = function(block) {
   }
 
   var func = this[block.type];
-  if (typeof func != 'function') {
-    throw Error('Language "' + this.name_ + '" does not know how to generate ' +
-        ' code for block type "' + block.type + '".');
-  }
+  goog.asserts.assertFunction(func,
+      'Language "%s" does not know how to generate code for block type "%s".',
+      this.name_, block.type);
   // First argument to func.call is the value of 'this' in the generator.
   // Prior to 24 September 2013 'this' was the only way to access the block.
   // The current prefered method of accessing the block is through the second
   // argument to func.call, which becomes the first parameter to the generator.
   var code = func.call(block, block);
-  if (Array.isArray(code)) {
+  if (goog.isArray(code)) {
     // Value blocks return tuples of code and operator order.
-    if (!block.outputConnection) {
-      throw TypeError('Expecting string from statement block: ' + block.type);
-    }
+    goog.asserts.assert(block.outputConnection,
+        'Expecting string from statement block "%s".', block.type);
     return [this.scrub_(block, code[0]), code[1]];
-  } else if (typeof code == 'string') {
+  } else if (goog.isString(code)) {
     var id = block.id.replace(/\$/g, '$$$$');  // Issue 251.
     if (this.STATEMENT_PREFIX) {
-      code = this.STATEMENT_PREFIX.replace(/%1/g, '\'' + id + '\'') + code;
+      code = this.STATEMENT_PREFIX.replace(/%1/g, '\'' + id + '\'') +
+          code;
     }
     return this.scrub_(block, code);
   } else if (code === null) {
     // Block has handled code generation itself.
     return '';
   } else {
-    throw SyntaxError('Invalid code generated: ' + code);
+    goog.asserts.fail('Invalid code generated: %s', code);
   }
 };
 
@@ -212,7 +212,7 @@ Blockly.Generator.prototype.blockToCode = function(block) {
  */
 Blockly.Generator.prototype.valueToCode = function(block, name, outerOrder) {
   if (isNaN(outerOrder)) {
-    throw TypeError('Expecting valid order from block: ' + block.type);
+    goog.asserts.fail('Expecting valid order from block "%s".', block.type);
   }
   var targetBlock = block.getInputTargetBlock(name);
   if (!targetBlock) {
@@ -225,13 +225,12 @@ Blockly.Generator.prototype.valueToCode = function(block, name, outerOrder) {
   }
   // Value blocks must return code and order of operations info.
   // Statement blocks must only return code.
-  if (!Array.isArray(tuple)) {
-    throw TypeError('Expecting tuple from value block: ' + targetBlock.type);
-  }
+  goog.asserts.assertArray(tuple, 'Expecting tuple from value block "%s".',
+      targetBlock.type);
   var code = tuple[0];
   var innerOrder = tuple[1];
   if (isNaN(innerOrder)) {
-    throw TypeError('Expecting valid order from value block: ' +
+    goog.asserts.fail('Expecting valid order from value block "%s".',
         targetBlock.type);
   }
   if (!code) {
@@ -283,10 +282,8 @@ Blockly.Generator.prototype.statementToCode = function(block, name) {
   var code = this.blockToCode(targetBlock);
   // Value blocks must return code and order of operations info.
   // Statement blocks must only return code.
-  if (typeof code != 'string') {
-    throw TypeError('Expecting code from statement block: ' +
-        (targetBlock && targetBlock.type));
-  }
+  goog.asserts.assertString(code, 'Expecting code from statement block "%s".',
+      targetBlock && targetBlock.type);
   if (code) {
     code = this.prefixLines(/** @type {string} */ (code), this.INDENT);
   }

--- a/core/gesture.js
+++ b/core/gesture.js
@@ -38,6 +38,7 @@ goog.require('Blockly.Tooltip');
 goog.require('Blockly.Touch');
 goog.require('Blockly.WorkspaceDragger');
 
+goog.require('goog.asserts');
 goog.require('goog.math.Coordinate');
 
 
@@ -430,9 +431,8 @@ Blockly.Gesture.prototype.updateIsDraggingWorkspace_ = function() {
  */
 Blockly.Gesture.prototype.updateIsDragging_ = function() {
   // Sanity check.
-  if (this.calledUpdateIsDragging_) {
-    throw Error('updateIsDragging_ should only be called once per gesture.');
-  }
+  goog.asserts.assert(!this.calledUpdateIsDragging_,
+      'updateIsDragging_ should only be called once per gesture.');
   this.calledUpdateIsDragging_ = true;
 
   // First check if it was a bubble drag.  Bubbles always sit on top of blocks.
@@ -510,7 +510,7 @@ Blockly.Gesture.prototype.doStart = function(e) {
     return;
   }
 
-  if (e.type.toLowerCase() == 'touchstart') {
+  if (goog.string.caseInsensitiveEquals(e.type, 'touchstart')) {
     Blockly.longStart_(e, this);
   }
 
@@ -659,10 +659,9 @@ Blockly.Gesture.prototype.handleRightClick = function(e) {
  * @package
  */
 Blockly.Gesture.prototype.handleWsStart = function(e, ws) {
-  if (this.hasStarted_) {
-    throw Error('Tried to call gesture.handleWsStart, ' +
-        'but the gesture had already been started.');
-  }
+  goog.asserts.assert(!this.hasStarted_,
+      'Tried to call gesture.handleWsStart, but the gesture had already been ' +
+      'started.');
   this.setStartWorkspace_(ws);
   this.mostRecentEvent_ = e;
   this.doStart(e);
@@ -675,10 +674,9 @@ Blockly.Gesture.prototype.handleWsStart = function(e, ws) {
  * @package
  */
 Blockly.Gesture.prototype.handleFlyoutStart = function(e, flyout) {
-  if (this.hasStarted_) {
-    throw Error('Tried to call gesture.handleFlyoutStart, ' +
-        'but the gesture had already been started.');
-  }
+  goog.asserts.assert(!this.hasStarted_,
+      'Tried to call gesture.handleFlyoutStart, but the gesture had already ' +
+      'been started.');
   this.setStartFlyout_(flyout);
   this.handleWsStart(e, flyout.getWorkspace());
 };
@@ -690,10 +688,9 @@ Blockly.Gesture.prototype.handleFlyoutStart = function(e, flyout) {
  * @package
  */
 Blockly.Gesture.prototype.handleBlockStart = function(e, block) {
-  if (this.hasStarted_) {
-    throw Error('Tried to call gesture.handleBlockStart, ' +
-        'but the gesture had already been started.');
-  }
+  goog.asserts.assert(!this.hasStarted_,
+      'Tried to call gesture.handleBlockStart, but the gesture had already ' +
+      'been started.');
   this.setStartBlock(block);
   this.mostRecentEvent_ = e;
 };
@@ -705,10 +702,9 @@ Blockly.Gesture.prototype.handleBlockStart = function(e, block) {
  * @package
  */
 Blockly.Gesture.prototype.handleBubbleStart = function(e, bubble) {
-  if (this.hasStarted_) {
-    throw Error('Tried to call gesture.handleBubbleStart, ' +
-        'but the gesture had already been started.');
-  }
+  goog.asserts.assert(!this.hasStarted_,
+      'Tried to call gesture.handleBubbleStart, but the gesture had already ' +
+      'been started.');
   this.setStartBubble(bubble);
   this.mostRecentEvent_ = e;
 };
@@ -803,10 +799,9 @@ Blockly.Gesture.prototype.bringBlockToFront_ = function() {
  * @package
  */
 Blockly.Gesture.prototype.setStartField = function(field) {
-  if (this.hasStarted_) {
-    throw Error('Tried to call gesture.setStartField, ' +
-        'but the gesture had already been started.');
-  }
+  goog.asserts.assert(!this.hasStarted_,
+      'Tried to call gesture.setStartField, but the gesture had already been ' +
+      'started.');
   if (!this.startField_) {
     this.startField_ = field;
   }

--- a/core/input.js
+++ b/core/input.js
@@ -28,6 +28,7 @@ goog.provide('Blockly.Input');
 
 goog.require('Blockly.Connection');
 goog.require('Blockly.FieldLabel');
+goog.require('goog.asserts');
 
 
 /**
@@ -41,7 +42,7 @@ goog.require('Blockly.FieldLabel');
  */
 Blockly.Input = function(type, name, block, connection) {
   if (type != Blockly.DUMMY_INPUT && !name) {
-    throw Error('Value inputs and statement inputs must have non-empty name.');
+    throw 'Value inputs and statement inputs must have non-empty name.';
   }
   /** @type {number} */
   this.type = type;
@@ -110,7 +111,7 @@ Blockly.Input.prototype.insertFieldAt = function(index, field, opt_name) {
     return this;
   }
   // Generate a FieldLabel when given a plain text field.
-  if (typeof field == 'string') {
+  if (goog.isString(field)) {
     field = new Blockly.FieldLabel(/** @type {string} */ (field));
   }
   field.setSourceBlock(this.sourceBlock_);
@@ -142,7 +143,7 @@ Blockly.Input.prototype.insertFieldAt = function(index, field, opt_name) {
 /**
  * Remove a field from this input.
  * @param {string} name The name of the field.
- * @throws {Error} if the field is not present.
+ * @throws {goog.asserts.AssertionError} if the field is not present.
  */
 Blockly.Input.prototype.removeField = function(name) {
   for (var i = 0, field; field = this.fieldRow[i]; i++) {
@@ -157,7 +158,7 @@ Blockly.Input.prototype.removeField = function(name) {
       return;
     }
   }
-  throw Error('Field "%s" not found.', name);
+  goog.asserts.fail('Field "%s" not found.', name);
 };
 
 /**
@@ -211,7 +212,7 @@ Blockly.Input.prototype.setVisible = function(visible) {
  */
 Blockly.Input.prototype.setCheck = function(check) {
   if (!this.connection) {
-    throw Error('This input does not have a connection.');
+    throw 'This input does not have a connection.';
   }
   this.connection.setCheck(check);
   return this;

--- a/core/rendered_connection.js
+++ b/core/rendered_connection.js
@@ -166,7 +166,7 @@ Blockly.RenderedConnection.prototype.tighten_ = function() {
     var block = this.targetBlock();
     var svgRoot = block.getSvgRoot();
     if (!svgRoot) {
-      throw Error('block is not rendered.');
+      throw 'block is not rendered.';
     }
     // Workspace coordinates.
     var xy = Blockly.utils.getRelativeXY(svgRoot);
@@ -347,7 +347,7 @@ Blockly.RenderedConnection.prototype.respawnShadow_ = function() {
     Blockly.RenderedConnection.superClass_.respawnShadow_.call(this);
     var blockShadow = this.targetBlock();
     if (!blockShadow) {
-      throw Error('Couldn\'t respawn the shadow block that should exist here.');
+      throw 'Couldn\'t respawn the shadow block that should exist here.';
     }
     blockShadow.initSvg();
     blockShadow.render(false);

--- a/core/scrollbar.js
+++ b/core/scrollbar.js
@@ -662,7 +662,7 @@ Blockly.Scrollbar.prototype.setVisible = function(visible) {
   // Ideally this would also apply to scrollbar pairs, but that's a bigger
   // headache (due to interactions with the corner square).
   if (this.pair_) {
-    throw Error('Unable to toggle visibility of paired scrollbars.');
+    throw 'Unable to toggle visibility of paired scrollbars.';
   }
   this.isVisible_ = visible;
   if (visibilityChanged) {

--- a/core/tooltip.js
+++ b/core/tooltip.js
@@ -167,8 +167,7 @@ Blockly.Tooltip.onMouseOver_ = function(e) {
   // If the tooltip is an object, treat it as a pointer to the next object in
   // the chain to look at.  Terminate when a string or function is found.
   var element = e.target;
-  while ((typeof element.tooltip != 'string') &&
-         (typeof element.tooltip != 'function')) {
+  while (!goog.isString(element.tooltip) && !goog.isFunction(element.tooltip)) {
     element = element.tooltip;
   }
   if (Blockly.Tooltip.element_ != element) {
@@ -290,7 +289,7 @@ Blockly.Tooltip.show_ = function() {
   goog.dom.removeChildren(/** @type {!Element} */ (Blockly.Tooltip.DIV));
   // Get the new text.
   var tip = Blockly.Tooltip.element_.tooltip;
-  while (typeof tip == 'function') {
+  while (goog.isFunction(tip)) {
     tip = tip();
   }
   tip = Blockly.utils.wrap(tip, Blockly.Tooltip.LIMIT);

--- a/core/utils.js
+++ b/core/utils.js
@@ -445,7 +445,7 @@ Blockly.utils.tokenizeInterpolation = function(message) {
  * @return {!string} String with message references replaced.
  */
 Blockly.utils.replaceMessageReferences = function(message) {
-  if (typeof message != 'string') {
+  if (!goog.isString(message)) {
     return message;
   }
   var interpolatedResult = Blockly.utils.tokenizeInterpolation_(message, false);
@@ -560,11 +560,11 @@ Blockly.utils.tokenizeInterpolation_ = function(message,
           // BKY_ is the prefix used to namespace the strings used in Blockly
           // core files and the predefined blocks in ../blocks/. These strings
           // are defined in ../msgs/ files.
-          var bklyKey = Blockly.utils.startsWith(keyUpper, 'BKY_') ?
+          var bklyKey = goog.string.startsWith(keyUpper, 'BKY_') ?
               keyUpper.substring(4) : null;
           if (bklyKey && bklyKey in Blockly.Msg) {
             var rawValue = Blockly.Msg[bklyKey];
-            if (typeof rawValue == 'string') {
+            if (goog.isString(rawValue)) {
               // Attempt to dereference substrings, too, appending to the end.
               Array.prototype.push.apply(tokens,
                   Blockly.utils.tokenizeInterpolation(rawValue));
@@ -873,7 +873,7 @@ Blockly.utils.insertAfter_ = function(newNode, refNode) {
   var siblingNode = refNode.nextSibling;
   var parentNode = refNode.parentNode;
   if (!parentNode) {
-    throw Error('Reference node has no parent.');
+    throw 'Reference node has no parent.';
   }
   if (siblingNode) {
     parentNode.insertBefore(newNode, siblingNode);
@@ -934,51 +934,4 @@ Blockly.utils.getViewportBBox = function() {
     top: scrollOffset.y,
     left: scrollOffset.x
   };
-};
-
-/**
- * Fast prefix-checker.
- * Copied from Closure's goog.string.startsWith.
- * @param {string} str The string to check.
- * @param {string} prefix A string to look for at the start of `str`.
- * @return {boolean} True if `str` begins with `prefix`.
- */
-Blockly.utils.startsWith = function(str, prefix) {
-  return str.lastIndexOf(prefix, 0) == 0;
-};
-
-/**
- * Removes the first occurrence of a particular value from an array.
- * @param {!Array} arr Array from which to remove
- *     value.
- * @param {*} obj Object to remove.
- * @return {boolean} True if an element was removed.
- */
-Blockly.utils.arrayRemove = function(arr, obj) {
-  var i = arr.indexOf(obj);
-  if (i == -1) {
-    return false;
-  }
-  arr.splice(i, 1);
-  return true;
-};
-
-/**
- * Converts degrees to radians.
- * Copied from Closure's goog.math.toRadians.
- * @param {number} angleDegrees Angle in degrees.
- * @return {number} Angle in radians.
- */
-Blockly.utils.toRadians = function(angleDegrees) {
-  return angleDegrees * Math.PI / 180;
-};
-
-/**
- * Converts radians to degrees.
- * Copied from Closure's goog.math.toDegrees.
- * @param {number} angleRadians Angle in radians.
- * @return {number} Angle in degrees.
- */
-Blockly.utils.toDegrees = function(angleRadians) {
-  return angleRadians * 180 / Math.PI;
 };

--- a/core/workspace.js
+++ b/core/workspace.js
@@ -176,8 +176,8 @@ Blockly.Workspace.prototype.addTopBlock = function(block) {
  * @param {!Blockly.Block} block Block to remove.
  */
 Blockly.Workspace.prototype.removeTopBlock = function(block) {
-  if (!Blockly.utils.arrayRemove(this.topBlocks_, block)) {
-    throw Error('Block not present in workspace\'s list of top-most blocks.');
+  if (!goog.array.remove(this.topBlocks_, block)) {
+    throw 'Block not present in workspace\'s list of top-most blocks.';
   }
 };
 
@@ -191,8 +191,7 @@ Blockly.Workspace.prototype.getTopBlocks = function(ordered) {
   // Copy the topBlocks_ list.
   var blocks = [].concat(this.topBlocks_);
   if (ordered && blocks.length > 1) {
-    var offset =
-        Math.sin(Blockly.utils.toRadians(Blockly.Workspace.SCAN_ANGLE));
+    var offset = Math.sin(goog.math.toRadians(Blockly.Workspace.SCAN_ANGLE));
     if (this.RTL) {
       offset *= -1;
     }
@@ -228,9 +227,8 @@ Blockly.Workspace.prototype.addTopComment = function(comment) {
  * @package
  */
 Blockly.Workspace.prototype.removeTopComment = function(comment) {
-  if (!Blockly.utils.arrayRemove(this.topComments_, comment)) {
-    throw Error('Comment not present in workspace\'s list of top-most ' +
-        'comments.');
+  if (!goog.array.remove(this.topComments_, comment)) {
+    throw 'Comment not present in workspace\'s list of top-most comments.';
   }
   // Note: If the comment database starts to hold block comments, this may need
   // to move to a separate function.
@@ -248,8 +246,7 @@ Blockly.Workspace.prototype.getTopComments = function(ordered) {
   // Copy the topComments_ list.
   var comments = [].concat(this.topComments_);
   if (ordered && comments.length > 1) {
-    var offset =
-        Math.sin(Blockly.utils.toRadians(Blockly.Workspace.SCAN_ANGLE));
+    var offset = Math.sin(goog.math.toRadians(Blockly.Workspace.SCAN_ANGLE));
     if (this.RTL) {
       offset *= -1;
     }
@@ -550,7 +547,7 @@ Blockly.Workspace.prototype.addChangeListener = function(func) {
  * @param {Function} func Function to stop calling.
  */
 Blockly.Workspace.prototype.removeChangeListener = function(func) {
-  Blockly.utils.arrayRemove(this.listeners_, func);
+  goog.array.remove(this.listeners_, func);
 };
 
 /**

--- a/core/workspace_comment_svg.js
+++ b/core/workspace_comment_svg.js
@@ -134,9 +134,7 @@ Blockly.WorkspaceCommentSvg.prototype.dispose = function() {
  * @package
  */
 Blockly.WorkspaceCommentSvg.prototype.initSvg = function() {
-  if (!this.workspace.rendered) {
-    throw TypeError('Workspace is headless.');
-  }
+  goog.asserts.assert(this.workspace.rendered, 'Workspace is headless.');
   if (!this.workspace.options.readOnly && !this.eventsInit_) {
     Blockly.bindEventWithChecks_(
         this.svgRectTarget_, 'mousedown', this, this.pathMouseDown_);

--- a/core/workspace_drag_surface_svg.js
+++ b/core/workspace_drag_surface_svg.js
@@ -32,6 +32,7 @@ goog.provide('Blockly.WorkspaceDragSurfaceSvg');
 
 goog.require('Blockly.utils');
 
+goog.require('goog.asserts');
 goog.require('goog.math.Coordinate');
 
 
@@ -137,16 +138,14 @@ Blockly.WorkspaceDragSurfaceSvg.prototype.getSurfaceTranslation = function() {
  */
 Blockly.WorkspaceDragSurfaceSvg.prototype.clearAndHide = function(newSurface) {
   if (!newSurface) {
-    throw Error('Couldn\'t clear and hide the drag surface: missing ' +
-        'new surface.');
+    throw 'Couldn\'t clear and hide the drag surface: missing new surface.';
   }
   var blockCanvas = this.SVG_.childNodes[0];
   var bubbleCanvas = this.SVG_.childNodes[1];
   if (!blockCanvas || !bubbleCanvas ||
       !Blockly.utils.hasClass(blockCanvas, 'blocklyBlockCanvas') ||
       !Blockly.utils.hasClass(bubbleCanvas, 'blocklyBubbleCanvas')) {
-    throw Error('Couldn\'t clear and hide the drag surface. ' +
-        'A node was missing.');
+    throw 'Couldn\'t clear and hide the drag surface.  A node was missing.';
   }
 
   // If there is a previous sibling, put the blockCanvas back right afterwards,
@@ -161,9 +160,8 @@ Blockly.WorkspaceDragSurfaceSvg.prototype.clearAndHide = function(newSurface) {
   Blockly.utils.insertAfter_(bubbleCanvas, blockCanvas);
   // Hide the drag surface.
   this.SVG_.style.display = 'none';
-  if (this.SVG_.childNodes.length) {
-    throw Error('Drag surface was not cleared.');
-  }
+  goog.asserts.assert(
+      this.SVG_.childNodes.length == 0, 'Drag surface was not cleared.');
   Blockly.utils.setCssTransform(this.SVG_, '');
   this.previousSibling_ = null;
 };
@@ -182,9 +180,8 @@ Blockly.WorkspaceDragSurfaceSvg.prototype.clearAndHide = function(newSurface) {
  */
 Blockly.WorkspaceDragSurfaceSvg.prototype.setContentsAndShow = function(
     blockCanvas, bubbleCanvas, previousSibling, width, height, scale) {
-  if (this.SVG_.childNodes.length) {
-    throw Error('Already dragging a block.');
-  }
+  goog.asserts.assert(
+      this.SVG_.childNodes.length == 0, 'Already dragging a block.');
   this.previousSibling_ = previousSibling;
   // Make sure the blocks and bubble canvas are scaled appropriately.
   blockCanvas.setAttribute('transform', 'translate(0, 0) scale(' + scale + ')');

--- a/core/workspace_dragger.js
+++ b/core/workspace_dragger.js
@@ -27,6 +27,7 @@
 goog.provide('Blockly.WorkspaceDragger');
 
 goog.require('goog.math.Coordinate');
+goog.require('goog.asserts');
 
 
 /**

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -930,7 +930,7 @@ Blockly.WorkspaceSvg.prototype.highlightBlock = function(id, opt_state) {
     var state = (opt_state === undefined) || opt_state;
     // Using Set here would be great, but at the cost of IE10 support.
     if (!state) {
-      Blockly.utils.arrayRemove(this.highlightedBlocks_, block);
+      goog.array.remove(this.highlightedBlocks_, block);
     } else if (this.highlightedBlocks_.indexOf(block) == -1) {
       this.highlightedBlocks_.push(block);
     }
@@ -1552,23 +1552,23 @@ Blockly.WorkspaceSvg.prototype.updateToolbox = function(tree) {
   tree = Blockly.Options.parseToolboxTree(tree);
   if (!tree) {
     if (this.options.languageTree) {
-      throw Error('Can\'t nullify an existing toolbox.');
+      throw 'Can\'t nullify an existing toolbox.';
     }
     return;  // No change (null to null).
   }
   if (!this.options.languageTree) {
-    throw Error('Existing toolbox is null.  Can\'t create new toolbox.');
+    throw 'Existing toolbox is null.  Can\'t create new toolbox.';
   }
   if (tree.getElementsByTagName('category').length) {
     if (!this.toolbox_) {
-      throw Error('Existing toolbox has no categories.  Can\'t change mode.');
+      throw 'Existing toolbox has no categories.  Can\'t change mode.';
     }
     this.options.languageTree = tree;
     this.toolbox_.populate_(tree);
     this.toolbox_.position();
   } else {
     if (!this.flyout_) {
-      throw Error('Existing toolbox has categories.  Can\'t change mode.');
+      throw 'Existing toolbox has categories.  Can\'t change mode.';
     }
     this.options.languageTree = tree;
     this.flyout_.show(tree.childNodes);
@@ -1603,7 +1603,7 @@ Blockly.WorkspaceSvg.prototype.setBrowserFocus = function() {
   try {
     // Focus the workspace SVG - this is for Chrome and Firefox.
     this.getParentSvg().focus();
-  } catch (e) {
+  }  catch (e) {
     // IE and Edge do not support focus on SVG elements. When that fails
     // above, get the injectionDiv (the workspace's parent) and focus that
     // instead.  This doesn't work in Chrome.
@@ -2044,14 +2044,13 @@ Blockly.WorkspaceSvg.getTopLevelWorkspaceMetrics_ = function() {
  */
 Blockly.WorkspaceSvg.setTopLevelWorkspaceMetrics_ = function(xyRatio) {
   if (!this.scrollbar) {
-    throw Error('Attempt to set top level workspace scroll without ' +
-        'scrollbars.');
+    throw 'Attempt to set top level workspace scroll without scrollbars.';
   }
   var metrics = this.getMetrics();
-  if (typeof xyRatio.x == 'number') {
+  if (goog.isNumber(xyRatio.x)) {
     this.scrollX = -metrics.contentWidth * xyRatio.x - metrics.contentLeft;
   }
-  if (typeof xyRatio.y == 'number') {
+  if (goog.isNumber(xyRatio.y)) {
     this.scrollY = -metrics.contentHeight * xyRatio.y - metrics.contentTop;
   }
   var x = this.scrollX + metrics.absoluteLeft;
@@ -2116,9 +2115,8 @@ Blockly.WorkspaceSvg.prototype.clear = function() {
  *     given button is clicked.
  */
 Blockly.WorkspaceSvg.prototype.registerButtonCallback = function(key, func) {
-  if (typeof func != 'function') {
-    throw TypeError('Button callbacks must be functions.');
-  }
+  goog.asserts.assert(goog.isFunction(func),
+      'Button callbacks must be functions.');
   this.flyoutButtonCallbacks_[key] = func;
 };
 
@@ -2152,9 +2150,8 @@ Blockly.WorkspaceSvg.prototype.removeButtonCallback = function(key) {
  */
 Blockly.WorkspaceSvg.prototype.registerToolboxCategoryCallback = function(key,
     func) {
-  if (typeof func != 'function') {
-    throw TypeError('Toolbox category callbacks must be functions.');
-  }
+  goog.asserts.assert(goog.isFunction(func),
+      'Toolbox category callbacks must be functions.');
   this.toolboxCategoryCallbacks_[key] = func;
 };
 

--- a/core/xml.js
+++ b/core/xml.js
@@ -33,6 +33,7 @@ goog.provide('Blockly.Xml');
 goog.require('Blockly.Events.BlockCreate');
 goog.require('Blockly.Events.VarCreate');
 
+goog.require('goog.asserts');
 goog.require('goog.dom');
 
 
@@ -464,7 +465,8 @@ Blockly.Xml.domToWorkspace = function(xml, workspace) {
         }
         variablesFirst = false;
       } else if (name == 'shadow') {
-        throw TypeError('Shadow block cannot be a top-level block.');
+        goog.asserts.fail('Shadow block cannot be a top-level block.');
+        variablesFirst = false;
       } else if (name == 'comment') {
         if (workspace.rendered) {
           Blockly.WorkspaceCommentSvg.fromXml(xmlChild, workspace, width);
@@ -648,9 +650,8 @@ Blockly.Xml.domToVariables = function(xmlVariables, workspace) {
 Blockly.Xml.domToBlockHeadless_ = function(xmlBlock, workspace) {
   var block = null;
   var prototypeName = xmlBlock.getAttribute('type');
-  if (!prototypeName) {
-    throw TypeError('Block type unspecified: ' + xmlBlock.outerHTML);
-  }
+  goog.asserts.assert(
+      prototypeName, 'Block type unspecified: %s', xmlBlock.outerHTML);
   var id = xmlBlock.getAttribute('id');
   block = workspace.newBlock(prototypeName, id);
 
@@ -751,7 +752,7 @@ Blockly.Xml.domToBlockHeadless_ = function(xmlBlock, workspace) {
           } else if (blockChild.previousConnection) {
             input.connection.connect(blockChild.previousConnection);
           } else {
-            throw TypeError(
+            goog.asserts.fail(
                 'Child block does not have output or previous statement.');
           }
         }
@@ -761,18 +762,15 @@ Blockly.Xml.domToBlockHeadless_ = function(xmlBlock, workspace) {
           block.nextConnection.setShadowDom(childShadowElement);
         }
         if (childBlockElement) {
-          if (!block.nextConnection) {
-            throw TypeError('Next statement does not exist.');
-          }
+          goog.asserts.assert(block.nextConnection,
+              'Next statement does not exist.');
           // If there is more than one XML 'next' tag.
-          if (block.nextConnection.isConnected()) {
-            throw TypeError('Next statement is already connected.');
-          }
+          goog.asserts.assert(!block.nextConnection.isConnected(),
+              'Next statement is already connected.');
           blockChild = Blockly.Xml.domToBlockHeadless_(childBlockElement,
               workspace);
-          if (!blockChild.previousConnection) {
-            throw TypeError('Next block does not have previous statement.');
-          }
+          goog.asserts.assert(blockChild.previousConnection,
+              'Next block does not have previous statement.');
           block.nextConnection.connect(blockChild.previousConnection);
         }
         break;
@@ -810,9 +808,8 @@ Blockly.Xml.domToBlockHeadless_ = function(xmlBlock, workspace) {
     // Ensure all children are also shadows.
     var children = block.getChildren(false);
     for (var i = 0, child; child = children[i]; i++) {
-      if (!child.isShadow()) {
-        throw TypeError('Shadow block not allowed non-shadow child.');
-      }
+      goog.asserts.assert(
+          child.isShadow(), 'Shadow block not allowed non-shadow child.');
     }
     block.setShadow(true);
   }


### PR DESCRIPTION
Reverts LLK/scratch-blocks#1664
Resolves https://github.com/LLK/scratch-vm/issues/1496

Unfortunately, it looks like the changes introduced in #1664 caused some critical issues when combined with the VM / GUI in how exceptions are handled. We absolutely want to make this change and help with the removal of the Closure Library from Scratch Blocks, but we'll need to make sure we get the entire error handling flow sorted out across repos. 

As this is a critical bug, we are reverting for now and then will follow-up with a more permanent / long-term solution. 