### PR TITLE
Make refreshToolboxSelection_ package instead of private

### DIFF
--- a/core/block_dragger.js
+++ b/core/block_dragger.js
@@ -289,7 +289,7 @@ Blockly.BlockDragger.prototype.endBlockDrag = function(e, currentDragDeltaXY) {
         }
       }
       // The proc deletion was valid, update the toolbox.
-      ws.refreshToolboxSelection_();
+      ws.refreshToolboxSelection();
     });
   }
 };

--- a/core/procedures.js
+++ b/core/procedures.js
@@ -568,10 +568,8 @@ Blockly.Procedures.deleteProcedureDefCallback = function(procCode,
   Blockly.Events.setGroup(true);
   definitionRoot.dispose();
   Blockly.Events.setGroup(false);
-
-  // TODO (#1354) Update this function when '_' is removed
   // Refresh toolbox, so caller doesn't appear there anymore
-  workspace.refreshToolboxSelection_();
+  workspace.refreshToolboxSelection();
 
   return true;
 };

--- a/core/workspace.js
+++ b/core/workspace.js
@@ -134,13 +134,12 @@ Blockly.Workspace.prototype.isClearing = false;
  */
 Blockly.Workspace.prototype.MAX_UNDO = 1024;
 
-// TODO (#1354) Update this function when it is fixed upstream
 /**
  * Refresh the toolbox. This is a no-op in a non-rendered workspace,
  * but may be overriden by subclasses.
- * @private
+ * @package
  */
-Blockly.Workspace.prototype.refreshToolboxSelection_ = function() {
+Blockly.Workspace.prototype.refreshToolboxSelection = function() {
   // No-op. Overriden by subclass.
 };
 

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1109,9 +1109,9 @@ Blockly.WorkspaceSvg.prototype.pasteWorkspaceComment_ = function(xmlComment) {
 
 /**
  * Refresh the toolbox unless there's a drag in progress.
- * @private
+ * @package
  */
-Blockly.WorkspaceSvg.prototype.refreshToolboxSelection_ = function() {
+Blockly.WorkspaceSvg.prototype.refreshToolboxSelection = function() {
   // Updating the toolbox can be expensive. Don't do it when when it is
   // disabled.
   if (this.toolbox_) {
@@ -1137,7 +1137,7 @@ Blockly.WorkspaceSvg.prototype.refreshToolboxSelection_ = function() {
  */
 Blockly.WorkspaceSvg.prototype.renameVariableById = function(id, newName) {
   Blockly.WorkspaceSvg.superClass_.renameVariableById.call(this, id, newName);
-  this.refreshToolboxSelection_();
+  this.refreshToolboxSelection();
 };
 
 /**
@@ -1148,7 +1148,7 @@ Blockly.WorkspaceSvg.prototype.renameVariableById = function(id, newName) {
  */
 Blockly.WorkspaceSvg.prototype.deleteVariableById = function(id) {
   Blockly.WorkspaceSvg.superClass_.deleteVariableById.call(this, id);
-  this.refreshToolboxSelection_();
+  this.refreshToolboxSelection();
 };
 
 /**
@@ -1173,7 +1173,7 @@ Blockly.WorkspaceSvg.prototype.createVariable = function(name, opt_type, opt_id,
   // For performance reasons, only refresh the the toolbox for new variables.
   // Variables that already exist should already be there.
   if (!variableInMap && (opt_type != Blockly.BROADCAST_MESSAGE_VARIABLE_TYPE)) {
-    this.refreshToolboxSelection_();
+    this.refreshToolboxSelection();
   }
   return newVar;
 };
@@ -2090,7 +2090,7 @@ Blockly.WorkspaceSvg.prototype.setToolboxRefreshEnabled = function(enabled) {
   this.toolboxRefreshEnabled_ = enabled;
   if (reenabled) {
     // Newly enabled.  Trigger a refresh.
-    this.refreshToolboxSelection_();
+    this.refreshToolboxSelection();
   }
 };
 

--- a/tests/custom_procedure_playground.html
+++ b/tests/custom_procedure_playground.html
@@ -188,7 +188,7 @@
       callback = null;
       mutationRoot = null;
       declarationWorkspace.clear();
-      definitionWorkspace.refreshToolboxSelection_()
+      definitionWorkspace.refreshToolboxSelection()
       editorActions.style.visibility = 'hidden';
     }
 
@@ -230,7 +230,7 @@
       callback = null;
       mutationRoot = null;
       declarationWorkspace.clear();
-      definitionWorkspace.refreshToolboxSelection_()
+      definitionWorkspace.refreshToolboxSelection()
       editorActions.style.visibility = 'hidden';
     }
 </script>

--- a/tests/workspace_svg/workspace_svg_test.js
+++ b/tests/workspace_svg/workspace_svg_test.js
@@ -102,7 +102,7 @@ function test_addNewVariableRefreshToolbox() {
 
   var mockControl = new goog.testing.MockControl();
   var mockMethod = mockControl.createMethodMock(Blockly.WorkspaceSvg.prototype,
-    'refreshToolboxSelection_');
+    'refreshToolboxSelection');
   try {
     mockMethod().$once();
     mockControl.$replayAll();
@@ -119,7 +119,7 @@ function test_addDuplicateVariableDoNotRefreshToolbox() {
   
   var mockControl = new goog.testing.MockControl();
   var mockMethod = mockControl.createMethodMock(Blockly.WorkspaceSvg.prototype,
-    'refreshToolboxSelection_');
+    'refreshToolboxSelection');
   try {
     mockMethod().$once();
     mockControl.$replayAll();


### PR DESCRIPTION
### Resolves

Fixes #1354, Update refreshToolboxSelection

### Proposed Changes

Make refreshToolboxSelection_ a package method and rename it to refreshToolboxSelection.

### Reason for Changes

See the blockly issue - https://github.com/google/blockly/issues/1554