### PR TITLE
Comment formatting improvements

### DIFF
--- a/core/css.js
+++ b/core/css.js
@@ -650,6 +650,7 @@ Blockly.Css.CONTENT = [
 
   '.scratchCommentBody {',
     'background-color: #fef49c;',
+    'border-radius: 4px;',
   '}',
 
   '.scratchCommentRect {',

--- a/core/scratch_bubble.js
+++ b/core/scratch_bubble.js
@@ -212,8 +212,8 @@ Blockly.ScratchBubble.prototype.createCommentTopBar_ = function() {
   this.commentTopBar_ = Blockly.utils.createSvgElement('rect',
       {
         'class': 'blocklyDraggable scratchCommentTopBar',
-        'x': Blockly.ScratchBubble.BORDER_WIDTH,
-        'y': Blockly.ScratchBubble.BORDER_WIDTH,
+        'rx': Blockly.ScratchBubble.BORDER_WIDTH,
+        'ry': Blockly.ScratchBubble.BORDER_WIDTH,
         'height': Blockly.ScratchBubble.TOP_BAR_HEIGHT
       }, this.bubbleGroup_);
 
@@ -530,12 +530,12 @@ Blockly.ScratchBubble.prototype.setBubbleSize = function(width, height) {
   var doubleBorderWidth = 2 * Blockly.ScratchBubble.BORDER_WIDTH;
   // Minimum size of a bubble.
   width = Math.max(width, doubleBorderWidth + 50);
-  height = Math.max(height, doubleBorderWidth + Blockly.ScratchBubble.TOP_BAR_HEIGHT);
+  height = Math.max(height, Blockly.ScratchBubble.TOP_BAR_HEIGHT);
   this.width_ = width;
   this.height_ = height;
   this.bubbleBack_.setAttribute('width', width);
   this.bubbleBack_.setAttribute('height', height);
-  this.commentTopBar_.setAttribute('width', width - doubleBorderWidth);
+  this.commentTopBar_.setAttribute('width', width);
   this.commentTopBar_.setAttribute('height', Blockly.ScratchBubble.TOP_BAR_HEIGHT);
   if (this.workspace_.RTL) {
     this.minimizeArrow_.setAttribute('x', width -

--- a/core/workspace_comment_render_svg.js
+++ b/core/workspace_comment_render_svg.js
@@ -242,8 +242,8 @@ Blockly.WorkspaceCommentSvg.prototype.createCommentTopBar_ = function() {
   this.svgHandleTarget_ = Blockly.utils.createSvgElement('rect',
       {
         'class': 'blocklyDraggable scratchCommentTopBar',
-        'x': Blockly.WorkspaceCommentSvg.BORDER_WIDTH,
-        'y': Blockly.WorkspaceCommentSvg.BORDER_WIDTH,
+        'rx': Blockly.WorkspaceCommentSvg.BORDER_WIDTH,
+        'ry': Blockly.WorkspaceCommentSvg.BORDER_WIDTH,
         'height': Blockly.WorkspaceCommentSvg.TOP_BAR_HEIGHT
       }, this.svgGroup_);
 
@@ -565,7 +565,7 @@ Blockly.WorkspaceCommentSvg.prototype.setSize = function(width, height) {
   this.svgRect_.setAttribute('height', height);
   this.svgRectTarget_.setAttribute('width', width);
   this.svgRectTarget_.setAttribute('height', height);
-  this.svgHandleTarget_.setAttribute('width', width - doubleBorderWidth);
+  this.svgHandleTarget_.setAttribute('width', width);
   this.svgHandleTarget_.setAttribute('height', Blockly.WorkspaceCommentSvg.TOP_BAR_HEIGHT);
   if (this.RTL) {
     this.minimizeArrow_.setAttribute('x', width -


### PR DESCRIPTION
### Resolves

Fixes #1626 - Comment rendering needs improvement

### Proposed Changes

Some CSS/SVG changes to fix: 1) The small gaps between the border and the top-bar rectangle and 2) The bottom-left part of the comment bleeds over the border.

With those issues fixed, comments will look like this now:

![image](https://user-images.githubusercontent.com/1689183/50223921-7a03d900-036a-11e9-8280-a8243f4135c6.png)


### Reason for Changes

Better look and feel
