### PR TITLE
 fix reporters having extra space below text.

### DIFF
--- a/core/css.js
+++ b/core/css.js
@@ -246,7 +246,7 @@ Blockly.Css.CONTENT = [
     'box-shadow: 0px 0px 8px 1px ' + Blockly.Colours.dropDownShadow + ';',
     'padding: 4px;',
     '-webkit-user-select: none;',
-    'min-height: 26px',
+    'min-height: 15px',
   '}',
 
   '.blocklyDropDownContent {',


### PR DESCRIPTION
### Proposed Changes

Update min height on drop down div, to fix reporter bubble size.

### Reason for Changes

@carljbowman noted in a recent bug hunt:
> Extra space below on the tooltip that shows a reporter’s value

### Test Coverage

Manually tested:

![image](https://user-images.githubusercontent.com/1786240/49665083-c02f7300-fa21-11e8-873a-5673a2d149e7.png)

![image](https://user-images.githubusercontent.com/1786240/49665100-ccb3cb80-fa21-11e8-9610-377655086bf3.png)
