### PR TITLE
Handle promise rejection for sound.play() in preload

### DIFF
--- a/core/workspace_audio.js
+++ b/core/workspace_audio.js
@@ -112,7 +112,7 @@ Blockly.WorkspaceAudio.prototype.preload = function() {
   for (var name in this.SOUNDS_) {
     var sound = this.SOUNDS_[name];
     sound.volume = 0.01;
-    sound.play();
+    sound.play().catch(function() {});
     sound.pause();
     // iOS can only process one sound at a time.  Trying to load more than one
     // corrupts the earlier ones.  Just load one and leave the others uncached.

--- a/core/workspace_audio.js
+++ b/core/workspace_audio.js
@@ -115,7 +115,7 @@ Blockly.WorkspaceAudio.prototype.preload = function() {
     // If we don't wait for the play request to complete before calling pause() we will get an exception:
     // Uncaught (in promise) DOMException: The play() request was interrupted by a call to pause().
     // See more: https://developers.google.com/web/updates/2017/06/play-request-was-interrupted
-    sound.play().then(sound.pause).catch(() => {
+    sound.play().then(sound.pause).catch(function() {
       // Play without user interaction was prevented.
     });
     // iOS can only process one sound at a time.  Trying to load more than one

--- a/core/workspace_audio.js
+++ b/core/workspace_audio.js
@@ -112,8 +112,12 @@ Blockly.WorkspaceAudio.prototype.preload = function() {
   for (var name in this.SOUNDS_) {
     var sound = this.SOUNDS_[name];
     sound.volume = 0.01;
-    sound.play().catch(function() {});
-    sound.pause();
+    // If we don't wait for the play request to complete before calling pause() we will get an exception:
+    // Uncaught (in promise) DOMException: The play() request was interrupted by a call to pause().
+    // See more: https://developers.google.com/web/updates/2017/06/play-request-was-interrupted
+    sound.play().then(sound.pause).catch(() => {
+      // Play without user interaction was prevented.
+    });
     // iOS can only process one sound at a time.  Trying to load more than one
     // corrupts the earlier ones.  Just load one and leave the others uncached.
     if (goog.userAgent.IPAD || goog.userAgent.IPHONE) {


### PR DESCRIPTION
### Resolves

audio play() called before user interaction [Blockly fix](https://github.com/google/blockly/pull/2162)

### Proposed Changes

Handle promise rejection for sound.play() in preload. 

### Reason for Changes

This removes the error, "play() failed because the user didn't interact with the document first."

### Test Coverage

None
