### PR TITLE
Fix style matching in Firefox 67 (port from Blockly)

### DIFF
--- a/core/utils.js
+++ b/core/utils.js
@@ -182,11 +182,7 @@ Blockly.utils.getRelativeXY = function(element) {
   // Then check for style = transform: translate(...) or translate3d(...)
   var style = element.getAttribute('style');
   if (style && style.indexOf('translate') > -1) {
-    var styleComponents = style.match(Blockly.utils.getRelativeXY.XY_2D_REGEX_);
-    // Try transform3d if 2d transform wasn't there.
-    if (!styleComponents) {
-      styleComponents = style.match(Blockly.utils.getRelativeXY.XY_3D_REGEX_);
-    }
+    var styleComponents = style.match(Blockly.utils.getRelativeXY.XY_STYLE_REGEX_);
     if (styleComponents) {
       xy.x += parseFloat(styleComponents[1]);
       if (styleComponents[3]) {
@@ -251,7 +247,7 @@ Blockly.utils.getScale_ = function(element) {
  * @private
  */
 Blockly.utils.getRelativeXY.XY_REGEX_ =
-    /translate\(\s*([-+\d.e]+)([ ,]\s*([-+\d.e]+)\s*\))?/;
+    /translate\(\s*([-+\d.e]+)([ ,]\s*([-+\d.e]+)\s*)?/;
 
 
 /**
@@ -263,22 +259,14 @@ Blockly.utils.getRelativeXY.XY_REGEX_ =
 Blockly.utils.getScale_REGEXP_ = /scale\(\s*([-+\d.e]+)\s*\)/;
 
 /**
- * Static regex to pull the x,y,z values out of a translate3d() style property.
+ * Static regex to pull the x,y values out of a translate3d() or translate3d()
+ * style property.
  * Accounts for same exceptions as XY_REGEXP_.
  * @type {!RegExp}
  * @private
  */
-Blockly.utils.getRelativeXY.XY_3D_REGEX_ =
-    /transform:\s*translate3d\(\s*([-+\d.e]+)px([ ,]\s*([-+\d.e]+)\s*)px([ ,]\s*([-+\d.e]+)\s*)px\)?/;
-
-/**
- * Static regex to pull the x,y,z values out of a translate3d() style property.
- * Accounts for same exceptions as XY_REGEXP_.
- * @type {!RegExp}
- * @private
- */
-Blockly.utils.getRelativeXY.XY_2D_REGEX_ =
-    /transform:\s*translate\(\s*([-+\d.e]+)px([ ,]\s*([-+\d.e]+)\s*)px\)?/;
+Blockly.utils.getRelativeXY.XY_STYLE_REGEX_ =
+    /transform:\s*translate(?:3d)?\(\s*([-+\d.e]+)\s*px([ ,]\s*([-+\d.e]+)\s*px)?/;
 
 /**
  * Helper method for creating SVG elements.


### PR DESCRIPTION
### Resolves

Fixes #1915 and fixes #1943.

### Proposed Changes

This PR is ported from google/blockly#2485. The description from that PR:

>Chrome returns ‘transform: translate(107px, 0px);’ whereas Firefox now
>returns ‘transform: translate(107px);’ if the y value is 0.  This is
>consistent with existing behaviour in the translate SVG attribute.
>
>The comment in our code specifically states:
>`// Accounts for same exceptions as XY_REGEX_`
>Yet that was not true at all.
>
>This PR makes the y argument optional (as falsely described in the
>comment).  It also merges the 2D and 3D regeps together to simplify the
>code.

### Reason for Changes

Fixes blocks being dragged from the flyout getting offset in Firefox 67+ (now the current release).

### Test Coverage

Tested manually on Firefox 68.0b3 and Chromium 68.0.3440.75. Works correctly in both browsers.

/cc @rachel-fenichel @NeilFraser