### PR TITLE
Scroll very long context menus

### DIFF
--- a/core/css.js
+++ b/core/css.js
@@ -818,6 +818,7 @@ Blockly.Css.CONTENT = [
 
   '.blocklyContextMenu {',
     'border-radius: 4px;',
+    'max-height: 100%;',
   '}',
 
   '.blocklyDropdownMenu {',

--- a/core/widgetdiv.js
+++ b/core/widgetdiv.js
@@ -274,8 +274,13 @@ Blockly.WidgetDiv.positionWithAnchor = function(viewportBBox, anchorBBox,
   var y = Blockly.WidgetDiv.calculateY_(viewportBBox, anchorBBox, widgetSize);
   var x = Blockly.WidgetDiv.calculateX_(viewportBBox, anchorBBox, widgetSize,
       rtl);
-
-  Blockly.WidgetDiv.positionInternal_(x, y, widgetSize.height);
+  
+  if (y < 0) {
+    Blockly.WidgetDiv.positionInternal_(x, 0, widgetSize.height + y);
+  }
+  else {
+    Blockly.WidgetDiv.positionInternal_(x, y, widgetSize.height);
+  }
 };
 
 /**


### PR DESCRIPTION
### Resolves

Very long right-click/context menus are cut off, resolves #1375

### Proposed Changes

If the context menu is created from above the top of the screen, it makes the context menu start from the top of the screen and then scroll.

For example:
![image](https://user-images.githubusercontent.com/1689183/49966752-bf8d5580-fed5-11e8-9d5d-0dfc162f132c.png)

### Question
I ended up modifying the blockly library files -- is it better to do a PR to the blockly repository rather than editing these files in scratch-blocks directly?
