### PR TITLE
Fix broken image for numpad delete button

### DIFF
--- a/core/colours.js
+++ b/core/colours.js
@@ -108,7 +108,7 @@ Blockly.Colours = {
   "numPadBackground": "#547AB2",
   "numPadBorder": "#435F91",
   "numPadActiveBackground": "#435F91",
-  "numPadText": "#FFFFFF",
+  "numPadText": "white", // Do not use hex here, it cannot be inlined with data-uri SVG
   "valueReportBackground": "#FFFFFF",
   "valueReportBorder": "#AAAAAA"
 };


### PR DESCRIPTION
It turns out we are creating a data-uri SVG for the delete button, but are using string interpolation for the color. If you use hex, this breaks the image on Chrome (but not Safari). Using a standard css color keyword (alternatively using RGB) fix the issue.

### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-blocks/issues/1955

This can be tested by force-enabling the numpad and trying number inputs in the vertical playground: in field_number.js#168, set showNumPad=true;