### PR TITLE
Use variable name as default value for rename prompts

### DIFF
--- a/core/variables.js
+++ b/core/variables.js
@@ -496,8 +496,8 @@ Blockly.Variables.renameVariable = function(workspace, variable,
   Blockly.prompt(promptText, promptDefaultText,
       function(newName, additionalVars) {
         if (variable.isCloud &&
-            newName.length > 0 && newName.indexOf(Blockly.Variables.CLOUD_PREFIX) == 0 ) {
-          newName = newName.substring(2); // The name validator will add the prefix back
+            newName.length > 0 && newName.indexOf(Blockly.Variables.CLOUD_PREFIX) == 0) {
+          newName = newName.substring(Blockly.Variables.CLOUD_PREFIX.length); // The name validator will add the prefix back
         }
         additionalVars = additionalVars || [];
         var additionalVarNames = variable.isLocal ? [] : additionalVars;

--- a/core/variables.js
+++ b/core/variables.js
@@ -497,7 +497,8 @@ Blockly.Variables.renameVariable = function(workspace, variable,
       function(newName, additionalVars) {
         if (variable.isCloud &&
             newName.length > 0 && newName.indexOf(Blockly.Variables.CLOUD_PREFIX) == 0) {
-          newName = newName.substring(Blockly.Variables.CLOUD_PREFIX.length); // The name validator will add the prefix back
+          newName = newName.substring(Blockly.Variables.CLOUD_PREFIX.length);
+          // The name validator will add the prefix back
         }
         additionalVars = additionalVars || [];
         var additionalVarNames = variable.isLocal ? [] : additionalVars;

--- a/core/variables.js
+++ b/core/variables.js
@@ -488,7 +488,7 @@ Blockly.Variables.renameVariable = function(workspace, variable,
   var validate = Blockly.Variables.nameValidator_.bind(null, varType);
 
   var promptText = promptMsg.replace('%1', variable.name);
-  Blockly.prompt(promptText, '',
+  Blockly.prompt(promptText, variable.name,
       function(newName, additionalVars) {
         if (variable.isCloud &&
             newName.length > 0 && newName.indexOf(Blockly.Variables.CLOUD_PREFIX) == 0 ) {

--- a/core/variables.js
+++ b/core/variables.js
@@ -488,7 +488,12 @@ Blockly.Variables.renameVariable = function(workspace, variable,
   var validate = Blockly.Variables.nameValidator_.bind(null, varType);
 
   var promptText = promptMsg.replace('%1', variable.name);
-  Blockly.prompt(promptText, variable.name,
+  var promptDefaultText = variable.name;
+  if (variable.isCloud && variable.name.indexOf(Blockly.Variables.CLOUD_PREFIX) == 0) {
+    promptDefaultText = promptDefaultText.substring(Blockly.Variables.CLOUD_PREFIX.length);
+  }
+
+  Blockly.prompt(promptText, promptDefaultText,
       function(newName, additionalVars) {
         if (variable.isCloud &&
             newName.length > 0 && newName.indexOf(Blockly.Variables.CLOUD_PREFIX) == 0 ) {


### PR DESCRIPTION
### Resolves

Together with LLK/scratch-gui#3984, resolves LLK/scratch-gui#3983. Should be merged **after** that PR.

### Proposed Changes

Passes the variable name as the default value for the rename prompt.

### Reason for Changes

So that it's easier to make a quick modification to a variable name (e.g. if you made a typo while creating the variable).

### Test Coverage

Tested manually.
