### PR TITLE
Return correct values for isNameUsed function

### DIFF
--- a/core/procedures.js
+++ b/core/procedures.js
@@ -181,11 +181,11 @@ Blockly.Procedures.isNameUsed = function(name, workspace, opt_exclude) {
     if (blocks[i].getProcedureDef) {
       var procName = blocks[i].getProcedureDef();
       if (Blockly.Names.equals(procName[0], name)) {
-        return false;
+        return true;
       }
     }
   }
-  return true;
+  return false;
 };
 
 /**


### PR DESCRIPTION
### Resolves

No related Github issue, but it fixes `Blockly.Procedures.isNamedUsed` returning an incorrect value. Fix was already added to Blockly by @marisaleung 
- https://github.com/google/blockly/commit/234c53157f676978ab9de232ed28305720443003#diff-14d8bd917c33ff9fb0dfee355a789189

### Proposed Changes

Changes the value returned when checking if a procedure name already exists. Currently the function returns `false` when `Blockly.Names.equals(procName[0], name)`, however, it should return `true`. This proposed change updates those values.

### Reason for Changes

If left unchanged, the `isNameUsed` function creates an infinite loop if a procedure name already exists. 
