### PR TITLE
scratch-gui #3007 - Added context menu to list variables

### DIFF
--- a/blocks_vertical/data.js
+++ b/blocks_vertical/data.js
@@ -579,13 +579,13 @@ Blockly.Constants.Data.CUSTOM_CONTEXT_MENU_GET_LIST_MIXIN = {
       }
     } else {
       var renameOption = {
-        text: Blockly.Msg.RENAME_VARIABLE,
+        text: Blockly.Msg.RENAME_LIST,
         enabled: true,
         callback: Blockly.Constants.Data.RENAME_OPTION_CALLBACK_FACTORY(this, 'LIST')
       };
       var name = this.getField('LIST').text_;
       var deleteOption = {
-        text: Blockly.Msg.DELETE_VARIABLE.replace('%1', name),
+        text: Blockly.Msg.DELETE_LIST.replace('%1', name),
         enabled: true,
         callback: Blockly.Constants.Data.DELETE_OPTION_CALLBACK_FACTORY(this, 'LIST')
       };

--- a/blocks_vertical/data.js
+++ b/blocks_vertical/data.js
@@ -607,6 +607,7 @@ Blockly.Extensions.registerMixin('contextMenu_getListBlock',
  * block.
  * @param {!Blockly.Block} block The block to update.
  * @param {string} name The new name to display on the block.
+ * @param {string} type The type of the field (VARIABLE or LIST).
  * @return {!function()} A function that updates the block with the new name.
  */
 Blockly.Constants.Data.VARIABLE_OPTION_CALLBACK_FACTORY = function(block, name, type) {
@@ -623,6 +624,7 @@ Blockly.Constants.Data.VARIABLE_OPTION_CALLBACK_FACTORY = function(block, name, 
  * Callback for rename variable dropdown menu option associated with a
  * variable getter block.
  * @param {!Blockly.Block} block The block with the variable to rename.
+ * @param {string} type The type of the field (VARIABLE or LIST).
  * @return {!function()} A function that renames the variable.
  */
 Blockly.Constants.Data.RENAME_OPTION_CALLBACK_FACTORY = function(block, type) {
@@ -637,6 +639,7 @@ Blockly.Constants.Data.RENAME_OPTION_CALLBACK_FACTORY = function(block, type) {
  * Callback for delete variable dropdown menu option associated with a
  * variable getter block.
  * @param {!Blockly.Block} block The block with the variable to delete.
+ * @param {string} type The type of the field (VARIABLE or LIST).
  * @return {!function()} A function that deletes the variable.
  */
 Blockly.Constants.Data.DELETE_OPTION_CALLBACK_FACTORY = function(block, type) {

--- a/core/field_variable.js
+++ b/core/field_variable.js
@@ -308,17 +308,29 @@ Blockly.FieldVariable.dropdownCreate = function() {
     // Set the uuid as the internal representation of the variable.
     options[i] = [variableModelList[i].name, variableModelList[i].getId()];
   }
+  var variableType = variableModelList[0].type;
   if (this.defaultType_ == Blockly.BROADCAST_MESSAGE_VARIABLE_TYPE) {
     options.unshift(
         [Blockly.Msg.NEW_BROADCAST_MESSAGE, Blockly.NEW_BROADCAST_MESSAGE_ID]);
   } else {
-    options.push([Blockly.Msg.RENAME_VARIABLE, Blockly.RENAME_VARIABLE_ID]);
-    if (Blockly.Msg.DELETE_VARIABLE) {
-      options.push(
-          [
-            Blockly.Msg.DELETE_VARIABLE.replace('%1', name),
-            Blockly.DELETE_VARIABLE_ID
-          ]);
+    if (variableType == Blockly.LIST_VARIABLE_TYPE) {
+      options.push([Blockly.Msg.RENAME_LIST, Blockly.RENAME_VARIABLE_ID]);
+      if (Blockly.Msg.DELETE_VARIABLE) {
+        options.push(
+            [
+              Blockly.Msg.DELETE_LIST.replace('%1', name),
+              Blockly.DELETE_VARIABLE_ID
+            ]);
+      }
+    } else {
+      options.push([Blockly.Msg.RENAME_VARIABLE, Blockly.RENAME_VARIABLE_ID]);
+      if (Blockly.Msg.DELETE_VARIABLE) {
+        options.push(
+            [
+              Blockly.Msg.DELETE_VARIABLE.replace('%1', name),
+              Blockly.DELETE_VARIABLE_ID
+            ]);
+      }
     }
   }
 

--- a/core/variable_map.js
+++ b/core/variable_map.js
@@ -240,13 +240,20 @@ Blockly.VariableMap.prototype.deleteVariableById = function(id) {
   var variable = this.getVariableById(id);
   if (variable) {
     // Check whether this variable is a function parameter before deleting.
+    var variableType = variable.type;
     var variableName = variable.name;
     var uses = this.getVariableUsesById(id);
     for (var i = 0, block; block = uses[i]; i++) {
       if (block.type == Blockly.PROCEDURES_DEFINITION_BLOCK_TYPE ||
         block.type == 'procedures_defreturn') {
         var procedureName = block.getFieldValue('NAME');
-        var deleteText = Blockly.Msg.CANNOT_DELETE_VARIABLE_PROCEDURE.
+        // Check whether variable is a list
+        if (variableType == Blockly.LIST_VARIABLE_TYPE) {
+          var deleteText = Blockly.Msg.CANNOT_DELETE_LIST_PROCEDURE;
+        } else {
+          var deleteText = Blockly.Msg.CANNOT_DELETE_VARIABLE_PROCEDURE;
+        }
+        deleteText = deleteText.
             replace('%1', variableName).
             replace('%2', procedureName);
         Blockly.alert(deleteText);
@@ -256,10 +263,16 @@ Blockly.VariableMap.prototype.deleteVariableById = function(id) {
 
     var map = this;
     if (uses.length > 1) {
-      // Confirm before deleting multiple blocks.
-      var confirmText = Blockly.Msg.DELETE_VARIABLE_CONFIRMATION.
+      // Check whether variable is a list
+      if (variableType == Blockly.LIST_VARIABLE_TYPE) {
+        var confirmText = Blockly.Msg.DELETE_LIST_CONFIRMATION;
+      } else {
+        var confirmText = Blockly.Msg.DELETE_VARIABLE_CONFIRMATION;
+      }
+      confirmText = confirmText.
           replace('%1', String(uses.length)).
           replace('%2', variableName);
+      // Confirm before deleting multiple blocks.
       Blockly.confirm(confirmText,
           function(ok) {
             if (ok) {

--- a/msg/messages.js
+++ b/msg/messages.js
@@ -335,9 +335,13 @@ Blockly.Msg.NEW_LIST = 'Make a List';
 Blockly.Msg.NEW_LIST_TITLE = 'New list name:';
 Blockly.Msg.LIST_MODAL_TITLE = 'New List';
 Blockly.Msg.LIST_ALREADY_EXISTS = 'A list named "%1" already exists.';
+Blockly.Msg.RENAME_LIST = 'Rename list';
 Blockly.Msg.RENAME_LIST_TITLE = 'Rename all "%1" lists to:';
 Blockly.Msg.RENAME_LIST_MODAL_TITLE = 'Rename List';
 Blockly.Msg.DEFAULT_LIST_ITEM = 'thing';
+Blockly.Msg.DELETE_LIST_CONFIRMATION = 'Delete %1 uses of the "%2" list?';
+Blockly.Msg.CANNOT_DELETE_LIST_PROCEDURE = 'Can\'t delete the list "%1" because it\'s part of the definition of the function "%2"';
+Blockly.Msg.DELETE_LIST = 'Delete the "%1" list';
 
 // Broadcast Messages
 // @todo Remove these once fully managed by Scratch VM / Scratch GUI


### PR DESCRIPTION
### Resolves

Resolves  https://github.com/LLK/scratch-gui/issues/3007 - New lists cannot be deleted or renamed by right clicking.

### Proposed Changes

Implemented context menu for lists similar to the one present for regular variables.

### Reason for Changes

This is an enhancement with the purpose of mirroring functionality that was present in the Scratch 2.0 editor.

### Test Coverage

No unit tests were implemented. A series of manual tests were executed after creating multiple variables & lists:

- Checked whether context menu was present for both.
- Checked whether helping text used the correct variable names.
- Checked whether renaming & deleting a variable or list produced the expected results. 
