### PR TITLE
Use grandparent block colours for number picker dropdowns

### DIFF
--- a/core/field_number.js
+++ b/core/field_number.js
@@ -197,8 +197,8 @@ Blockly.FieldNumber.prototype.showNumPad_ = function() {
   this.addButtons_(contentDiv);
 
   // Set colour and size of drop-down
-  Blockly.DropDownDiv.setColour(Blockly.Colours.numPadBackground,
-      Blockly.Colours.numPadBorder);
+  Blockly.DropDownDiv.setColour(this.sourceBlock_.parentBlock_.getColour(),
+      this.sourceBlock_.getColourTertiary());
   contentDiv.style.width = Blockly.FieldNumber.DROPDOWN_WIDTH + 'px';
 
   this.position_();
@@ -238,12 +238,18 @@ Blockly.FieldNumber.prototype.position_ = function() {
  * @private
  */
 Blockly.FieldNumber.prototype.addButtons_ = function(contentDiv) {
+  var buttonColour = this.sourceBlock_.parentBlock_.getColour();
+  var buttonBorderColour = this.sourceBlock_.parentBlock_.getColourTertiary();
+
   // Add numeric keypad buttons
   var buttons = Blockly.FieldNumber.NUMPAD_BUTTONS;
   for (var i = 0, buttonText; buttonText = buttons[i]; i++) {
     var button = document.createElement('button');
     button.setAttribute('role', 'menuitem');
     button.setAttribute('class', 'blocklyNumPadButton');
+    button.setAttribute('style',
+        'background:' + buttonColour + ';' +
+        'border: 1px solid ' + buttonBorderColour + ';');
     button.title = buttonText;
     button.innerHTML = buttonText;
     Blockly.bindEvent_(button, 'mousedown', button,
@@ -264,6 +270,9 @@ Blockly.FieldNumber.prototype.addButtons_ = function(contentDiv) {
   var eraseButton = document.createElement('button');
   eraseButton.setAttribute('role', 'menuitem');
   eraseButton.setAttribute('class', 'blocklyNumPadButton');
+  eraseButton.setAttribute('style',
+      'background:' + buttonColour + ';' +
+      'border: 1px solid ' + buttonBorderColour + ';');
   eraseButton.title = 'Delete';
 
   var eraseImage = document.createElement('img');


### PR DESCRIPTION
### Resolves

No issue, just came up in passing

### Proposed Changes

Set dropdown colours based on grandparent block colours for the number picker dropdown, making it match the behaviour of other dropdowns.

### Reason for Changes

Looks nicer

### Test Coverage

Tested in the vertical playground.

Old:
![image](https://user-images.githubusercontent.com/13686399/47386297-230eba00-d6c1-11e8-8c27-5aec3e909155.png)

New:
![image](https://user-images.githubusercontent.com/13686399/47386329-39b51100-d6c1-11e8-9fca-7b66e60a2bcd.png)
