### PR TITLE
Choose sensible defaults for custom procedure parameters.

### DIFF
--- a/blocks_vertical/procedures.js
+++ b/blocks_vertical/procedures.js
@@ -624,7 +624,7 @@ Blockly.ScratchBlocks.ProcedureUtils.addBooleanExternal = function() {
   this.procCode_ = this.procCode_ + ' %b';
   this.displayNames_.push('boolean');
   this.argumentIds_.push(Blockly.utils.genUid());
-  this.argumentDefaults_.push('todo');
+  this.argumentDefaults_.push('false');
   this.updateDisplay_();
   this.focusLastEditor_();
 };
@@ -639,7 +639,7 @@ Blockly.ScratchBlocks.ProcedureUtils.addStringNumberExternal = function() {
   this.procCode_ = this.procCode_ + ' %s';
   this.displayNames_.push('number or text');
   this.argumentIds_.push(Blockly.utils.genUid());
-  this.argumentDefaults_.push('todo');
+  this.argumentDefaults_.push('');
   this.updateDisplay_();
   this.focusLastEditor_();
 };


### PR DESCRIPTION
### Resolves

Resolves #1745 

### Proposed Changes

Title says it all.

### Reason for Changes

[Recent changes in the scratch-vm](https://github.com/LLK/scratch-vm/pull/1642) make it so that these values are now getting used.

### Test Coverage

Manually tested that an empty value for a boolean parameter in a procedure call does not evaluate to 'todo' anymore.

cc\ @BryceLTaylor, @mzgoddard 