### PR TITLE
Go to definition

### DIFF
--- a/blocks_vertical/vertical_extensions.js
+++ b/blocks_vertical/vertical_extensions.js
@@ -202,13 +202,13 @@ Blockly.ScratchBlocks.VerticalExtensions.PROCEDURE_DEF_CONTEXTMENU = {
  */
 Blockly.ScratchBlocks.VerticalExtensions.PROCEDURE_CALL_CONTEXTMENU = {
   /**
-   * Add the "edit" option to the context menu.
-   * @todo Add "go to definition" option once implemented.
+   * Add the "edit" and "go to definition" options to the context menu.
    * @param {!Array.<!Object>} menuOptions List of menu options to edit.
    * @this Blockly.Block
    */
   customContextMenu: function(menuOptions) {
     menuOptions.push(Blockly.Procedures.makeEditOption(this));
+    menuOptions.push(Blockly.Procedures.makeShowDefinitionOption(this));
   }
 };
 

--- a/core/procedures.js
+++ b/core/procedures.js
@@ -519,13 +519,15 @@ Blockly.Procedures.makeEditOption = function(block) {
 /**
  * Callback to show the procedure definition corresponding to a custom command
  * block.
- * TODO(#1136): Implement.
  * @param {!Blockly.Block} block The block that was right-clicked.
  * @private
  */
 Blockly.Procedures.showProcedureDefCallback_ = function(block) {
-  alert('TODO(#1136): implement showing procedure definition (procCode was "' +
-      block.procCode_ + '")');
+  var def = Blockly.Procedures.getDefineBlock(block.getProcCode(), block.workspace);
+  if (def) {
+    block.workspace.centerOnBlock(def.id);
+    def.select();
+  }
 };
 
 /**

--- a/core/procedures.js
+++ b/core/procedures.js
@@ -523,9 +523,12 @@ Blockly.Procedures.makeEditOption = function(block) {
  * @private
  */
 Blockly.Procedures.showProcedureDefCallback_ = function(block) {
-  var def = Blockly.Procedures.getDefineBlock(block.getProcCode(), block.workspace);
+  // If block clicked is in the toolbox, its definition will be in
+  // block.workspace.targetWorkspace. Otherwise, it will be in block.workspace.
+  var workspace = block.workspace.targetWorkspace || block.workspace;
+  var def = Blockly.Procedures.getDefineBlock(block.getProcCode(), workspace);
   if (def) {
-    block.workspace.centerOnBlock(def.id);
+    workspace.centerOnBlock(def.id);
     def.select();
   }
 };


### PR DESCRIPTION
### Resolves

Fixes #1136, Implement "go to procedure definition"

### Proposed Changes

Add a "go to definition" option to the context menu for custom blocks.

![image](https://user-images.githubusercontent.com/1689183/50222176-71f56a80-0365-11e9-8996-86ad2d88082e.png)


### Reason for Changes

Now that `Blockly.WorkspaceSvg.prototype.centerOnBlock` has been added, we can implement the "go to definition" feature.
