### PR TITLE
Fix local compile on Windows

### DIFF
--- a/build.py
+++ b/build.py
@@ -323,7 +323,7 @@ class Gen_compressed(threading.Thread):
       for group in [["google-closure-compiler"], dash_args]:
         args.extend(filter(lambda item: item, group))
 
-      proc = subprocess.Popen(args, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+      proc = subprocess.Popen(args, stdin=subprocess.PIPE, stdout=subprocess.PIPE, shell=True)
       (stdout, stderr) = proc.communicate()
 
       # Build the JSON response.
@@ -566,7 +566,7 @@ if __name__ == "__main__":
 
     # Sanity check the local compiler
     test_args = [closure_compiler, os.path.join("build", "test_input.js")]
-    test_proc = subprocess.Popen(test_args, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+    test_proc = subprocess.Popen(test_args, stdin=subprocess.PIPE, stdout=subprocess.PIPE, shell=True)
     (stdout, _) = test_proc.communicate()
     assert stdout == read(os.path.join("build", "test_expect.js"))
 


### PR DESCRIPTION
### Resolves

Resolves #1523

### Proposed Changes

This change sets the `shell=True` flag in the two places we use `subprocess.Popen` to run the Closure Compiler locally.

### Reason for Changes

We call the local compiler with `subprocess.Popen`, passing `google-closure-compiler` as the command to run. On Windows, the actual command is `google-closure-compiler.cmd` -- the extension is automatically added by the shell. Unfortunately `subprocess.Popen` by default bypasses the shell, leading to an error on Windows. Setting `shell=True` makes `Popen` use the Windows shell (`cmd`) and correctly find `google-closure-compiler.cmd`.
