### PR TITLE
Use fill-opacity for notepicker shadow

### DIFF
--- a/core/field_note.js
+++ b/core/field_note.js
@@ -193,11 +193,18 @@ Blockly.FieldNote.EDGE_PADDING = 1;
 Blockly.FieldNote.SHADOW_HEIGHT = 4;
 
 /**
- * A translucent gray color, for the shadow on the piano.
+ * Color for the shadow on the piano.
  * @type {string}
  * @const
  */
-Blockly.FieldNote.SHADOW_COLOR = 'rgba(.2, .2, .2, .2)';
+Blockly.FieldNote.SHADOW_COLOR = '#000';
+
+/**
+ * Opacity for the shadow on the piano.
+ * @type {string}
+ * @const
+ */
+Blockly.FieldNote.SHADOW_OPACITY = '.2';
 
 /**
  * A color for the white piano keys.
@@ -451,7 +458,8 @@ Blockly.FieldNote.prototype.showEditor_ = function() {
         'y': Blockly.FieldNote.TOP_MENU_HEIGHT,
         'width': this.fieldEditorWidth_,
         'height': Blockly.FieldNote.SHADOW_HEIGHT,
-        'fill': Blockly.FieldNote.SHADOW_COLOR
+        'fill': Blockly.FieldNote.SHADOW_COLOR,
+        'fill-opacity': Blockly.FieldNote.SHADOW_OPACITY
       }, svg);
 
   // Octave buttons

--- a/core/field_note.js
+++ b/core/field_note.js
@@ -204,7 +204,7 @@ Blockly.FieldNote.SHADOW_COLOR = '#000';
  * @type {string}
  * @const
  */
-Blockly.FieldNote.SHADOW_OPACITY = '.2';
+Blockly.FieldNote.SHADOW_OPACITY = .2;
 
 /**
  * A color for the white piano keys.


### PR DESCRIPTION
### Resolves

On Mac Safari, note picker drop shadow is black #1784

### Proposed Changes

Use fill-opacity instead of rgba to create the drop shadow.

### Reason for Changes

It looks like Safari doesn't support putting an rgba color in the "fill" attribute for svg elements. See https://stackoverflow.com/questions/6042550/svg-fill-color-transparency-alpha/6047978

### Test Coverage

None
