### PR TITLE
Track cloud variable info

### DIFF
--- a/core/variable_events.js
+++ b/core/variable_events.js
@@ -89,6 +89,7 @@ Blockly.Events.VarCreate = function(variable) {
   this.varType = variable.type;
   this.varName = variable.name;
   this.isLocal = variable.isLocal;
+  this.isCloud = variable.isCloud;
 };
 goog.inherits(Blockly.Events.VarCreate, Blockly.Events.VarBase);
 
@@ -107,6 +108,7 @@ Blockly.Events.VarCreate.prototype.toJson = function() {
   json['varType'] = this.varType;
   json['varName'] = this.varName;
   json['isLocal'] = this.isLocal;
+  json['isCloud'] = this.isCloud;
   return json;
 };
 
@@ -119,6 +121,7 @@ Blockly.Events.VarCreate.prototype.fromJson = function(json) {
   this.varType = json['varType'];
   this.varName = json['varName'];
   this.isLocal = json['isLocal'];
+  this.isCloud = json['isCloud'];
 };
 
 /**
@@ -128,7 +131,7 @@ Blockly.Events.VarCreate.prototype.fromJson = function(json) {
 Blockly.Events.VarCreate.prototype.run = function(forward) {
   var workspace = this.getEventWorkspace_();
   if (forward) {
-    workspace.createVariable(this.varName, this.varType, this.varId, this.isLocal);
+    workspace.createVariable(this.varName, this.varType, this.varId, this.isLocal, this.isCloud);
   } else {
     workspace.deleteVariableById(this.varId);
   }
@@ -149,6 +152,7 @@ Blockly.Events.VarDelete = function(variable) {
   this.varType = variable.type;
   this.varName = variable.name;
   this.isLocal = variable.isLocal;
+  this.isCloud = variable.isCloud;
 };
 goog.inherits(Blockly.Events.VarDelete, Blockly.Events.VarBase);
 
@@ -167,6 +171,7 @@ Blockly.Events.VarDelete.prototype.toJson = function() {
   json['varType'] = this.varType;
   json['varName'] = this.varName;
   json['isLocal'] = this.isLocal;
+  json['isCloud'] = this.isCloud;
   return json;
 };
 
@@ -179,6 +184,7 @@ Blockly.Events.VarDelete.prototype.fromJson = function(json) {
   this.varType = json['varType'];
   this.varName = json['varName'];
   this.isLocal = json['isLocal'];
+  this.isCloud = json['isCloud'];
 };
 
 /**
@@ -190,7 +196,7 @@ Blockly.Events.VarDelete.prototype.run = function(forward) {
   if (forward) {
     workspace.deleteVariableById(this.varId);
   } else {
-    workspace.createVariable(this.varName, this.varType, this.varId, this.isLocal);
+    workspace.createVariable(this.varName, this.varType, this.varId, this.isLocal, this.isCloud);
   }
 };
 

--- a/core/variable_map.js
+++ b/core/variable_map.js
@@ -175,10 +175,11 @@ Blockly.VariableMap.prototype.renameVariableWithConflict_ = function(variable,
  * @param {string=} opt_id The unique ID of the variable. This will default to
  *     a UUID.
  * @param {boolean=} opt_isLocal Whether the variable is locally scoped.
+ * @param {boolean=} opt_isCloud Whether the variable is a cloud variable.
  * @return {?Blockly.VariableModel} The newly created variable.
  */
 Blockly.VariableMap.prototype.createVariable = function(name,
-    opt_type, opt_id, opt_isLocal) {
+    opt_type, opt_id, opt_isLocal, opt_isCloud) {
   var variable = this.getVariable(name, opt_type);
   if (variable) {
     if (opt_id && variable.getId() != opt_id) {
@@ -203,7 +204,7 @@ Blockly.VariableMap.prototype.createVariable = function(name,
   opt_type = opt_type || '';
 
   variable = new Blockly.VariableModel(this.workspace, name, opt_type, opt_id,
-      opt_isLocal);
+      opt_isLocal, opt_isCloud);
   // If opt_type is not a key, create a new list.
   if (!this.variableMap_[opt_type]) {
     this.variableMap_[opt_type] = [variable];

--- a/core/variable_model.js
+++ b/core/variable_model.js
@@ -43,10 +43,12 @@ goog.require('goog.string');
  * @param {string=} opt_id The unique ID of the variable. This will default to
  *     a UUID.
  * @param {boolean=} opt_isLocal Whether the variable is locally scoped.
+ * @param {boolean=} opt_isCloud Whether the variable is a cloud variable.
  * @see {Blockly.FieldVariable}
  * @constructor
  */
-Blockly.VariableModel = function(workspace, name, opt_type, opt_id, opt_isLocal) {
+Blockly.VariableModel = function(workspace, name, opt_type, opt_id,
+    opt_isLocal, opt_isCloud) {
   /**
    * The workspace the variable is in.
    * @type {!Blockly.Workspace}
@@ -84,6 +86,12 @@ Blockly.VariableModel = function(workspace, name, opt_type, opt_id, opt_isLocal)
    * @package
    */
   this.isLocal = opt_isLocal || false;
+
+  /**
+   * Whether the variable is a cloud variable.
+   * @package
+   */
+  this.isCloud = opt_isCloud || false;
 
   Blockly.Events.fire(new Blockly.Events.VarCreate(this));
 };

--- a/core/workspace.js
+++ b/core/workspace.js
@@ -341,10 +341,12 @@ Blockly.Workspace.prototype.renameVariableById = function(id, newName) {
  * @param {string=} opt_id The unique ID of the variable. This will default to
  *     a UUID.
  * @param {boolean=} opt_isLocal Whether the variable to create is locally scoped.
+ * @param {boolean=} opt_isCloud Whether the variable to create is locally scoped.
  * @return {?Blockly.VariableModel} The newly created variable.
  */
-Blockly.Workspace.prototype.createVariable = function(name, opt_type, opt_id, opt_isLocal) {
-  return this.variableMap_.createVariable(name, opt_type, opt_id, opt_isLocal);
+Blockly.Workspace.prototype.createVariable = function(name, opt_type, opt_id,
+    opt_isLocal, opt_isCloud) {
+  return this.variableMap_.createVariable(name, opt_type, opt_id, opt_isLocal, opt_isCloud);
 };
 
 /**

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1161,14 +1161,15 @@ Blockly.WorkspaceSvg.prototype.deleteVariableById = function(id) {
  * @param {string=} opt_id The unique ID of the variable. This will default to
  *     a UUID.
  * @param {boolean=} opt_isLocal Whether the variable is locally scoped.
+ * @param {boolean=} opt_isCloud Whether the variable is a cloud variable.
  * @return {?Blockly.VariableModel} The newly created variable.
  * @package
  */
 Blockly.WorkspaceSvg.prototype.createVariable = function(name, opt_type, opt_id,
-    opt_isLocal) {
+    opt_isLocal, opt_isCloud) {
   var variableInMap = (this.getVariable(name, opt_type) != null);
   var newVar = Blockly.WorkspaceSvg.superClass_.createVariable.call(
-      this, name, opt_type, opt_id, opt_isLocal);
+      this, name, opt_type, opt_id, opt_isLocal, opt_isCloud);
   // For performance reasons, only refresh the the toolbox for new variables.
   // Variables that already exist should already be there.
   if (!variableInMap && (opt_type != Blockly.BROADCAST_MESSAGE_VARIABLE_TYPE)) {

--- a/core/xml.js
+++ b/core/xml.js
@@ -72,6 +72,7 @@ Blockly.Xml.variablesToDom = function(variableList) {
     element.setAttribute('type', variable.type);
     element.setAttribute('id', variable.getId());
     element.setAttribute('islocal', variable.isLocal);
+    element.setAttribute('isCloud', variable.isCloud);
     variables.appendChild(element);
   }
   return variables;
@@ -638,12 +639,13 @@ Blockly.Xml.domToVariables = function(xmlVariables, workspace) {
     var type = xmlChild.getAttribute('type');
     var id = xmlChild.getAttribute('id');
     var isLocal = xmlChild.getAttribute('islocal') == 'true';
+    var isCloud = xmlChild.getAttribute('isCloud') == 'true';
     var name = xmlChild.textContent;
 
     if (typeof(type) === undefined || type === null) {
       throw Error('Variable with id, ' + id + ' is without a type');
     }
-    workspace.createVariable(name, type, id, isLocal);
+    workspace.createVariable(name, type, id, isLocal, isCloud);
   }
 };
 

--- a/tests/jsunit/event_test.js
+++ b/tests/jsunit/event_test.js
@@ -375,9 +375,26 @@ function test_varCreate_toJson() {
     var event = new Blockly.Events.VarCreate(variable);
     var json = event.toJson();
     var expectedJson = ({type: "var_create", varId: "id1", varType: "type1",
-      varName: "name1", isLocal: false});
+      varName: "name1", isLocal: false, isCloud: false});
 
     assertEquals(JSON.stringify(expectedJson), JSON.stringify(json));
+
+    var localVariable = workspace.createVariable('name2', 'type2', 'id2', true);
+    var event2 = new Blockly.Events.VarCreate(localVariable);
+    var json2 = event2.toJson();
+    var expectedJson2 = ({type: "var_create", varId: "id2", varType: "type2",
+      varName: "name2", isLocal: true, isCloud: false});
+
+    assertEquals(JSON.stringify(expectedJson2), JSON.stringify(json2));
+
+    var cloudVariable = workspace.createVariable('name3', 'type3', 'id3', false, true);
+    var event3 = new Blockly.Events.VarCreate(cloudVariable);
+    var json3 = event3.toJson();
+    var expectedJson3 = ({type: "var_create", varId: "id3", varType: "type3",
+      varName: "name3", isLocal: false, isCloud: true});
+
+    assertEquals(JSON.stringify(expectedJson3), JSON.stringify(json3));
+
   } finally {
     eventTest_tearDown();
   }
@@ -434,9 +451,25 @@ function test_varDelete_toJson() {
   var event = new Blockly.Events.VarDelete(variable);
   var json = event.toJson();
   var expectedJson = ({type: "var_delete", varId: "id1", varType: "type1",
-    varName: "name1", isLocal: false});
+    varName: "name1", isLocal: false, isCloud: false});
 
   assertEquals(JSON.stringify(expectedJson), JSON.stringify(json));
+
+  var localVariable = workspace.createVariable('name2', 'type2', 'id2', true);
+  var event2 = new Blockly.Events.VarDelete(localVariable);
+  var json2 = event2.toJson();
+  var expectedJson2 = ({type: "var_delete", varId: "id2", varType: "type2",
+    varName: "name2", isLocal: true, isCloud: false});
+
+  assertEquals(JSON.stringify(expectedJson2), JSON.stringify(json2));
+
+  var cloudVariable = workspace.createVariable('name3', 'type3', 'id3', false, true);
+  var event3 = new Blockly.Events.VarDelete(cloudVariable);
+  var json3 = event3.toJson();
+  var expectedJson3 = ({type: "var_delete", varId: "id3", varType: "type3",
+    varName: "name3", isLocal: false, isCloud: true});
+
+  assertEquals(JSON.stringify(expectedJson2), JSON.stringify(json2));
   eventTest_tearDown();
 }
 


### PR DESCRIPTION
### Proposed Changes

Track information about cloud variables and handle adding the cloud unicode character to the variable.

### Reason for Changes

Allows for the creation of cloud variables from the variable modal.

### Test Coverage

Testing instructions included in the related scratch-gui PR.

### Related PRs
- LLK/scratch-gui#3749
- LLK/scratch-vm#1755