### PR TITLE
Support for GUI overriding contents of "of" block property menu

### DIFF
--- a/blocks_vertical/default_toolbox.js
+++ b/blocks_vertical/default_toolbox.js
@@ -341,6 +341,9 @@ Blockly.Blocks.defaultToolbox = '<xml id="toolbox-categories" style="display: no
     '<block type="sensing_timer" id="sensing_timer"></block>' +
     '<block type="sensing_resettimer" id="sensing_resettimer"></block>' +
     '<block type="sensing_of" id="sensing_of">' +
+      '<value name="PROPERTY">' +
+        '<shadow type="sensing_of_property_menu"></shadow>' +
+      '</value>' +
       '<value name="OBJECT">' +
         '<shadow type="sensing_of_object_menu"></shadow>' +
       '</value>' +

--- a/blocks_vertical/sensing.js
+++ b/blocks_vertical/sensing.js
@@ -401,9 +401,39 @@ Blockly.Blocks['sensing_resettimer'] = {
   }
 };
 
+Blockly.Blocks['sensing_of_property_menu'] = {
+  /**
+   * "* of _" property menu (the first dropdown).
+   * @this Blockly.block
+   */
+  init: function() {
+    this.jsonInit({
+      "message0": "%1",
+      "args0": [
+        {
+          "type": "field_dropdown",
+          "name": "PROPERTY",
+          "options": [
+            [Blockly.Msg.SENSING_OF_XPOSITION, 'x position'],
+            [Blockly.Msg.SENSING_OF_YPOSITION, 'y position'],
+            [Blockly.Msg.SENSING_OF_DIRECTION, 'direction'],
+            [Blockly.Msg.SENSING_OF_COSTUMENUMBER, 'costume #'],
+            [Blockly.Msg.SENSING_OF_COSTUMENAME, 'costume name'],
+            [Blockly.Msg.SENSING_OF_SIZE, 'size'],
+            [Blockly.Msg.SENSING_OF_VOLUME, 'volume'],
+            [Blockly.Msg.SENSING_OF_BACKDROPNUMBER, 'backdrop #'],
+            [Blockly.Msg.SENSING_OF_BACKDROPNAME, 'backdrop name']
+          ]
+        }
+      ],
+      "extensions": ["colours_sensing", "output_string"]
+    });
+  }
+};
+
 Blockly.Blocks['sensing_of_object_menu'] = {
   /**
-   * "* of _" object menu.
+   * "* of _" object menu (the second dropdown).
    * @this Blockly.Block
    */
   init: function() {
@@ -424,7 +454,6 @@ Blockly.Blocks['sensing_of_object_menu'] = {
   }
 };
 
-
 Blockly.Blocks['sensing_of'] = {
   /**
    * Block to report properties of sprites.
@@ -435,19 +464,8 @@ Blockly.Blocks['sensing_of'] = {
       "message0": Blockly.Msg.SENSING_OF,
       "args0": [
         {
-          "type": "field_dropdown",
-          "name": "PROPERTY",
-          "options": [
-            [Blockly.Msg.SENSING_OF_XPOSITION, 'x position'],
-            [Blockly.Msg.SENSING_OF_YPOSITION, 'y position'],
-            [Blockly.Msg.SENSING_OF_DIRECTION, 'direction'],
-            [Blockly.Msg.SENSING_OF_COSTUMENUMBER, 'costume #'],
-            [Blockly.Msg.SENSING_OF_COSTUMENAME, 'costume name'],
-            [Blockly.Msg.SENSING_OF_SIZE, 'size'],
-            [Blockly.Msg.SENSING_OF_VOLUME, 'volume'],
-            [Blockly.Msg.SENSING_OF_BACKDROPNUMBER, 'backdrop #'],
-            [Blockly.Msg.SENSING_OF_BACKDROPNAME, 'backdrop name']
-          ]
+          "type": "input_value",
+          "name": "PROPERTY"
         },
         {
           "type": "input_value",


### PR DESCRIPTION
### Resolves

Towards LLK/scratch-vm#1425. Should be merged before LLK/scratch-gui#3102.

### Proposed Changes

Changes the `PROPERTY` menu so that it functions in the same way as the `OBJECT` menu.

### Reason for Changes

So that the GUI PR can add custom behavior to the dropdowns.

### Test Coverage

Tested manually (see GUI PR).
