### PR TITLE
Fix importing cloud vars from xml.

### DIFF
--- a/core/xml.js
+++ b/core/xml.js
@@ -639,7 +639,7 @@ Blockly.Xml.domToVariables = function(xmlVariables, workspace) {
     var type = xmlChild.getAttribute('type');
     var id = xmlChild.getAttribute('id');
     var isLocal = xmlChild.getAttribute('islocal') == 'true';
-    var isCloud = xmlChild.getAttribute('isCloud') == 'true';
+    var isCloud = xmlChild.getAttribute('iscloud') == 'true';
     var name = xmlChild.textContent;
 
     if (typeof(type) === undefined || type === null) {


### PR DESCRIPTION
### Proposed Changes

Towards resolving an issue with renaming cloud variables. Track isCloud flag from xml properly.

Related to LLK/scratch-vm#1795.

### Reason for Changes

Renaming cloud vars was not working properly (was removing the cloud unicode character) after the block used to rename the variable got reloaded (e.g. switching to the costumes tab and back to blocks and attempting to rename a cloud variable using a block in the toolbox).

### Test Coverage

Manually tested (along with changes from LLK/scratch-vm#1795):

1. Create a cloud variable
2. Switch to the costumes tab
3. Switch back to the blocks tab
4. Right click on the variable reporter in the toolbox to rename the cloud variable.
5. Rename the variable.
6. Observe that the variable is renamed keeping the cloud unicode character. On scratch.ly, the cloud unicode character is gone after the rename.
