### PR TITLE
Fixes webpack problem breaking 'npm install'

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "travis-after-all": "1.4.4",
     "uglifyjs-webpack-plugin": "^1.2.5",
     "webdriverio": "4.8.0",
-    "webpack": "^4.8.0",
-    "webpack-cli": "^2.0.15"
+    "webpack": "^4.22.0",
+    "webpack-cli": "^3.1.1"
   }
 }


### PR DESCRIPTION

### Resolves

#1734 

### Proposed Changes
Forcing never versions of webpack and webpack-cli


### Reason for Changes
Running 'npm install' from fresh repo will result in error. 
See: https://github.com/webpack/webpack/issues/8082
### Test Coverage

No tests added
