### PR TITLE
Add a context menu to the list getter block

### DIFF
--- a/msg/messages.js
+++ b/msg/messages.js
@@ -340,6 +340,8 @@ Blockly.Msg.LIST_ALREADY_EXISTS = 'A list named "%1" already exists.';
 Blockly.Msg.RENAME_LIST_TITLE = 'Rename all "%1" lists to:';
 Blockly.Msg.RENAME_LIST_MODAL_TITLE = 'Rename List';
 Blockly.Msg.DEFAULT_LIST_ITEM = 'thing';
+Blockly.Msg.DELETE_LIST = 'Delete the "%1" list';
+Blockly.Msg.RENAME_LIST = 'Rename list';
 
 // Broadcast Messages
 // @todo Remove these once fully managed by Scratch VM / Scratch GUI


### PR DESCRIPTION
### Resolves

Fixes #1223
### Proposed Changes

Create a mixin to add context menu options to list getter blocks.  It's parallel to the one that we have for variable getter blocks.  

Modify the referenced callback to take a `fieldName` parameter, since the variable blocks have a field named `VARIABLE` and the list blocks have a field named `LIST`.

### Reason for Changes

Match Scratch 2.0 behaviour.

### Test Coverage

Tested by creating multiple variables and multiple lists in the vertical playground, then checking that I can right-click on them.  In the flyout, right-click shows rename and delete options.  These work for lists, and still work for variables.

In the main workspace right-click shows all of the names of other variables of the same type.  This works for lists, and still works for variables.

### Additional Information
This adds two new messages, and the vm probably needs to listen for events and do something in response.  