### PR TITLE
Deletion of single hat blocks connected to a stack

### DIFF
--- a/core/block.js
+++ b/core/block.js
@@ -339,8 +339,7 @@ Blockly.Block.prototype.unplug = function(opt_healStack) {
       // Disconnect from any superior block.
       this.outputConnection.disconnect();
     }
-  }
-  else {
+  } else {
     if (this.previousConnection) {
       var previousTarget = null;
       if (this.previousConnection.isConnected()) {

--- a/core/block.js
+++ b/core/block.js
@@ -339,13 +339,16 @@ Blockly.Block.prototype.unplug = function(opt_healStack) {
       // Disconnect from any superior block.
       this.outputConnection.disconnect();
     }
-  } else if (this.previousConnection) {
-    var previousTarget = null;
-    if (this.previousConnection.isConnected()) {
-      // Remember the connection that any next statements need to connect to.
-      previousTarget = this.previousConnection.targetConnection;
-      // Detach this block from the parent's tree.
-      this.previousConnection.disconnect();
+  }
+  else {
+    if (this.previousConnection) {
+      var previousTarget = null;
+      if (this.previousConnection.isConnected()) {
+        // Remember the connection that any next statements need to connect to.
+        previousTarget = this.previousConnection.targetConnection;
+        // Detach this block from the parent's tree.
+        this.previousConnection.disconnect();
+      }
     }
     var nextBlock = this.getNextBlock();
     if (opt_healStack && nextBlock) {


### PR DESCRIPTION
### Resolves

Deletion behavior on right-clicking the first block - fixes #245, fixes #1776

### Proposed Changes

When deleting a block with no previousConnection (i.e. a hat block), this change allows for disconnection of the hat block from the rest of the stack. Thus, only the hat block is deleted.

### Reason for Changes

"Delete this block" should delete only a single block, even if it's a hat block.

### Test Coverage

None
