### PR TITLE
Remove custom touch handling for dropdowns

### DIFF
--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -210,21 +210,6 @@ Blockly.FieldDropdown.prototype.showEditor_ = function() {
   }
   // Listen for mouse/keyboard events.
   goog.events.listen(menu, goog.ui.Component.EventType.ACTION, callback);
-  // Listen for touch events (why doesn't Closure handle this already?).
-  function callbackTouchStart(e) {
-    var control = this.getOwnerControl(/** @type {Node} */ (e.target));
-    // Highlight the menu item.
-    control.handleMouseDown(e);
-  }
-  function callbackTouchEnd(e) {
-    var control = this.getOwnerControl(/** @type {Node} */ (e.target));
-    // Activate the menu item.
-    control.performActionInternal(e);
-  }
-  menu.getHandler().listen(
-      menu.getElement(), goog.events.EventType.TOUCHSTART, callbackTouchStart);
-  menu.getHandler().listen(
-      menu.getElement(), goog.events.EventType.TOUCHEND, callbackTouchEnd);
 
   // Record windowSize and scrollOffset before adding menu.
   menu.render(contentDiv);


### PR DESCRIPTION
### Resolves

None that I found
### Proposed Changes
Get rid of custom touch handling code for dropdown fields.

### Reason for Changes

Scratch-blocks version of [this change](https://github.com/google/blockly/pull/1904).

The touch handler was selecting on touch up, which meant that you couldn't scroll a long dropdown--releasing the scroll would select an item.

Closure implemented touch handling since this code was put in place.
### Test Coverage

Tested in chrome pretending to be mobile, in scratch-blocks playground and integrated with scratch-gui