### PR TITLE
Clear dropdown width to fix half-width bug

### DIFF
--- a/core/dropdowndiv.js
+++ b/core/dropdowndiv.js
@@ -151,6 +151,7 @@ Blockly.DropDownDiv.getContentDiv = function() {
  */
 Blockly.DropDownDiv.clearContent = function() {
   Blockly.DropDownDiv.content_.innerHTML = '';
+  Blockly.DropDownDiv.content_.style.width = '';
 };
 
 /**


### PR DESCRIPTION
### Resolves

On Android, number picker makes the note picker appear half-width #1783

### Proposed Changes

Clear dropdown width when it is hidden

### Reason for Changes

See https://github.com/LLK/scratch-blocks/issues/1783#issuecomment-438519140

### Test Coverage

None