### PR TITLE
Remove 'To JavaScript' button

### DIFF
--- a/tests/vertical_playground.html
+++ b/tests/vertical_playground.html
@@ -136,12 +136,6 @@
         taChange();
       }
 
-      function toCode(lang) {
-        var output = document.getElementById('importExport');
-        output.value = Blockly[lang].workspaceToCode(workspace);
-        taChange();
-      }
-
       // Disable the "Import from XML" button if the XML is invalid.
       // Preserve text between page reloads.
       function taChange() {
@@ -538,8 +532,6 @@
       <input type="button" value="Export to XML" onclick="toXml()">
       &nbsp;
       <input type="button" value="Import from XML" onclick="fromXml()" id="import">
-      <br>
-      <input type="button" value="To JavaScript" onclick="toCode('JavaScript')">
       <br>
       <textarea id="importExport" style="width: 26%; height: 12em"
         onchange="taChange();" onkeyup="taChange()"></textarea>


### PR DESCRIPTION
### Resolves

Resolves #1893

### Proposed Changes

Removes the "To JavaScript" button and the "toCode" function it triggered

### Reason for Changes

To resolve a help-wanted issue.
> Because generators were removed from `scratch-blocks` this button should also be removed.

### Test Coverage

This is the removal of a test.