### PR TITLE
Fix - Dragging a block over vertical category menu doesn't delete it immediately

### DIFF
--- a/core/toolbox.js
+++ b/core/toolbox.js
@@ -559,8 +559,10 @@ Blockly.Toolbox.prototype.selectCategoryById = function(id) {
 Blockly.Toolbox.prototype.setSelectedItemFactory = function(item) {
   var selectedItem = item;
   return function() {
-    this.setSelectedItem(selectedItem);
-    Blockly.Touch.clearTouchIdentifier();
+    if (!this.workspace_.isDragging()) {
+      this.setSelectedItem(selectedItem);
+      Blockly.Touch.clearTouchIdentifier();
+    }
   };
 };
 


### PR DESCRIPTION
### Resolves

Fixes #1830 (Dragging a block over vertical category menu doesn't delete it immediately)

### Proposed Changes

Don't bind on mouseup for the toolbox when block is being dragged over it.

### Reason for Changes

It turns out, when the mouseup event is called when hovering over a toolbox, the `Blockly.Toolbox.prototype.setSelectedItemFactory` method calls `Blockly.Touch.clearTouchIdentifier`. This messes up the event handling for when the _block_ is finished dragging (because `Blockly.Touch.touchIdentifier_` becomes `null`). So, these changes make sure not to call this event handler when someone is already dragging a block.
