### PR TITLE
Fix non-deterministic build error #1409

### DIFF
--- a/blocks_vertical/procedures.js
+++ b/blocks_vertical/procedures.js
@@ -30,6 +30,7 @@ goog.require('Blockly.constants');
 
 
 // TODO: Create a namespace properly.
+Blockly.ScratchBlocks = Blockly.ScratchBlocks || {};
 Blockly.ScratchBlocks.ProcedureUtils = {};
 
 // Serialization and deserialization.


### PR DESCRIPTION
### Resolves

This fixes #1409, at least on my machine.

### Proposed Changes

By the time `Blockly.ScratchBlocks.ProcedureUtils` was defined, `Blockly.ScratchBlocks` had not been defined. This makes sure `Blockly.ScratchBlocks` is defined.

### Reason for Changes

This is the first line of JavaScript code that I've ever written in my life, so I'm not even sure if this is the right way to define the namespace. #1409 was blocking me from working on scratch-gui and scratch-blocks. Seems like this change fixed the error.

### Test Coverage

No tests added.
