### PR TITLE
Allow block comments to be editable on mobile by catching the mousedo…

### DIFF
--- a/core/comment.js
+++ b/core/comment.js
@@ -220,8 +220,9 @@ Blockly.Comment.prototype.setVisible = function(visible) {
  */
 Blockly.Comment.prototype.textareaFocus_ = function(_e) {
   // Ideally this would be hooked to the focus event for the comment.
-  // However doing so in Firefox swallows the cursor for unknown reasons.
-  // So this is hooked to mouseup instead.  No big deal.
+  // This is tied to mousedown, however doing so in Firefox swallows the cursor
+  // for unknown reasons.
+  // See https://github.com/LLK/scratch-blocks/issues/1631 for more history.
   if (this.bubble_.promote_()) {
     // Since the act of moving this node within the DOM causes a loss of focus,
     // we need to reapply the focus.

--- a/core/scratch_block_comment.js
+++ b/core/scratch_block_comment.js
@@ -231,7 +231,7 @@ Blockly.ScratchBlockComment.prototype.createEditor_ = function() {
   this.textarea_ = textarea;
   this.textarea_.style.margin = (Blockly.ScratchBlockComment.TEXTAREA_OFFSET) + 'px';
   this.foreignObject_.appendChild(body);
-  Blockly.bindEventWithChecks_(textarea, 'mouseup', this, this.textareaFocus_);
+  Blockly.bindEventWithChecks_(textarea, 'mousedown', this, this.textareaFocus_);
   // Don't zoom with mousewheel.
   Blockly.bindEventWithChecks_(textarea, 'wheel', this, function(e) {
     e.stopPropagation();


### PR DESCRIPTION
…wn event and grabbing focus instead of the mouse up.  This makes the experience a bit worse in firefox (you have to click twice to focus the comment now), but fixing this the right way is invovled.  See #1631 for full context.

### Resolves

#1631 

### Proposed Changes

Make the focus callback trigger on mousedown instead of mouseup.

### Reason for Changes

https://github.com/LLK/scratch-blocks/issues/1631

### Test Coverage

Tested on mac chrome, firefox, safari and chrome on android.