### PR TITLE
Change the order of the arrow keys

### DIFF
--- a/blocks_vertical/event.js
+++ b/blocks_vertical/event.js
@@ -277,10 +277,10 @@ Blockly.Blocks['event_whenkeypressed'] = {
           "name": "KEY_OPTION",
           "options": [
             [Blockly.Msg.EVENT_WHENKEYPRESSED_SPACE, 'space'],
-            [Blockly.Msg.EVENT_WHENKEYPRESSED_LEFT, 'left arrow'],
-            [Blockly.Msg.EVENT_WHENKEYPRESSED_RIGHT, 'right arrow'],
-            [Blockly.Msg.EVENT_WHENKEYPRESSED_DOWN, 'down arrow'],
             [Blockly.Msg.EVENT_WHENKEYPRESSED_UP, 'up arrow'],
+            [Blockly.Msg.EVENT_WHENKEYPRESSED_DOWN, 'down arrow'],
+            [Blockly.Msg.EVENT_WHENKEYPRESSED_RIGHT, 'right arrow'],
+            [Blockly.Msg.EVENT_WHENKEYPRESSED_LEFT, 'left arrow'],
             [Blockly.Msg.EVENT_WHENKEYPRESSED_ANY, 'any'],
             ['a', 'a'],
             ['b', 'b'],

--- a/blocks_vertical/sensing.js
+++ b/blocks_vertical/sensing.js
@@ -226,10 +226,10 @@ Blockly.Blocks['sensing_keyoptions'] = {
           "name": "KEY_OPTION",
           "options": [
             [Blockly.Msg.EVENT_WHENKEYPRESSED_SPACE, 'space'],
-            [Blockly.Msg.EVENT_WHENKEYPRESSED_LEFT, 'left arrow'],
-            [Blockly.Msg.EVENT_WHENKEYPRESSED_RIGHT, 'right arrow'],
-            [Blockly.Msg.EVENT_WHENKEYPRESSED_DOWN, 'down arrow'],
             [Blockly.Msg.EVENT_WHENKEYPRESSED_UP, 'up arrow'],
+            [Blockly.Msg.EVENT_WHENKEYPRESSED_DOWN, 'down arrow'],
+            [Blockly.Msg.EVENT_WHENKEYPRESSED_RIGHT, 'right arrow'],
+            [Blockly.Msg.EVENT_WHENKEYPRESSED_LEFT, 'left arrow'],
             [Blockly.Msg.EVENT_WHENKEYPRESSED_ANY, 'any'],
             ['a', 'a'],
             ['b', 'b'],


### PR DESCRIPTION
### Resolves

Fixes https://github.com/LLK/scratch-gui/issues/2173

### Proposed Changes

Reorders the arrow keys

### Reason for Changes

Be consistent with Scratch 2.0

### Test Coverage

<img width="268" alt="screen shot 2018-12-12 at 4 24 11 pm" src="https://user-images.githubusercontent.com/399209/49899692-6b796700-fe2a-11e8-9493-9efb4162dda9.png">
<img width="245" alt="screen shot 2018-12-12 at 4 23 59 pm" src="https://user-images.githubusercontent.com/399209/49899693-6b796700-fe2a-11e8-9b37-015a9ab26919.png">

