### PR TITLE
Sort list variables in context menu

### DIFF
--- a/blocks_vertical/data.js
+++ b/blocks_vertical/data.js
@@ -527,6 +527,7 @@ Blockly.Constants.Data.CUSTOM_CONTEXT_MENU_GET_VARIABLE_MIXIN = {
       for (var i = 0; i < variablesList.length; i++) {
         var varName = variablesList[i].name;
         if (varName == currentVarName) continue;
+
         var option = {enabled: true};
         option.text = varName;
 
@@ -579,6 +580,9 @@ Blockly.Constants.Data.CUSTOM_CONTEXT_MENU_GET_LIST_MIXIN = {
     var currentVarName = this.getField(fieldName).text_;
     if (!this.isInFlyout) {
       var variablesList = this.workspace.getVariablesOfType('list');
+      variablesList.sort(function(a, b) {
+        return Blockly.scratchBlocksUtils.compareStrings(a.name, b.name);
+      });
       for (var i = 0; i < variablesList.length; i++) {
         var varName = variablesList[i].name;
         if (varName == currentVarName) continue;


### PR DESCRIPTION
### Resolves

No issue, but it'd be corresponding to #1879.

### Proposed Changes

This is the exact same PR as #1888 from a couple months ago but for lists now. It sorts the variable (list) options in the list right-click menu.

### Reason for Changes

Consistency with other menus in Scratch 3.0.

### Test Coverage

Tested manually (created lists "a, z, b", dragged out an "a" block, then right-clicked it - on develop it shows "z, b", on this PR it shows "b, z" correctly).
