### PR TITLE
Allow selecting the last two piano keys

### DIFF
--- a/core/field_note.js
+++ b/core/field_note.js
@@ -309,7 +309,7 @@ Blockly.FieldNote.KEY_INFO = [
  * @type {number}
  * @const
  */
-Blockly.FieldNote.MAX_NOTE = 130;
+Blockly.FieldNote.MAX_NOTE = 132;
 
 /**
  * The fraction of the distance to the target location to move the piano at each


### PR DESCRIPTION
### Proposed Changes

Currently, the last two piano keys in the `note_field` type are not selectable. This PR changes the max note for the field validation, so that you can select the last two piano keys.

### Reason for Changes

Either the last two blocks should be selectable or the last octave should be removed (IMO :))
