### PR TITLE
Raise dragging layer z-index

### DIFF
--- a/core/css.js
+++ b/core/css.js
@@ -218,7 +218,7 @@ Blockly.Css.CONTENT = [
     'right: 0;',
     'bottom: 0;',
     'overflow: visible !important;',
-    'z-index: 50;', /* Display above the toolbox */
+    'z-index: 1000;', /* Display above the toolbox */
   '}',
 
   '.blocklyTooltipDiv {',


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_
Resolving various z-index issues in gui and www.

### Proposed Changes

_Describe what this Pull Request does_
Raise the dragging layer z-index to match the gui.
### Reason for Changes

_Explain why these changes should be made_
There are other ui elements (menus, alerts etc) that are above the toolbox. Anything being dragged should be above those. Gui uses 1000 (or greater) as the z-index when dragging costumes, sounds, etc. Blocks should match.

Looking at other z-index values, there didn't appear to be anything else between 50 and 1000. Raising it to 1000 matches the z-index for `blocklyDropDownDiv`. Should `blocklyDropDownDiv` get a small increment to maintain its position above the drag-layer? 
### Test Coverage

_Please show how you have added tests to cover your changes_
Doesn't change functionality so it should be covered by existing tests.
