### PR TITLE
"Say something" for block comment

### DIFF
--- a/core/contextmenu.js
+++ b/core/contextmenu.js
@@ -293,7 +293,7 @@ Blockly.ContextMenu.blockCommentOption = function(block) {
     // If there's no comment, add an option to create a comment.
     commentOption.text = Blockly.Msg.ADD_COMMENT;
     commentOption.callback = function() {
-      block.setCommentText('');
+      block.setCommentText(Blockly.Msg.WORKSPACE_COMMENT_DEFAULT_TEXT);
     };
   }
   return commentOption;


### PR DESCRIPTION
### Resolves
Resolves #1839 

### Proposed Changes
Uses `WORKSPACE_COMMENT_DEFAULT_TEXT` for block comment.
The key name is kept, because it'll be hard to change it.
### Reason for Changes
It should say so.

### Test Coverage
Windows 7 does not allow me to test scratch-blocks, sorry... Let me test with this pr
