### PR TITLE
Menu items can be functions, to support the 'record...' option

### DIFF
--- a/blocks_vertical/sound.js
+++ b/blocks_vertical/sound.js
@@ -49,7 +49,10 @@ Blockly.Blocks['sound_sounds_menu'] = {
             ['7', '6'],
             ['8', '7'],
             ['9', '8'],
-            ['10', '9']
+            ['10', '9'],
+            ['call a function', function() {
+              window.alert('function called!');}
+            ]
           ]
         }
       ],

--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -303,6 +303,11 @@ Blockly.FieldDropdown.prototype.onItemSelected = function(menu, menuItem) {
     // Call any validation function, and allow it to override.
     value = this.callValidator(value);
   }
+  // If the value of the menu item is a function, call it and do not select it.
+  if (typeof value == 'function') {
+    value();
+    return;
+  }
   if (value !== null) {
     this.setValue(value);
   }

--- a/msg/messages.js
+++ b/msg/messages.js
@@ -276,6 +276,7 @@ Blockly.Msg.SOUND_EFFECTS_PAN = 'pan left/right';
 Blockly.Msg.SOUND_CHANGEVOLUMEBY = 'change volume by %1';
 Blockly.Msg.SOUND_SETVOLUMETO = 'set volume to %1%';
 Blockly.Msg.SOUND_VOLUME = 'volume';
+Blockly.Msg.SOUND_RECORD = 'record...';
 
 // Category labels
 Blockly.Msg.CATEGORY_MOTION = 'Motion';


### PR DESCRIPTION
### Resolves

Progress toward https://github.com/LLK/scratch-gui/issues/1368

### Proposed Changes

Field dropdown, when you select something, checks if its value is a function, and if so, calls it (and does not select it).

Also, add a new message to localize the string 'record...'.

### Reason for Changes

We'd like to make it more obvious that you can record your own sound, and make the process accessible directly from the play sound blocks themselves (as in Scratch 2.0).

Generally, we want to add additional options, such as "add sound..." to add a sound from the library, and the corresponding options for costumes and backdrops like "paint costume..." and "add costume...".

### Test Coverage

The vertical playground's "play sound" and "start sound" blocks have a "record..." option that calls a function.