### PR TITLE
Fix build

### DIFF
--- a/blocks_vertical/procedures.js
+++ b/blocks_vertical/procedures.js
@@ -28,10 +28,7 @@ goog.provide('Blockly.ScratchBlocks.ProcedureUtils');
 goog.require('Blockly.Blocks');
 goog.require('Blockly.Colours');
 goog.require('Blockly.constants');
-goog.require('Blockly.Msg');
 goog.require('Blockly.ScratchBlocks.VerticalExtensions');
-goog.require('Blockly.utils');
-goog.require('Blockly.WidgetDiv');
 
 // Serialization and deserialization.
 

--- a/blocks_vertical/procedures.js
+++ b/blocks_vertical/procedures.js
@@ -23,14 +23,15 @@
  */
 'use strict';
 
-goog.provide('Blockly.Blocks.procedures');
+goog.provide('Blockly.ScratchBlocks.ProcedureUtils');
 
 goog.require('Blockly.Blocks');
+goog.require('Blockly.Colours');
 goog.require('Blockly.constants');
-
-
-// TODO: Create a namespace properly.
-Blockly.ScratchBlocks.ProcedureUtils = {};
+goog.require('Blockly.Msg');
+goog.require('Blockly.ScratchBlocks.VerticalExtensions');
+goog.require('Blockly.utils');
+goog.require('Blockly.WidgetDiv');
 
 // Serialization and deserialization.
 

--- a/build.py
+++ b/build.py
@@ -272,6 +272,10 @@ class Gen_compressed(threading.Thread):
     elif block_type == "common":
       target_filename = "blocks_compressed.js"
       filenames = glob.glob(os.path.join("blocks_common", "*.js"))
+
+    # glob.glob ordering is platform-dependent and not necessary deterministic
+    filenames.sort()  # Deterministic build.
+
     # Define the parameters for the POST request.
     params = [
       ("compilation_level", "SIMPLE"),
@@ -283,6 +287,7 @@ class Gen_compressed(threading.Thread):
     # Add Blockly.Colours for use of centralized colour bank
     filenames.append(os.path.join("core", "colours.js"))
     filenames.append(os.path.join("core", "constants.js"))
+    
     for filename in filenames:
       # Append filenames as false arguments the step before compiling will
       # either transform them into arguments for local or remote compilation


### PR DESCRIPTION
### Resolves

#1409 

### Proposed Changes

It sorts the filenames generated by `glob.glob` for a deterministic build—the order is platform-dependent and not guaranteed to be sorted.

Also, it attempts to correctly create namespaces and dependencies in `blocks_vertical/procedures.js`.

### Reason for Changes

@StephenPCG's [investigation](https://github.com/LLK/scratch-blocks/issues/1409#issue-306212950) determined that these issues result in failed CI builds.

### Test Coverage

I haven't added test coverage, but I'm happy to do try with some help and guidance.