### PR TITLE
Support scientific notation in numerical inputs

### DIFF
--- a/core/field_number.js
+++ b/core/field_number.js
@@ -135,6 +135,9 @@ Blockly.FieldNumber.prototype.getNumRestrictor = function(opt_min, opt_max,
   if (this.negativeAllowed_) {
     pattern += "|[-]";
   }
+  if (this.exponentialAllowed_) {
+    pattern += "|e";
+  }
   return new RegExp(pattern);
 };
 
@@ -151,6 +154,7 @@ Blockly.FieldNumber.prototype.setConstraints_ = function(opt_min, opt_max,
       (Math.floor(opt_precision) != opt_precision);
   this.negativeAllowed_ = (typeof opt_min == 'undefined') || isNaN(opt_min) ||
       opt_min < 0;
+  this.exponentialAllowed_ = this.decimalAllowed_;
 };
 
 /**

--- a/core/field_number.js
+++ b/core/field_number.js
@@ -136,7 +136,7 @@ Blockly.FieldNumber.prototype.getNumRestrictor = function(opt_min, opt_max,
     pattern += "|[-]";
   }
   if (this.exponentialAllowed_) {
-    pattern += "|e";
+    pattern += "|[eE]";
   }
   return new RegExp(pattern);
 };


### PR DESCRIPTION
### Resolves

Resolves #1301.

### Proposed Changes

Allows the letter "e" to be inputted into number inputs.

### Reason for Changes

To support scientific notation inside number inputs, which is a feature in Scratch 2.0.

### Test Coverage

Tested manually in blocks and gui with the following script:

![The script "when green flag clicked, go to x: -1e2 y: 0, glide 1 secs to x: 1e2 y: 0, say 2.5e3 / 2"](https://user-images.githubusercontent.com/9948030/48307251-72f1db80-e51f-11e8-9863-a12924e1afe3.png)

~~It looks like I might be able to add tests in `tests/jsunit/field_number_test.js`, but I'm not 100% sure.~~ I think I would need to figure out how to get Selenium running locally, which seems to be sort of a big task - so I can't add unit tests myself.

Aside: It's possible to input "e123e7e1eeeee", but this is no different from Scratch 2.0 behavior. You can also do the same thing with the negative sign ("-") already. (Interestingly, Scratch 1.4 will do some verification in number inputs; no such in later versions. Also, 2.0 is the first version with support for scientific notation in number inputs.)