### PR TITLE
Use opt_secondValue in addBlock as expected

### DIFF
--- a/core/data_category.js
+++ b/core/data_category.js
@@ -427,7 +427,7 @@ Blockly.DataCategory.addBlock = function(xmlList, variable, blockType,
     }
     if (opt_secondValue) {
       secondValueField = Blockly.DataCategory.createValue(opt_secondValue[0],
-          opt_secondValue[1], opt_value[2]);
+          opt_secondValue[1], opt_secondValue[2]);
     }
 
     var gap = 8;


### PR DESCRIPTION
### Resolves

Closes #1927.

### Proposed Changes

Use the parameter `opt_secondValue` instead of `opt_value` where appropriate.

### Reason for Changes

`opt_secondValue[2]` was not used at all in the code, which lead to behaviour seen in #1927.

### Test Coverage

No tests were added, no existing tests were broken.
