### PR TITLE
Fix #1345.  Android triggers a window resize event when the soft keyb…

### DIFF
--- a/core/blockly.js
+++ b/core/blockly.js
@@ -315,8 +315,29 @@ Blockly.onContextMenu_ = function(e) {
  * @param {boolean=} opt_allowToolbox If true, don't close the toolbox.
  */
 Blockly.hideChaff = function(opt_allowToolbox) {
-  Blockly.Tooltip.hide();
+  Blockly.hideChaffInternal_(opt_allowToolbox);
   Blockly.WidgetDiv.hide(true);
+};
+
+/**
+ * Close tooltips, context menus, dropdown selections, etc.
+ * For some elements (e.g. field text inputs), rather than hiding, it will
+ * move them.
+ * @param {boolean=} opt_allowToolbox If true, don't close the toolbox.
+ */
+Blockly.hideChaffOnResize = function(opt_allowToolbox) {
+  Blockly.hideChaffInternal_(opt_allowToolbox);
+  Blockly.WidgetDiv.repositionForWindowResize();
+};
+
+/**
+ * Does a majority of the work for hideChaff including tooltips, dropdowns,
+ * toolbox, etc. It does not deal with the WidgetDiv.
+ * @param {boolean=} opt_allowToolbox If true, don't close the toolbox.
+ * @private
+ */
+Blockly.hideChaffInternal_ = function(opt_allowToolbox) {
+  Blockly.Tooltip.hide();
   Blockly.DropDownDiv.hideWithoutAnimation();
   if (!opt_allowToolbox) {
     var workspace = Blockly.getMainWorkspace();

--- a/core/inject.js
+++ b/core/inject.js
@@ -364,7 +364,7 @@ Blockly.init_ = function(mainWorkspace) {
   var workspaceResizeHandler = Blockly.bindEventWithChecks_(window, 'resize',
       null,
       function() {
-        Blockly.hideChaff(true);
+        Blockly.hideChaffOnResize(true);
         Blockly.svgResize(mainWorkspace);
       });
   mainWorkspace.setResizeHandlerWrapper(workspaceResizeHandler);

--- a/core/widgetdiv.js
+++ b/core/widgetdiv.js
@@ -123,6 +123,27 @@ Blockly.WidgetDiv.show = function(newOwner, rtl, opt_dispose,
 };
 
 /**
+ *  Repositions the widgetDiv on window resize. If it doesn't know how to
+ *  calculate the new position, it wll just hide it instead.
+ */
+Blockly.WidgetDiv.repositionForWindowResize = function() {
+  // This condition mainly catches the widget div when it is being used as a
+  // text input.  It is important not to close it in this case because on Android,
+  // when a field is focused, the soft keyboard opens triggering a window resize
+  // event and we want the widget div to stick around so users can type into it.
+  if (Blockly.WidgetDiv.owner_
+      && Blockly.WidgetDiv.owner_.getScaledBBox_
+      && Blockly.WidgetDiv.owner_.getSize) {
+    var widgetScaledBBox = Blockly.WidgetDiv.owner_.getScaledBBox_();
+    var widgetSize = Blockly.WidgetDiv.owner_.getSize();
+    Blockly.WidgetDiv.positionInternal_(widgetScaledBBox.left, widgetScaledBBox.top,
+        widgetSize.height);
+  } else {
+    Blockly.WidgetDiv.hide();
+  }
+};
+
+/**
  * Destroy the widget and hide the div.
  * @param {boolean=} opt_noAnimate If set, animation will not be run for the hide.
  */


### PR DESCRIPTION
…oard pops up (i.e. when the text field is focused) which caused us to call hideChaff and close the widget div, unfocusing the text input and auto-closing the keyboard. This PR adds a new method to call from the window resize handler that moves the widget div rather than hiding it.

### Resolves

#1345 and https://github.com/LLK/scratch-gui/issues/2692

### Proposed Changes

Split hideChaff into two versions - one as the standard one that closes everything - tooltips, toolbox, dropdowns, context menus, field editors, etc. The second is expected to be called on window resize.  For that version, everything hides except the widget div (which is what renders text field editors). Instead the widgetDiv tries to reposition itself along with the window resize instead of closing itself.  If it doesn't know how to reposition itself, it just hides itself. This is hacky since it doesn't solve it for everything the widget div contains, but it works for text fields which are unusable on mobile right now.

You can notice the change in this gifs: If you click in a text field and then resize the window, it still stays highlighted:
![resizetextopen](https://user-images.githubusercontent.com/15675877/47382723-f1055400-d6d0-11e8-86c8-2111010b8fa8.gif)

And the before behavior, as soon as the window starts to resize, the text field is no longer selected:
![2018-10-23 14 47 27](https://user-images.githubusercontent.com/15675877/47383403-9bca4200-d6d2-11e8-9796-4617fa9c881b.gif)

