### PR TITLE
Localize "item # of value in list" block

### DIFF
--- a/blocks_vertical/data.js
+++ b/blocks_vertical/data.js
@@ -391,7 +391,7 @@ Blockly.Blocks['data_itemnumoflist'] = {
    */
   init: function() {
     this.jsonInit({
-      "message0": "item # of %1 in %2",
+      "message0": Blockly.Msg.DATA_ITEMNUMOFLIST,
       "args0": [
         {
           "type": "input_value",

--- a/msg/messages.js
+++ b/msg/messages.js
@@ -67,6 +67,7 @@ Blockly.Msg.DATA_DELETEALLOFLIST = 'delete all of %1';
 Blockly.Msg.DATA_INSERTATLIST = 'insert %1 at %2 of %3';
 Blockly.Msg.DATA_REPLACEITEMOFLIST = 'replace item %1 of %2 with %3';
 Blockly.Msg.DATA_ITEMOFLIST = 'item %1 of %2';
+Blockly.Msg.DATA_ITEMNUMOFLIST = 'item # of %1 in %2';
 Blockly.Msg.DATA_LENGTHOFLIST = 'length of %1';
 Blockly.Msg.DATA_LISTCONTAINSITEM = '%1 contains %2?';
 Blockly.Msg.DATA_SHOWLIST = 'show list %1';


### PR DESCRIPTION
### Resolves

Fixes #1713.

### Proposed Changes

Adds a translation/localization message for the "item # of () in ()" list block.

### Reason for Changes

Support for more translation.

I think my original PR for this block, #1425, must have been created before `Blockly.Msg` was used for blocks, but merged after - so this is a lone block left untranslated.

### Test Coverage

Tested manually - the block still shows up correctly in `tests/vertical_playground.html`.