### PR TITLE
Fix switching variables via context menu 

### DIFF
--- a/blocks_vertical/data.js
+++ b/blocks_vertical/data.js
@@ -526,7 +526,7 @@ Blockly.Constants.Data.CUSTOM_CONTEXT_MENU_GET_VARIABLE_MIXIN = {
 
         option.callback =
             Blockly.Constants.Data.VARIABLE_OPTION_CALLBACK_FACTORY(this,
-                option.text, fieldName);
+                variablesList[i].getId(), fieldName);
         options.push(option);
       }
     } else {
@@ -579,7 +579,7 @@ Blockly.Constants.Data.CUSTOM_CONTEXT_MENU_GET_LIST_MIXIN = {
 
         option.callback =
             Blockly.Constants.Data.VARIABLE_OPTION_CALLBACK_FACTORY(this,
-                option.text, fieldName);
+                variablesList[i].getId(), fieldName);
         options.push(option);
       }
     } else {
@@ -610,18 +610,18 @@ Blockly.Extensions.registerMixin('contextMenu_getListBlock',
  * menu, and clicking on that item changes the text of the field on the source
  * block.
  * @param {!Blockly.Block} block The block to update.
- * @param {string} name The new name to display on the block.
+ * @param {string} id The id of the variable to set on this block.
  * @param {string} fieldName The name of the field to update on the block.
  * @return {!function()} A function that updates the block with the new name.
  */
 Blockly.Constants.Data.VARIABLE_OPTION_CALLBACK_FACTORY = function(block,
-    name, fieldName) {
+    id, fieldName) {
   return function() {
     var variableField = block.getField(fieldName);
     if (!variableField) {
       console.log("Tried to get a variable field on the wrong type of block.");
     }
-    variableField.setText(name);
+    variableField.setValue(id);
   };
 };
 

--- a/core/variables.js
+++ b/core/variables.js
@@ -299,6 +299,7 @@ Blockly.Variables.createVariable = function(workspace, opt_callback, opt_type) {
   // Prompt the user to enter a name for the variable
   Blockly.prompt(newMsg, '',
       function(text, additionalVars, variableOptions) {
+        variableOptions = variableOptions || {};
         var scope = variableOptions.scope;
         var isLocal = (scope === 'local') || false;
         var isCloud = variableOptions.isCloud || false;


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-gui/issues/2944

### Proposed Changes

_Describe what this Pull Request does_

Looks like this code was not updated when we moved from variable names to IDs. So just move the callback code to use IDs and `setValue` instead of names and `setText`

I was able to test this (after fixing the playground) by turning on the workspace event logging and noting that before this change, no "change" event was being emitted when the context menu was used. But after this change, the correct "change" event is emitted when using the context menu.

I also tested this by embedding it in the GUI and making sure the reported value from stack clicks was correct after switching variables. 