### PR TITLE
Use different text for variable and list deletion/renaming

### DIFF
--- a/core/field_variable.js
+++ b/core/field_variable.js
@@ -313,11 +313,20 @@ Blockly.FieldVariable.dropdownCreate = function() {
     options.unshift(
         [Blockly.Msg.NEW_BROADCAST_MESSAGE, Blockly.NEW_BROADCAST_MESSAGE_ID]);
   } else {
-    options.push([Blockly.Msg.RENAME_VARIABLE, Blockly.RENAME_VARIABLE_ID]);
-    if (Blockly.Msg.DELETE_VARIABLE) {
+    // Scalar variables and lists have the same backing action, but the option
+    // text is different.
+    if (this.defaultType_ == Blockly.LIST_VARIABLE_TYPE) {
+      var renameText = Blockly.Msg.RENAME_LIST;
+      var deleteText = Blockly.Msg.DELETE_LIST;
+    } else {
+      var renameText = Blockly.Msg.RENAME_VARIABLE;
+      var deleteText = Blockly.Msg.DELETE_VARIABLE;
+    }
+    options.push([renameText, Blockly.RENAME_VARIABLE_ID]);
+    if (deleteText) {
       options.push(
           [
-            Blockly.Msg.DELETE_VARIABLE.replace('%1', name),
+            deleteText.replace('%1', name),
             Blockly.DELETE_VARIABLE_ID
           ]);
     }

--- a/msg/messages.js
+++ b/msg/messages.js
@@ -340,6 +340,8 @@ Blockly.Msg.LIST_ALREADY_EXISTS = 'A list named "%1" already exists.';
 Blockly.Msg.RENAME_LIST_TITLE = 'Rename all "%1" lists to:';
 Blockly.Msg.RENAME_LIST_MODAL_TITLE = 'Rename List';
 Blockly.Msg.DEFAULT_LIST_ITEM = 'thing';
+Blockly.Msg.DELETE_LIST = 'Delete the "%1" list';
+Blockly.Msg.RENAME_LIST = 'Rename list';
 
 // Broadcast Messages
 // @todo Remove these once fully managed by Scratch VM / Scratch GUI


### PR DESCRIPTION
### Resolves

#1434 
### Proposed Changes

Check the default type of the variable field, and use different rename and delete messages accordingly.
### Reason for Changes

Not mixing up variables and lists in text that we display to users.

### Test Coverage

Tested in the vertical playground by creating variables and lists, opening the dropdowns, and renaming and deleting them.  Rename and delete both work on both variables and lists, and the text looks correct for all four options.
