### PR TITLE
Disable pointer events on field angle arrow to fix firefox dragging

### DIFF
--- a/core/css.js
+++ b/core/css.js
@@ -794,6 +794,9 @@ Blockly.Css.CONTENT = [
     'cursor: pointer;',
   '}',
 
+  '.blocklyAngleDragArrow {',
+    'pointer-events: none',
+  '}',
 
   '.blocklyAngleMarks {',
     'stroke: #fff;',

--- a/core/field_angle.js
+++ b/core/field_angle.js
@@ -229,7 +229,8 @@ Blockly.FieldAngle.prototype.showEditor_ = function() {
         'width': Blockly.FieldAngle.ARROW_WIDTH,
         'height': Blockly.FieldAngle.ARROW_WIDTH,
         'x': -Blockly.FieldAngle.ARROW_WIDTH / 2,
-        'y': -Blockly.FieldAngle.ARROW_WIDTH / 2
+        'y': -Blockly.FieldAngle.ARROW_WIDTH / 2,
+        'class': 'blocklyAngleDragArrow'
       },
       this.handle_);
   this.arrowSvg_.setAttributeNS(


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Resolves an issue where it was hard to use the angle picker on firefox because the image inside the handle would start dragging instead, messing with the events. Demo:

![drag-angle--broken](https://user-images.githubusercontent.com/654102/48009937-99141780-e0ea-11e8-8f4b-691aa94f1e80.gif)


### Proposed Changes

_Describe what this Pull Request does_

Add pointer-events: none to the image using CSS to prevent starting a drag on the image itself. This does not impact grabbing the handle because those events are bound on the circle around the image. 

### Reason for Changes

_Explain why these changes should be made_

Fix firefox angle picker

### Test Coverage

_Please show how you have added tests to cover your changes_

![drag-angle--fixed](https://user-images.githubusercontent.com/654102/48010011-bb0d9a00-e0ea-11e8-8d2f-8efbd0d2ab66.gif)

This can be tested in the vertical playground