### PR TITLE
Make insertion markers for define blocks have the correct width

### DIFF
--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -1606,6 +1606,7 @@ Blockly.BlockSvg.prototype.renderDefineBlock_ = function(steps, inputRows,
         input.connection.targetBlock().getHeightWidth().width +
         Blockly.BlockSvg.DEFINE_BLOCK_PADDING_RIGHT;
   } else {
+    // Handles the case where block is being rendered as an insertion marker
     rightSide = Math.max(Blockly.BlockSvg.MIN_BLOCK_X_WITH_STATEMENT, rightSide)
     + Blockly.BlockSvg.DEFINE_BLOCK_PADDING_RIGHT;
   }

--- a/core/block_render_svg_vertical.js
+++ b/core/block_render_svg_vertical.js
@@ -1606,7 +1606,8 @@ Blockly.BlockSvg.prototype.renderDefineBlock_ = function(steps, inputRows,
         input.connection.targetBlock().getHeightWidth().width +
         Blockly.BlockSvg.DEFINE_BLOCK_PADDING_RIGHT;
   } else {
-    rightSide = Blockly.BlockSvg.MIN_BLOCK_X_WITH_STATEMENT;
+    rightSide = Math.max(Blockly.BlockSvg.MIN_BLOCK_X_WITH_STATEMENT, rightSide)
+    + Blockly.BlockSvg.DEFINE_BLOCK_PADDING_RIGHT;
   }
   rightSide -= Blockly.BlockSvg.DEFINE_HAT_CORNER_RADIUS;
 


### PR DESCRIPTION
### Resolves

#1186 

### Proposed Changes

Make insertion markers for define blocks have to correct width. 

### Reason for Changes

Trying to fix #1186

### Test Coverage

No tests added
