### PR TITLE
Fix flyout button

### DIFF
--- a/core/flyout_button.js
+++ b/core/flyout_button.js
@@ -307,7 +307,7 @@ Blockly.FlyoutButton.prototype.dispose = function() {
 Blockly.FlyoutButton.prototype.onMouseUp_ = function(e) {
   var gesture = this.targetWorkspace_.getGesture(e);
   if (gesture) {
-    // If we're in the middle of dragging something (blocks. workspace, etc.) ignore the button.
+    // If we're in the middle of dragging something (blocks, workspace, etc.) ignore the button.
     // Otherwise, cancel the gesture.
     if (gesture.isDragging()) {
       return;

--- a/core/flyout_button.js
+++ b/core/flyout_button.js
@@ -307,6 +307,11 @@ Blockly.FlyoutButton.prototype.dispose = function() {
 Blockly.FlyoutButton.prototype.onMouseUp_ = function(e) {
   var gesture = this.targetWorkspace_.getGesture(e);
   if (gesture) {
+    // If we're in the middle of dragging something (blocks. workspace, etc.) ignore the button.
+    // Otherwise, cancel the gesture.
+    if (gesture.isDragging()) {
+      return;
+    }
     gesture.cancel();
   }
 


### PR DESCRIPTION
…g in process.

This issue was caused by adding pointer-events:none on the drag surface 
element in https://github.com/LLK/scratch-gui/pull/2584

### Resolves

#1671 
### Proposed Changes

Bail out of the flyout button mouse up handler when a drag is in progress so that ending a drag doesn't cause a button click. 
