### PR TITLE
Add field sound dropdown

### DIFF
--- a/blocks_vertical/sound.js
+++ b/blocks_vertical/sound.js
@@ -37,7 +37,7 @@ Blockly.Blocks['sound_sounds_menu'] = {
       "message0": "%1",
       "args0": [
         {
-          "type": "field_dropdown",
+          "type": "field_sounddropdown",
           "name": "SOUND_MENU",
           "options": [
             ['1', '0'],

--- a/blocks_vertical/sound.js
+++ b/blocks_vertical/sound.js
@@ -49,7 +49,8 @@ Blockly.Blocks['sound_sounds_menu'] = {
             ['7', '6'],
             ['8', '7'],
             ['9', '8'],
-            ['10', '9']
+            ['10', '9'],
+            ['record...', Blockly.SOUND_RECORD_ID]
           ]
         }
       ],

--- a/core/blockly.js
+++ b/core/blockly.js
@@ -41,6 +41,7 @@ goog.require('Blockly.FieldColourSlider');
 // Add it only if you need it.
 //goog.require('Blockly.FieldDate');
 goog.require('Blockly.FieldDropdown');
+goog.require('Blockly.FieldSoundDropdown');
 goog.require('Blockly.FieldIconMenu');
 goog.require('Blockly.FieldImage');
 goog.require('Blockly.FieldTextInput');
@@ -400,6 +401,14 @@ Blockly.refreshStatusButtons = function(workspace) {
       buttons[i].refreshStatus();
     }
   }
+};
+
+/**
+ * A callback for initiating the process of recording a sound. Should be
+ * overridden.
+ */
+Blockly.recordSoundCallback = function() {
+  window.alert('record a sound');
 };
 
 /**

--- a/core/constants.js
+++ b/core/constants.js
@@ -385,3 +385,9 @@ Blockly.StatusButtonState = {
   "READY": "ready",
   "NOT_READY": "not ready",
 };
+
+/**
+ * String for use in field_sound_dropdown.
+ * @const {string}
+ */
+Blockly.SOUND_RECORD_ID = 'SOUND_RECORD_ID';

--- a/core/field_sound_dropdown.js
+++ b/core/field_sound_dropdown.js
@@ -70,23 +70,6 @@ Blockly.FieldSoundDropdown.prototype.onItemSelected = function(menu, menuItem) {
 };
 
 /**
- * Initialize everything needed to render this field.  This includes making sure
- * that the field's value is valid.
- * @public
- */
-Blockly.FieldSoundDropdown.prototype.init = function() {
-  if (this.fieldGroup_) {
-    // Dropdown has already been initialized once.
-    return;
-  }
-  Blockly.FieldSoundDropdown.superClass_.init.call(this);
-
-  var options = this.getOptions();
-  options.push(['record...', '_record_']);
-
-};
-
-/**
  * Construct a FieldDropdown from a JSON arg object.
  * @param {!Object} element A JSON object with options.
  * @returns {!Blockly.FieldSoundDropdown} The new field instance.

--- a/core/field_sound_dropdown.js
+++ b/core/field_sound_dropdown.js
@@ -55,7 +55,7 @@ goog.inherits(Blockly.FieldSoundDropdown, Blockly.FieldDropdown);
 Blockly.FieldSoundDropdown.prototype.onItemSelected = function(menu, menuItem) {
   var value = menuItem.getValue();
 
-  if (value == '_record_') {
+  if (value == Blockly.SOUND_RECORD_ID) {
     Blockly.recordSoundCallback();
     return;
   }

--- a/core/field_sound_dropdown.js
+++ b/core/field_sound_dropdown.js
@@ -2,7 +2,7 @@
  * @license
  * Visual Blocks Editor
  *
- * Copyright 2013 Google Inc.
+ * Copyright 2018 Massachusetts Institute of Technology
  * https://developers.google.com/blockly/
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -29,7 +29,7 @@ goog.provide('Blockly.FieldSoundDropdown');
 goog.require('Blockly.FieldDropdown');
 
 /**
- * Class for an editable dropdown field.
+ * Class for a dropdown field showing a menu of sounds, with additional options.
  * @param {(!Array.<!Array>|!Function)} menuGenerator An array of options
  *     for a dropdown list, or a function which generates these options.
  * @param {Function=} opt_validator A function that is executed when a new
@@ -55,6 +55,8 @@ goog.inherits(Blockly.FieldSoundDropdown, Blockly.FieldDropdown);
 Blockly.FieldSoundDropdown.prototype.onItemSelected = function(menu, menuItem) {
   var value = menuItem.getValue();
 
+  // If the 'record' option is selected, call the callback and do not set the
+  // selection.
   if (value == Blockly.SOUND_RECORD_ID) {
     Blockly.recordSoundCallback();
     return;

--- a/core/field_sound_dropdown.js
+++ b/core/field_sound_dropdown.js
@@ -1,0 +1,100 @@
+/**
+ * @license
+ * Visual Blocks Editor
+ *
+ * Copyright 2013 Google Inc.
+ * https://developers.google.com/blockly/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Dropdown menu for sounds.
+ * @author ericr@media.mit.edu (Eric Rosenbaum)
+ */
+'use strict';
+
+goog.provide('Blockly.FieldSoundDropdown');
+
+goog.require('Blockly.FieldDropdown');
+
+/**
+ * Class for an editable dropdown field.
+ * @param {(!Array.<!Array>|!Function)} menuGenerator An array of options
+ *     for a dropdown list, or a function which generates these options.
+ * @param {Function=} opt_validator A function that is executed when a new
+ *     option is selected, with the newly selected value as its sole argument.
+ *     If it returns a value, that value (which must be one of the options) will
+ *     become selected in place of the newly selected option, unless the return
+ *     value is null, in which case the change is aborted.
+ * @extends {Blockly.Field}
+ * @constructor
+ */
+Blockly.FieldSoundDropdown = function(menuGenerator, opt_validator) {
+  // Call parent's constructor.
+  Blockly.FieldSoundDropdown.superClass_.constructor.call(this, menuGenerator,
+      opt_validator);
+};
+goog.inherits(Blockly.FieldSoundDropdown, Blockly.FieldDropdown);
+
+/**
+ * Handle the selection of an item in the dropdown menu.
+ * @param {!goog.ui.Menu} menu The Menu component clicked.
+ * @param {!goog.ui.MenuItem} menuItem The MenuItem selected within menu.
+ */
+Blockly.FieldSoundDropdown.prototype.onItemSelected = function(menu, menuItem) {
+  var value = menuItem.getValue();
+
+  if (value == '_record_') {
+    Blockly.recordSoundCallback();
+    return;
+  }
+
+  if (this.sourceBlock_) {
+    // Call any validation function, and allow it to override.
+    value = this.callValidator(value);
+  }
+  if (value !== null) {
+    this.setValue(value);
+  }
+};
+
+/**
+ * Initialize everything needed to render this field.  This includes making sure
+ * that the field's value is valid.
+ * @public
+ */
+Blockly.FieldSoundDropdown.prototype.init = function() {
+  if (this.fieldGroup_) {
+    // Dropdown has already been initialized once.
+    return;
+  }
+  Blockly.FieldSoundDropdown.superClass_.init.call(this);
+
+  var options = this.getOptions();
+  options.push(['record...', '_record_']);
+
+};
+
+/**
+ * Construct a FieldDropdown from a JSON arg object.
+ * @param {!Object} element A JSON object with options.
+ * @returns {!Blockly.FieldSoundDropdown} The new field instance.
+ * @package
+ * @nocollapse
+ */
+Blockly.FieldSoundDropdown.fromJson = function(element) {
+  return new Blockly.FieldSoundDropdown(element['options']);
+};
+
+Blockly.Field.register('field_sounddropdown', Blockly.FieldSoundDropdown);

--- a/msg/messages.js
+++ b/msg/messages.js
@@ -276,6 +276,7 @@ Blockly.Msg.SOUND_EFFECTS_PAN = 'pan left/right';
 Blockly.Msg.SOUND_CHANGEVOLUMEBY = 'change volume by %1';
 Blockly.Msg.SOUND_SETVOLUMETO = 'set volume to %1%';
 Blockly.Msg.SOUND_VOLUME = 'volume';
+Blockly.Msg.SOUND_RECORD = 'record...';
 
 // Category labels
 Blockly.Msg.CATEGORY_MOTION = 'Motion';


### PR DESCRIPTION
### Resolves

Progress toward https://github.com/LLK/scratch-gui/issues/1368

### Proposed Changes

Add a new dropdown field, specifically for the menu of sounds in the "play sound" and "start sound" blocks. The only change for now is that this field checks if a special item has been selected, "record...", which triggers a callback that can be overridden by the GUI.

### Reason for Changes

We'd like to make it more obvious that you can record your own sound, and make the process accessible directly from the play sound blocks themselves (as in Scratch 2.0). 

We imagine in the future that we might want to add additional options to this menu (such as "add sound..." to add a sound from the library). 

We also may want to add options like this to other blocks (such as options in the "switch costume" block for drawing a new costume and adding one from the library), which would mean making a similar subclass for the costume menu (or maybe abstract these into a more abstract menu-with-special-options class).

We also should consider using buttons inside the menus to better distinguish this type of option.

I encountered some questions- interested in feedback on these: 
- The special 'record...' option could be added by the field itself (I couldn't get that to work right because of the way the GUI updates dynamic menus). For now I am adding it from the GUI. 
- The value of the record option in the menu is currently a string constant, but it could instead be set to the callback itself (and then the field would check if the value is a function, and if so call it directly). This would prevent the problem that exists in this version, where if you name a sound "SOUND_RECORD_ID", trying to select it triggers the sound recorder.   

### Test Coverage

The vertical playground's "play sound" and "start sound" blocks have a "record..." option that should trigger the callback and show an alert.

