### PR TITLE
Don't allow illegal connections to procedure prototype blocks

### DIFF
--- a/core/connection.js
+++ b/core/connection.js
@@ -312,11 +312,15 @@ Blockly.Connection.prototype.canConnectWithReason_ = function(target) {
     return Blockly.Connection.REASON_CHECKS_FAILED;
   } else if (blockA.isShadow() && !blockB.isShadow()) {
     return Blockly.Connection.REASON_SHADOW_PARENT;
-  } else if (blockA.type == Blockly.PROCEDURES_DEFINITION_BLOCK_TYPE &&
-      blockB.type != 'procedures_prototype' &&
-      superiorConn == blockA.getInput('custom_block').connection ) {
+  } else if ((blockA.type == Blockly.PROCEDURES_DEFINITION_BLOCK_TYPE &&
+      blockB.type != Blockly.PROCEDURES_PROTOTYPE_BLOCK_TYPE &&
+      superiorConn == blockA.getInput('custom_block').connection) ||
+      (blockB.type == Blockly.PROCEDURES_PROTOTYPE_BLOCK_TYPE &&
+      blockA.type != Blockly.PROCEDURES_DEFINITION_BLOCK_TYPE)) {
     // Hack to fix #1127: Fail attempts to connect to the custom_block input
     // on a defnoreturn block, unless the connecting block is a specific type.
+    // And hack to fix #1534: Fail attempts to connect anything but a
+    // defnoreturn block to a prototype block.
     return Blockly.Connection.REASON_CUSTOM_PROCEDURE;
   }
   return Blockly.Connection.CAN_CONNECT;

--- a/tests/custom_procedure_playground.html
+++ b/tests/custom_procedure_playground.html
@@ -133,6 +133,15 @@
         </value>
       </block>
     </category>
+    <category name="Statements">
+      <block type="control_forever"></block>
+      <block type="sound_stopallsounds"></block>
+      <block type="control_start_as_clone"></block>
+      <block type="control_stop">
+        <mutation hasnext="false"></mutation>
+        <field name="STOP_OPTION">all</field>
+      </block>
+    </category>
   </xml>
 
   <script>


### PR DESCRIPTION
### Resolves

Fixes #1534

### Proposed Changes

Add another reason that connections can be disallowed because of custom procedures: when the superior block is not a procedure definition block but the inferior block is a procedure prototype block, it's not allowed.

### Reason for Changes

See #1534.  Behaviour was amusing but bad.

### Test Coverage

Tested by adding a few blocks to the custom procedure playground and checking there.