### PR TITLE
Initialize currentDragDeltaXY_ correctly

### DIFF
--- a/core/gesture.js
+++ b/core/gesture.js
@@ -515,6 +515,7 @@ Blockly.Gesture.prototype.doStart = function(e) {
   }
 
   this.mouseDownXY_ = new goog.math.Coordinate(e.clientX, e.clientY);
+  this.currentDragDeltaXY_ = new goog.math.Coordinate(0, 0);
 
   this.bindMouseEvents(e);
 };


### PR DESCRIPTION
### Resolves

Fixes #1550
### Proposed Changes

Initialize `currentDragDeltaXY_` in `doStart`

### Reason for Changes

Fixes a type error that shows up whenever you right-click duplicate

### Test Coverage

Tested in the vertical playground by right-click duplicating a block and checking the logs.