### PR TITLE
Add some missing utility functions

### DIFF
--- a/core/utils.js
+++ b/core/utils.js
@@ -935,3 +935,26 @@ Blockly.utils.getViewportBBox = function() {
     left: scrollOffset.x
   };
 };
+
+/**
+ * Fast prefix-checker.
+ * Copied from Closure's goog.string.startsWith.
+ * @param {string} str The string to check.
+ * @param {string} prefix A string to look for at the start of `str`.
+ * @return {boolean} True if `str` begins with `prefix`.
+ * @package
+ */
+Blockly.utils.startsWith = function(str, prefix) {
+  return str.lastIndexOf(prefix, 0) == 0;
+};
+
+/**
+ * Converts degrees to radians.
+ * Copied from Closure's goog.math.toRadians.
+ * @param {number} angleDegrees Angle in degrees.
+ * @return {number} Angle in radians.
+ * @package
+ */
+Blockly.utils.toRadians = function(angleDegrees) {
+  return angleDegrees * Math.PI / 180;
+};


### PR DESCRIPTION
### Resolves

#1687 references Blockly.utils.startsWith and Blockly.utils.toRadians, neither of which exist in scratch-blocks.

### Proposed Changes

Create the missing functions (should have happened as part of #1687)

### Reason for Changes

Resolve errors on every mouse move.

### Test Coverage

Confirmed that the errors are gone in the vertical playground.