### PR TITLE
Tell external callback if procedure definition dialog is for editing

### DIFF
--- a/core/procedures.js
+++ b/core/procedures.js
@@ -392,6 +392,7 @@ Blockly.Procedures.newProcedureMutation = function() {
 Blockly.Procedures.createProcedureDefCallback_ = function(workspace) {
   Blockly.Procedures.externalProcedureDefCallback(
       Blockly.Procedures.newProcedureMutation(),
+      false, // Not an edit.
       Blockly.Procedures.createProcedureCallbackFactory_(workspace)
   );
 };
@@ -470,6 +471,7 @@ Blockly.Procedures.editProcedureCallback_ = function(block) {
   // Block now refers to the procedure prototype block, it is safe to proceed.
   Blockly.Procedures.externalProcedureDefCallback(
       block.mutationToDom(),
+      true, // Is an edit.
       Blockly.Procedures.editProcedureCallbackFactory_(block)
   );
 };
@@ -493,7 +495,7 @@ Blockly.Procedures.editProcedureCallbackFactory_ = function(block) {
  * Callback to create a new procedure custom command block.
  * @public
  */
-Blockly.Procedures.externalProcedureDefCallback = function(/** mutator, callback */) {
+Blockly.Procedures.externalProcedureDefCallback = function(/** mutator, isEdit, callback */) {
   alert('External procedure editor must be override Blockly.Procedures.externalProcedureDefCallback');
 };
 


### PR DESCRIPTION
### Resolves

Towards #1856. Should be merged before LLK/scratch-gui#4572.

### Proposed Changes

Adds a new `isEdit` argument (between `mutator` and `callback`) to `Blockly.Procedures.externalProcedureDefCallback` that tells whether or not the call came from editing an existing procedure.

### Reason for Changes

Support to fix the above bug! This could also let the "Make a Block" dialog display more relevant text, like "Edit Block".

### Test Coverage

Tested manually (as part of LLK/scratch-gui#4572).