### PR TITLE
ENA-189 Add "go to definition" menu option so it's easy to find your custom blocks/procedures

### DIFF
--- a/blocks_vertical/vertical_extensions.js
+++ b/blocks_vertical/vertical_extensions.js
@@ -202,13 +202,13 @@ Blockly.ScratchBlocks.VerticalExtensions.PROCEDURE_DEF_CONTEXTMENU = {
  */
 Blockly.ScratchBlocks.VerticalExtensions.PROCEDURE_CALL_CONTEXTMENU = {
   /**
-   * Add the "edit" option to the context menu.
-   * @todo Add "go to definition" option once implemented.
+   * Add the "edit" and "go to definition" options to the context menu.
    * @param {!Array.<!Object>} menuOptions List of menu options to edit.
    * @this Blockly.Block
    */
   customContextMenu: function(menuOptions) {
     menuOptions.push(Blockly.Procedures.makeEditOption(this));
+    menuOptions.push(Blockly.Procedures.makeShowDefinitionOption(this));
   }
 };
 

--- a/core/procedures.js
+++ b/core/procedures.js
@@ -519,13 +519,15 @@ Blockly.Procedures.makeEditOption = function(block) {
 /**
  * Callback to show the procedure definition corresponding to a custom command
  * block.
- * TODO(#1136): Implement.
  * @param {!Blockly.Block} block The block that was right-clicked.
  * @private
  */
 Blockly.Procedures.showProcedureDefCallback_ = function(block) {
-  alert('TODO(#1136): implement showing procedure definition (procCode was "' +
-      block.procCode_ + '")');
+  var def = Blockly.Procedures.getDefineBlock(block.getProcCode(), block.workspace);
+  if (def) {
+    block.workspace.centerOnBlock(def.id);
+    def.select();
+  }
 };
 
 /**

--- a/core/procedures.js
+++ b/core/procedures.js
@@ -526,10 +526,10 @@ Blockly.Procedures.showProcedureDefCallback_ = function(block) {
   // If block clicked is in the toolbox, its definition will be in
   // block.workspace.targetWorkspace. Otherwise, it will be in block.workspace.
   var workspace = block.workspace.targetWorkspace || block.workspace;
-  var def = Blockly.Procedures.getDefineBlock(block.getProcCode(), workspace);
-  if (def) {
-    workspace.centerOnBlock(def.id);
-    def.select();
+  var proto = Blockly.Procedures.getPrototypeBlock(block.getProcCode(), workspace);
+  if (proto) {
+    workspace.centerOnBlock(proto.id);
+    proto.select();
   }
 };
 

--- a/core/procedures.js
+++ b/core/procedures.js
@@ -523,9 +523,12 @@ Blockly.Procedures.makeEditOption = function(block) {
  * @private
  */
 Blockly.Procedures.showProcedureDefCallback_ = function(block) {
-  var def = Blockly.Procedures.getDefineBlock(block.getProcCode(), block.workspace);
+  // If block clicked is in the toolbox, its definition will be in
+  // block.workspace.targetWorkspace. Otherwise, it will be in block.workspace.
+  var workspace = block.workspace.targetWorkspace || block.workspace;
+  var def = Blockly.Procedures.getDefineBlock(block.getProcCode(), workspace);
   if (def) {
-    block.workspace.centerOnBlock(def.id);
+    workspace.centerOnBlock(def.id);
     def.select();
   }
 };


### PR DESCRIPTION
### Resolves

Resolves #1136.

### Proposed Changes

This PR is based off of @epicfaace's changes in #1834. It adds a "go to definition" menu option to custom procedure callers, which now makes the workspace viewport center on the prototype (top) of the custom block.

![Screenshot summarizing the new feature: the context menu with the new option highlighted, opened on the caller block in the palette, and the result of clicking it, the viewport centered on the prototype block of the custom procedure.](https://user-images.githubusercontent.com/9948030/59278102-c94f0600-8c37-11e9-86be-e636e112f8ce.png)

### Reason for Changes

The "go to definition" feature is much requested, and was part of Scratch 2.0 (where the block was called "define").

This particular PR contains the additional change of centering on the block's prototype instead of the entire script (its "definition"). However, I'm not 110% sure this is the best behavior. I feel it would be better if, when the entire script *can* be fit inside the workspace, the full script would be centered upon. When it *can't* fit, the top of the workspace (with some padding) would be aligned with the top of the custom block (the prototype), so as to show as much of the script as possible. (We'd want to take care to do the same check for the X-axis, so that custom blocks with very wide blocks don't have their start-end cut off. Worth being sure of LTR/RTL support here!)

### Test Coverage

Only manual testing on both Firefox and Chromium, on project ID `316338651` (unshared) and [Bubble Scratch v0.9](https://scratch.mit.edu/projects/222972802).

(/cc @picklesrus since you reviewed the original PR by @epicfaace!)