### PR TITLE
When duplicating on touch, don't start a drag with the new blocks

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -669,8 +669,10 @@ Blockly.BlockSvg.prototype.showContextMenu_ = function(e) {
   var block = this;
   var menuOptions = [];
 
+  var isMouseEvent = Blockly.Touch.getTouchIdentifierFromEvent(e) == 'mouse';
   if (this.isDeletable() && this.isMovable() && !block.isInFlyout) {
-    menuOptions.push(Blockly.ContextMenu.blockDuplicateOption(block));
+    menuOptions.push(
+        Blockly.ContextMenu.blockDuplicateOption(block, isMouseEvent));
     if (this.isEditable() && this.workspace.options.comments) {
       menuOptions.push(Blockly.ContextMenu.blockCommentOption(block));
     }

--- a/core/contextmenu.js
+++ b/core/contextmenu.js
@@ -257,14 +257,17 @@ Blockly.ContextMenu.blockHelpOption = function(block) {
 /**
  * Make a context menu option for duplicating the current block.
  * @param {!Blockly.BlockSvg} block The block where the right-click originated.
+ * @param {boolean} isMouseEvent True if the event that caused the context
+ *     menu to open came from a mouse.  False if touch.
  * @return {!Object} A menu option, containing text, enabled, and a callback.
  * @package
  */
-Blockly.ContextMenu.blockDuplicateOption = function(block) {
+Blockly.ContextMenu.blockDuplicateOption = function(block, isMouseEvent) {
   var duplicateOption = {
     text: Blockly.Msg.DUPLICATE,
     enabled: true,
-    callback: Blockly.scratchBlocksUtils.duplicateAndDragCallback(block)
+    callback:
+        Blockly.scratchBlocksUtils.duplicateAndDragCallback(block, isMouseEvent)
   };
   return duplicateOption;
 };


### PR DESCRIPTION
### Resolves

Fixes #1647 

### Proposed Changes

Check whether the context menu on a block was opened from a mouse event or other event.

If it was a mouse event, keep the current behaviour of creating new blocks and immediately starting a drag.

If it was not a mouse event, place the new blocks slightly offset from the old blocks (down and to the right in LTR, down and to the left in RTL) and don't start a new drag.

### Reason for Changes

Starting a new drag on touchend with no mouse pointer is a bad experience--no pointer to track, and no way to tell that the current state is "dragging".

### Test Coverage

Tested in LTR and RTL in the playground.

### Additional Information
I'm just offsetting by 100, 100.  If you want other offsets, that's easy to change as well.