### PR TITLE
Comments follow mouse pointer when duplicating

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -673,11 +673,9 @@ Blockly.BlockSvg.prototype.showContextMenu_ = function(e) {
   // Save the current block in a variable for use in closures.
   var block = this;
   var menuOptions = [];
-
-  var isMouseEvent = Blockly.Touch.getTouchIdentifierFromEvent(e) == 'mouse';
   if (this.isDeletable() && this.isMovable() && !block.isInFlyout) {
     menuOptions.push(
-        Blockly.ContextMenu.blockDuplicateOption(block, isMouseEvent));
+        Blockly.ContextMenu.blockDuplicateOption(block, e));
     if (this.isEditable() && this.workspace.options.comments) {
       menuOptions.push(Blockly.ContextMenu.blockCommentOption(block));
     }

--- a/core/contextmenu.js
+++ b/core/contextmenu.js
@@ -270,7 +270,6 @@ Blockly.ContextMenu.blockDuplicateOption = function(block, event) {
   };
   return duplicateOption;
 };
-//
 
 /**
  * Make a context menu option for adding or removing comments on the current
@@ -444,7 +443,6 @@ Blockly.ContextMenu.commentDuplicateOption = function(comment) {
       Blockly.duplicate_(comment);
     }
   };
-  //
   return duplicateOption;
 };
 

--- a/core/contextmenu.js
+++ b/core/contextmenu.js
@@ -270,7 +270,7 @@ Blockly.ContextMenu.blockDuplicateOption = function(block, event) {
   };
   return duplicateOption;
 };
-// 
+//
 
 /**
  * Make a context menu option for adding or removing comments on the current

--- a/core/contextmenu.js
+++ b/core/contextmenu.js
@@ -257,20 +257,20 @@ Blockly.ContextMenu.blockHelpOption = function(block) {
 /**
  * Make a context menu option for duplicating the current block.
  * @param {!Blockly.BlockSvg} block The block where the right-click originated.
- * @param {boolean} isMouseEvent True if the event that caused the context
- *     menu to open came from a mouse.  False if touch.
+ * @param {!Event} event Event that caused the context menu to open.
  * @return {!Object} A menu option, containing text, enabled, and a callback.
  * @package
  */
-Blockly.ContextMenu.blockDuplicateOption = function(block, isMouseEvent) {
+Blockly.ContextMenu.blockDuplicateOption = function(block, event) {
   var duplicateOption = {
     text: Blockly.Msg.DUPLICATE,
     enabled: true,
     callback:
-        Blockly.scratchBlocksUtils.duplicateAndDragCallback(block, isMouseEvent)
+        Blockly.scratchBlocksUtils.duplicateAndDragCallback(block, event)
   };
   return duplicateOption;
 };
+// 
 
 /**
  * Make a context menu option for adding or removing comments on the current
@@ -441,9 +441,11 @@ Blockly.ContextMenu.commentDuplicateOption = function(comment) {
     text: Blockly.Msg.DUPLICATE,
     enabled: true,
     callback: function() {
-      Blockly.duplicate_(comment);
+      Blockly.scratchBlocksUtils.duplicateAndDragCallback(comment, false);
+      // Blockly.duplicate_(comment);
     }
   };
+  //
   return duplicateOption;
 };
 

--- a/core/contextmenu.js
+++ b/core/contextmenu.js
@@ -441,8 +441,7 @@ Blockly.ContextMenu.commentDuplicateOption = function(comment) {
     text: Blockly.Msg.DUPLICATE,
     enabled: true,
     callback: function() {
-      Blockly.scratchBlocksUtils.duplicateAndDragCallback(comment, false);
-      // Blockly.duplicate_(comment);
+      Blockly.duplicate_(comment);
     }
   };
   //

--- a/core/contextmenu.js
+++ b/core/contextmenu.js
@@ -432,16 +432,15 @@ Blockly.ContextMenu.commentDeleteOption = function(comment) {
  * Make a context menu option for duplicating the current workspace comment.
  * @param {!Blockly.WorkspaceCommentSvg} comment The workspace comment where the
  *     right-click originated.
+ * @param {!Event} event Event that caused the context menu to open.
  * @return {!Object} A menu option, containing text, enabled, and a callback.
  * @package
  */
-Blockly.ContextMenu.commentDuplicateOption = function(comment) {
+Blockly.ContextMenu.commentDuplicateOption = function(comment, event) {
   var duplicateOption = {
     text: Blockly.Msg.DUPLICATE,
     enabled: true,
-    callback: function() {
-      Blockly.duplicate_(comment);
-    }
+    callback: Blockly.scratchBlocksUtils.duplicateAndDragCallback(comment, event)
   };
   return duplicateOption;
 };

--- a/core/gesture.js
+++ b/core/gesture.js
@@ -975,6 +975,24 @@ Blockly.Gesture.prototype.forceStartBlockDrag = function(fakeEvent, block) {
 };
 
 /**
+ * Don't even think about using this function before talking to rachel-fenichel.
+ *
+ * Force a drag to start without clicking and dragging the bubble itself.  Used
+ * to attach duplicated bubbles to the mouse pointer.
+ * @param {!Object} fakeEvent An object with the properties needed to start a
+ *     drag, including clientX and clientY.
+ * @param {!Blockly.BlockSvg} bubble The bubble to start dragging.
+ * @package
+ */
+Blockly.Gesture.prototype.forceStartBubbleDrag = function(fakeEvent, bubble) {
+  this.handleBubbleStart(fakeEvent, bubble);
+  this.handleWsStart(fakeEvent, bubble.workspace);
+  this.isDraggingBubble_ = true;
+  this.hasExceededDragRadius_ = true;
+  this.startDraggingBubble_();
+};
+
+/**
  * Duplicate the target block and start dragging the duplicated block.
  * This should be done once we are sure that it is a block drag, and no earlier.
  * Specifically for argument reporters in custom block defintions.

--- a/core/scratch_blocks_utils.js
+++ b/core/scratch_blocks_utils.js
@@ -223,7 +223,7 @@ Blockly.scratchBlocksUtils.duplicateAndDragCallback = function(oldBlock, event) 
 
       if (isMouseEvent) {
         // e is not a real mouseEvent/touchEvent/pointerEvent.  It's an event
-        // created by the context menu that has the coordinates of the mouse
+        // created by the context menu and has the coordinates of the mouse
         // click that opened the context menu.
         var fakeEvent = {
           clientX: event.clientX,

--- a/core/scratch_blocks_utils.js
+++ b/core/scratch_blocks_utils.js
@@ -163,14 +163,13 @@ Blockly.scratchBlocksUtils.blockIsRecyclable = function(block) {
  * which acts as though it were pressed and mid-drag.  Clicking the mouse
  * releases the new dragging block.
  * @param {!Blockly.BlockSvg} oldBlock The block that will be duplicated.
- * @param {boolean} isMouseEvent True if the event that caused the context
- *     menu to open came from a mouse.  False if touch.
+ * @param {!Event} event Event that caused the context menu to open.
  * @return {Function} A callback function that duplicates the block and starts a
  *     drag.
  * @package
  */
-Blockly.scratchBlocksUtils.duplicateAndDragCallback = function(oldBlock,
-    isMouseEvent) {
+Blockly.scratchBlocksUtils.duplicateAndDragCallback = function(oldBlock, event) {
+  var isMouseEvent = Blockly.Touch.getTouchIdentifierFromEvent(event) === 'mouse';
   return function(e) {
     // Give the context menu a chance to close.
     setTimeout(function() {
@@ -223,31 +222,12 @@ Blockly.scratchBlocksUtils.duplicateAndDragCallback = function(oldBlock,
       }
 
       if (isMouseEvent) {
-        // The position of the old block in pixels relative to the main
-        // workspace's origin.
-        var oldBlockPosPixels = oldBlockPosWs.scale(ws.scale);
-
-        // The offset in pixels between the main workspace's origin and the upper left
-        // corner of the injection div.
-        var mainOffsetPixels = ws.getOriginOffsetInPixels();
-
-        // The position of the old block in pixels relative to the upper left corner
-        // of the injection div.
-        var finalOffsetPixels = goog.math.Coordinate.sum(mainOffsetPixels,
-            oldBlockPosPixels);
-
-        var injectionDiv = ws.getInjectionDiv();
-        // Bounding rect coordinates are in client coordinates, meaning that they
-        // are in pixels relative to the upper left corner of the visible browser
-        // window.  These coordinates change when you scroll the browser window.
-        var boundingRect = injectionDiv.getBoundingClientRect();
-
         // e is not a real mouseEvent/touchEvent/pointerEvent.  It's an event
-        // created by the context menu and doesn't have the correct coordinates.
-        // But it does have some information that we need.
+        // created by the context menu that has the coordinates of the mouse
+        // click that opened the context menu.
         var fakeEvent = {
-          clientX: finalOffsetPixels.x + boundingRect.left,
-          clientY: finalOffsetPixels.y + boundingRect.top,
+          clientX: event.clientX,
+          clientY: event.clientY,
           type: 'mousedown',
           preventDefault: function() {
             e.preventDefault();

--- a/core/workspace_comment_svg.js
+++ b/core/workspace_comment_svg.js
@@ -175,7 +175,7 @@ Blockly.WorkspaceCommentSvg.prototype.showContextMenu_ = function(e) {
   var menuOptions = [];
 
   if (this.isDeletable() && this.isMovable()) {
-    menuOptions.push(Blockly.ContextMenu.commentDuplicateOption(comment));
+    menuOptions.push(Blockly.ContextMenu.commentDuplicateOption(comment, e));
     menuOptions.push(Blockly.ContextMenu.commentDeleteOption(comment));
   }
 

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -2234,15 +2234,20 @@ Blockly.WorkspaceSvg.prototype.cancelCurrentGesture = function() {
  * to attach duplicated blocks to the mouse pointer.
  * @param {!Object} fakeEvent An object with the properties needed to start a
  *     drag, including clientX and clientY.
- * @param {!Blockly.BlockSvg} block The block to start dragging.
+ * @param {!Blockly.BlockSvg|Blockly.WorkspaceCommentSvg} item The block/comment to start dragging.
  * @package
  */
 Blockly.WorkspaceSvg.prototype.startDragWithFakeEvent = function(fakeEvent,
-    block) {
+    item) {
   Blockly.Touch.clearTouchIdentifier();
   Blockly.Touch.checkTouchIdentifier(fakeEvent);
-  var gesture = block.workspace.getGesture(fakeEvent);
-  gesture.forceStartBlockDrag(fakeEvent, block);
+  var gesture = item.workspace.getGesture(fakeEvent);
+  if (item.isComment) {
+    gesture.forceStartBubbleDrag(fakeEvent, item);
+  }
+  else {
+    gesture.forceStartBlockDrag(fakeEvent, item);
+  }
 };
 
 /**


### PR DESCRIPTION
### Resolves

Resolves #1526, Duplicating a workspace comment should attach the comment to the mouse

### Proposed Changes

Modifies `Blockly.scratchBlocksUtils.duplicateAndDragCallback` to work for both comments and blocks.

Should be merged after #1826.

### Reason for Changes

A much better experience when duplicating comments.

### Test Coverage

None
