### PR TITLE
Make all number inputs LTR

### DIFF
--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -233,6 +233,10 @@ Blockly.FieldTextInput.prototype.showEditor_ = function(
   if (readOnly) {
     htmlInput.setAttribute('readonly', 'true');
   }
+  if (this.sourceBlock_.type === 'math_number') {
+    // All number fields are LTR.
+    htmlInput.setAttribute('dir', 'ltr');
+  }
   /** @type {!HTMLInputElement} */
   Blockly.FieldTextInput.htmlInput_ = htmlInput;
   div.appendChild(htmlInput);


### PR DESCRIPTION
### Resolves

Resolves #1709, resolves #1708, resolves #1707 

### Proposed Changes

Make all number inputs LTR

### Reason for Changes

Number inputs should always be LTR, even when an RTL language is being used.

### Test Coverage

None
