### PR TITLE
Gave the drag handle a bit more spacing to avoid glow getting cut

### DIFF
--- a/core/field_angle.js
+++ b/core/field_angle.js
@@ -117,10 +117,17 @@ Blockly.FieldAngle.HANDLE_RADIUS = 10;
 Blockly.FieldAngle.ARROW_WIDTH = Blockly.FieldAngle.HANDLE_RADIUS;
 
 /**
+ * Half the stroke-width used for the "glow" around the drag handle, rounded up to nearest whole pixel
+ */
+
+Blockly.FieldAngle.HANDLE_GLOW_WIDTH = 3;
+
+/**
  * Radius of protractor circle.  Slightly smaller than protractor size since
  * otherwise SVG crops off half the border at the edges.
  */
-Blockly.FieldAngle.RADIUS = Blockly.FieldAngle.HALF - Blockly.FieldAngle.HANDLE_RADIUS - 1;
+Blockly.FieldAngle.RADIUS = Blockly.FieldAngle.HALF
+    - Blockly.FieldAngle.HANDLE_RADIUS - Blockly.FieldAngle.HANDLE_GLOW_WIDTH;
 
 /**
  * Radius of central dot circle.


### PR DESCRIPTION
### Resolves

#1766

### Proposed Changes

Gives the drag handle a bit more spacing to avoid the "glow" getting cut off at and around degrees:0, 90, 180 and 270

### Reason for Changes

To resolve #1766

### Test Coverage

No test added or changed
