### PR TITLE
Update data_category.js

### DIFF
--- a/core/data_category.js
+++ b/core/data_category.js
@@ -427,7 +427,7 @@ Blockly.DataCategory.addBlock = function(xmlList, variable, blockType,
     }
     if (opt_secondValue) {
       secondValueField = Blockly.DataCategory.createValue(opt_secondValue[0],
-          opt_secondValue[1], opt_value[2]);
+          opt_secondValue[1], opt_secondValue[2]);
     }
 
     var gap = 8;


### PR DESCRIPTION
Blockly.DataCategory.addBlock function could not properly add opt_secondValue

### Resolves

Blockly.DataCategory.addBlock repair

### Proposed Changes

function variable change

### Reason for Changes

properly add block

### Test Coverage

change opt_value to opt_secondValue
