### PR TITLE
Accept validator function when making a dropdown field via .fromJson

### DIFF
--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -64,13 +64,14 @@ goog.inherits(Blockly.FieldDropdown, Blockly.Field);
 
 /**
  * Construct a FieldDropdown from a JSON arg object.
- * @param {!Object} element A JSON object with options.
+ * @param {!Object} element A JSON object with options and, optionally,
+ *     a validator function.
  * @returns {!Blockly.FieldDropdown} The new field instance.
  * @package
  * @nocollapse
  */
 Blockly.FieldDropdown.fromJson = function(element) {
-  return new Blockly.FieldDropdown(element['options']);
+  return new Blockly.FieldDropdown(element['options'], element['validator']);
 };
 
 /**


### PR DESCRIPTION
### Resolves

Towards LLK/scratch-gui#4400 - this is supporting code for LLK/scratch-gui#4613 and should be merged before it!

### Proposed Changes

This PR adds makes it so that `FieldDropdown.fromJson` can take a validator function and pass it to the `FieldDropdown` constructor. In practice, that means you can add `"validator": function() { ... }` to a block's `jsonInit` function:

```
this.jsonInit({
  message0: `%1`,
  args0: [
    {
      type: 'field_dropdown',
      name: ...,
      options: ...,
      validator: function() { ... }
    }
  ]
});
```

### Reason for Changes

Support for LLK/scratch-gui#4613! This is also a generally useful tweak, but I didn't adjust the rest of the fields to also take validator functions. That can be done if wanted, but right now there's no PR that requires it.

### Test Coverage

Tested manually. Dropdowns still work, and validators function are passed through properly!