### PR TITLE
Wrap drag surface so overflow is cut off

### DIFF
--- a/core/block_drag_surface.js
+++ b/core/block_drag_surface.js
@@ -112,6 +112,8 @@ Blockly.BlockDragSurfaceSvg.prototype.createDom = function() {
   if (this.SVG_) {
     return;  // Already created.
   }
+  this.wrapper_ = goog.dom.createDom('div', 'blocklyDragSurfaceWrapper');
+  document.body.appendChild(this.wrapper_);
   this.SVG_ = Blockly.utils.createSvgElement('svg',
       {
         'xmlns': Blockly.SVG_NS,
@@ -119,13 +121,23 @@ Blockly.BlockDragSurfaceSvg.prototype.createDom = function() {
         'xmlns:xlink': 'http://www.w3.org/1999/xlink',
         'version': '1.1',
         'class': 'blocklyBlockDragSurface'
-      }, this.container_);
+      }, this.wrapper_);
   this.dragGroup_ = Blockly.utils.createSvgElement('g', {}, this.SVG_);
   // Belongs in Scratch Blocks, but not Blockly.
   var defs = Blockly.utils.createSvgElement('defs', {}, this.SVG_);
   this.dragShadowFilterId_ = this.createDropShadowDom_(defs);
   this.dragGroup_.setAttribute(
       'filter', 'url(#' + this.dragShadowFilterId_ + ')');
+};
+
+/**
+ * Set the distance to offset the dragged SVG.
+ * @param {number} left
+ * @param {number} top
+ */
+Blockly.BlockDragSurfaceSvg.prototype.setOffset = function(left, top) {
+  this.SVG_.style.marginLeft = left + 'px';
+  this.SVG_.style.marginTop = top + 'px';
 };
 
 /**
@@ -183,7 +195,7 @@ Blockly.BlockDragSurfaceSvg.prototype.setBlocksAndShow = function(blocks) {
       this.dragGroup_.childNodes.length == 0, 'Already dragging a block.');
   // appendChild removes the blocks from the previous parent
   this.dragGroup_.appendChild(blocks);
-  this.SVG_.style.display = 'block';
+  this.wrapper_.style.display = 'block';
   this.surfaceXY_ = new goog.math.Coordinate(0, 0);
   // This allows blocks to be dragged outside of the blockly svg space.
   // This should be reset to hidden at the end of the block drag.
@@ -221,7 +233,7 @@ Blockly.BlockDragSurfaceSvg.prototype.translateSurfaceInternal_ = function() {
   // fuzzy while they are being dragged on the drag surface.
   x = x.toFixed(0);
   y = y.toFixed(0);
-  this.SVG_.style.display = 'block';
+  this.wrapper_.style.display = 'block';
 
   Blockly.utils.setCssTransform(this.SVG_,
       'translate3d(' + x + 'px, ' + y + 'px, 0px)');
@@ -285,7 +297,7 @@ Blockly.BlockDragSurfaceSvg.prototype.clearAndHide = function(opt_newSurface) {
   } else {
     this.dragGroup_.removeChild(this.getCurrentBlock());
   }
-  this.SVG_.style.display = 'none';
+  this.wrapper_.style.display = 'none';
   goog.asserts.assert(
       this.dragGroup_.childNodes.length == 0, 'Drag group was not cleared.');
   this.surfaceXY_ = null;

--- a/core/block_drag_surface.js
+++ b/core/block_drag_surface.js
@@ -113,7 +113,7 @@ Blockly.BlockDragSurfaceSvg.prototype.createDom = function() {
     return;  // Already created.
   }
   this.wrapper_ = goog.dom.createDom('div', 'blocklyDragSurfaceWrapper');
-  document.body.appendChild(this.wrapper_);
+  this.container_.appendChild(this.wrapper_);
   this.SVG_ = Blockly.utils.createSvgElement('svg',
       {
         'xmlns': Blockly.SVG_NS,

--- a/core/block_drag_surface.js
+++ b/core/block_drag_surface.js
@@ -197,12 +197,6 @@ Blockly.BlockDragSurfaceSvg.prototype.setBlocksAndShow = function(blocks) {
   this.dragGroup_.appendChild(blocks);
   this.wrapper_.style.display = 'block';
   this.surfaceXY_ = new goog.math.Coordinate(0, 0);
-  // This allows blocks to be dragged outside of the blockly svg space.
-  // This should be reset to hidden at the end of the block drag.
-  // Note that this behavior is different from blockly where block disappear
-  // "under" the blockly area.
-  var injectionDiv = document.getElementsByClassName('injectionDiv')[0];
-  injectionDiv.style.overflow = 'visible';
 };
 
 /**
@@ -301,11 +295,4 @@ Blockly.BlockDragSurfaceSvg.prototype.clearAndHide = function(opt_newSurface) {
   goog.asserts.assert(
       this.dragGroup_.childNodes.length == 0, 'Drag group was not cleared.');
   this.surfaceXY_ = null;
-
-  // Reset the overflow property back to hidden so that nothing appears outside
-  // of the blockly area.
-  // Note that this behavior is different from blockly. See note in
-  // setBlocksAndShow.
-  var injectionDiv = document.getElementsByClassName('injectionDiv')[0];
-  injectionDiv.style.overflow = 'hidden';
 };

--- a/core/block_drag_surface.js
+++ b/core/block_drag_surface.js
@@ -131,9 +131,9 @@ Blockly.BlockDragSurfaceSvg.prototype.createDom = function() {
 };
 
 /**
- * Set the distance to offset the dragged SVG.
- * @param {number} left
- * @param {number} top
+ * Set the distance to offset the dragged SVG (in pixels).
+ * @param {number} left - Left offset.
+ * @param {number} top - Y offset.
  */
 Blockly.BlockDragSurfaceSvg.prototype.setOffset = function(left, top) {
   this.SVG_.style.marginLeft = left + 'px';

--- a/core/block_dragger.js
+++ b/core/block_dragger.js
@@ -162,6 +162,9 @@ Blockly.BlockDragger.prototype.startBlockDrag = function(currentDragDeltaXY) {
     Blockly.Events.setGroup(true);
   }
 
+  var svgRect = this.workspace_.getParentSvg().getBoundingClientRect();
+  this.workspace_.getBlockDragSurface().setOffset(svgRect.x, svgRect.y);
+
   this.workspace_.setResizesEnabled(false);
   Blockly.BlockAnimations.disconnectUiStop();
 

--- a/core/bubble_dragger.js
+++ b/core/bubble_dragger.js
@@ -112,6 +112,9 @@ Blockly.BubbleDragger.prototype.startBubbleDrag = function() {
     Blockly.Events.setGroup(true);
   }
 
+  var svgRect = this.workspace_.getParentSvg().getBoundingClientRect();
+  this.workspace_.getBlockDragSurface().setOffset(svgRect.x, svgRect.y);
+
   this.workspace_.setResizesEnabled(false);
   this.draggingBubble_.setAutoLayout(false);
   if (this.dragSurface_) {

--- a/core/css.js
+++ b/core/css.js
@@ -212,6 +212,7 @@ Blockly.Css.CONTENT = [
 
   '.blocklyDragSurfaceWrapper {',
     'display: none;',
+    'pointer-events: none;',
     'position: fixed;',
     'top: 0;',
     'left: 0;',

--- a/core/css.js
+++ b/core/css.js
@@ -210,15 +210,25 @@ Blockly.Css.CONTENT = [
     'overflow: visible;',
   '}',
 
-  '.blocklyBlockDragSurface {',
+  '.blocklyDragSurfaceWrapper {',
     'display: none;',
+    'position: fixed;',
+    'top: 0;',
+    'left: 0;',
+    'width: 100%;',
+    'height: 100%;',
+    'overflow: hidden !important;',
+    'z-index: 50;', /* Display above the toolbox */
+  '}',
+
+  '.blocklyBlockDragSurface {',
+    'display: block;',
     'position: absolute;',
     'top: 0;',
     'left: 0;',
     'right: 0;',
     'bottom: 0;',
     'overflow: visible !important;',
-    'z-index: 50;', /* Display above the toolbox */
   '}',
 
   '.blocklyTooltipDiv {',


### PR DESCRIPTION
### Resolves

I don't think it's filed, but this fixes an issue with blocks that is the same in principle as LLK/scratch-gui#1791; particularly, fixes the scrollbar showing up when you drag a block past the edge of the screen. Also fixes LLK/scratch-gui#953 (since toggling overflow is no longer necessary).

Also is support for upcoming LLK/scratch-gui#4530.

While I can't be certain, I'm hoping this fixes or helps towards #1855 as well.

### Proposed Changes

Wraps the drag surface in a wrapper element that covers the whole screen and is marked as `overflow: hidden`. (This is the same technique as in LLK/scratch-gui#4527: If an element is outside of the screen, it will be cut off, and will not cause a scrollbar to show up.)

Since the SVG which follows the mouse as it is dragged is now positioned relative to this fixed element rather than the workspace, we use margin CSS properties to offset the element to the original position.

Note we don't need to place the element on the document body (as I originally thought we might, mentioned in https://github.com/LLK/scratch-gui/issues/1792#issuecomment-452839712); the `position: fixed` CSS makes the wrapper already effectively ignore whatever hierarchy it's in.

### Reason for Changes

To improve block dragging behavior in general.

### Test Coverage

Tested manually in a variety of cases:

* Blocks follow the mouse as it is dragged properly (and are dropped in the place they are visually dragged over, just as expected).
  * Even if the workspace is scaled (zoom buttons).
  * Even if the entire page is zoomed (browser zoom).
* Z-indexing is unchanged; dragged blocks are still positioned over the flyout.

Also tested inside of scratch-gui, where everything performs as expected.