### PR TITLE
Sort context menu variable list

### DIFF
--- a/blocks_vertical/data.js
+++ b/blocks_vertical/data.js
@@ -521,6 +521,9 @@ Blockly.Constants.Data.CUSTOM_CONTEXT_MENU_GET_VARIABLE_MIXIN = {
     var currentVarName = this.getField(fieldName).text_;
     if (!this.isInFlyout) {
       var variablesList = this.workspace.getVariablesOfType('');
+      variablesList.sort(function(a, b) {
+        return Blockly.scratchBlocksUtils.compareStrings(a.name, b.name);
+      });
       for (var i = 0; i < variablesList.length; i++) {
         var varName = variablesList[i].name;
         if (varName == currentVarName) continue;


### PR DESCRIPTION
### Resolves

Fixes #1879.

### Proposed Changes

Sorts the variable list in the variable context menu:

![A halfway-scrolled context menu with many alphabetically sorted variables in it.](https://user-images.githubusercontent.com/9948030/52234818-f1e57e80-2898-11e9-9129-766da2d90310.png)

Sorts list context menus, too:

![The same deal, but in the context menu of a list reporter.](https://user-images.githubusercontent.com/9948030/52235074-82bc5a00-2899-11e9-9979-0fa714595fe5.png)

### Reason for Changes

To make the context menu of variable/list menus more useful, and more consistent with other lists of variables in the UI.

### Test Coverage

No new unit tests. Tested manually.