### PR TITLE
Darken droppable menu inputs when menu is open.

### DIFF
--- a/core/block.js
+++ b/core/block.js
@@ -239,6 +239,13 @@ Blockly.Block.prototype.colourSecondary_ = '#FF0000';
 Blockly.Block.prototype.colourTertiary_ = '#FF0000';
 
 /**
+ * Fill colour used to override default shadow colour behaviour.
+ * @type {string}
+ * @private
+ */
+Blockly.Block.prototype.shadowColour_ = null;
+
+/**
  * Dispose of this block.
  * @param {boolean} healStack If true, then try to heal any gap by connecting
  *     the next statement with the previous statement.  Otherwise, dispose of
@@ -787,6 +794,35 @@ Blockly.Block.prototype.getColourSecondary = function() {
  */
 Blockly.Block.prototype.getColourTertiary = function() {
   return this.colourTertiary_;
+};
+
+/**
+ * Get the shadow colour of a block.
+ * @return {string} #RRGGBB string.
+ */
+Blockly.Block.prototype.getShadowColour = function() {
+  return this.shadowColour_;
+};
+
+/**
+ * Set the shadow colour of a block.
+ * @param {number|string} colour HSV hue value, or #RRGGBB string.
+ */
+Blockly.Block.prototype.setShadowColour = function(colour) {
+  this.shadowColour_ = this.makeColour_(colour);
+  if (this.rendered) {
+    this.updateColour();
+  }
+};
+
+/**
+ * Clear the shadow colour of a block.
+ */
+Blockly.Block.prototype.clearShadowColour = function() {
+  this.shadowColour_ = null;
+  if (this.rendered) {
+    this.updateColour();
+  }
 };
 
 /**

--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -523,7 +523,12 @@ Blockly.BlockSvg.prototype.updateColour = function() {
 
   // Render block fill
   if (this.isGlowingBlock_ || renderShadowed) {
-    var fillColour = this.getColourSecondary();
+    // Use the block's shadow colour if possible.
+    if (this.getShadowColour()) {
+      var fillColour = this.getShadowColour();
+    } else {
+      var fillColour = this.getColourSecondary();
+    }
   } else {
     var fillColour = this.getColour();
   }

--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -265,10 +265,7 @@ Blockly.FieldDropdown.prototype.showEditor_ = function() {
   // Update colour to look selected.
   if (!this.disableColourChange_) {
     if (this.sourceBlock_.isShadow()) {
-      this.savedPrimary_ = this.sourceBlock_.getColour();
-      this.sourceBlock_.setColour(this.sourceBlock_.getColourTertiary(),
-          this.sourceBlock_.getColourSecondary(),
-          this.sourceBlock_.getColourTertiary());
+      this.sourceBlock_.setShadowColour(this.sourceBlock_.getColourTertiary());
     } else if (this.box_) {
       this.box_.setAttribute('fill', this.sourceBlock_.getColourTertiary());
     }
@@ -283,9 +280,7 @@ Blockly.FieldDropdown.prototype.onHide = function() {
   // Update colour to look selected.
   if (!this.disableColourChange_ && this.sourceBlock_) {
     if (this.sourceBlock_.isShadow()) {
-      this.sourceBlock_.setColour(this.savedPrimary_,
-          this.sourceBlock_.getColourSecondary(),
-          this.sourceBlock_.getColourTertiary());
+      this.sourceBlock_.clearShadowColour();
     } else if (this.box_) {
       this.box_.setAttribute('fill', this.sourceBlock_.getColour());
     }


### PR DESCRIPTION
### Resolves

Fixes #1408
### Proposed Changes

Add a shadow colour attribute and set it appropriately.

### Reason for Changes

Port of fixes from https://github.com/Microsoft/pxt-blockly/pull/128

### Test Coverage

Tested in the vertical playground with the "distance to mouse-pointer" block.