### PR TITLE
Update to "Handle promise rejection for sound.play() in preload"

### DIFF
--- a/core/workspace_audio.js
+++ b/core/workspace_audio.js
@@ -112,7 +112,7 @@ Blockly.WorkspaceAudio.prototype.preload = function() {
   for (var name in this.SOUNDS_) {
     var sound = this.SOUNDS_[name];
     sound.volume = 0.01;
-    sound.play();
+    sound.play().catch(function() {});
     sound.pause();
     // iOS can only process one sound at a time.  Trying to load more than one
     // corrupts the earlier ones.  Just load one and leave the others uncached.

--- a/core/workspace_audio.js
+++ b/core/workspace_audio.js
@@ -112,7 +112,6 @@ Blockly.WorkspaceAudio.prototype.preload = function() {
   for (var name in this.SOUNDS_) {
     var sound = this.SOUNDS_[name];
     sound.volume = 0.01;
-
     var playPromise = sound.play();
 
     // Edge does not return a promise, so we need to check.

--- a/core/workspace_audio.js
+++ b/core/workspace_audio.js
@@ -115,7 +115,7 @@ Blockly.WorkspaceAudio.prototype.preload = function() {
     // If we don't wait for the play request to complete before calling pause() we will get an exception:
     // Uncaught (in promise) DOMException: The play() request was interrupted by a call to pause().
     // See more: https://developers.google.com/web/updates/2017/06/play-request-was-interrupted
-    sound.play().then(sound.pause).catch(() => {
+    sound.play().then(sound.pause).catch(function() {
       // Play without user interaction was prevented.
     });
     // iOS can only process one sound at a time.  Trying to load more than one

--- a/core/workspace_audio.js
+++ b/core/workspace_audio.js
@@ -119,7 +119,7 @@ Blockly.WorkspaceAudio.prototype.preload = function() {
       // If we don't wait for the play request to complete before calling pause() we will get an exception:
       // Uncaught (in promise) DOMException: The play() request was interrupted by a call to pause().
       // See more: https://developers.google.com/web/updates/2017/06/play-request-was-interrupted
-        playPromise.then(sound.pause).catch(function() {
+      playPromise.then(sound.pause).catch(function() {
         // Play without user interaction was prevented.
       });
     } else {

--- a/core/workspace_audio.js
+++ b/core/workspace_audio.js
@@ -112,12 +112,21 @@ Blockly.WorkspaceAudio.prototype.preload = function() {
   for (var name in this.SOUNDS_) {
     var sound = this.SOUNDS_[name];
     sound.volume = 0.01;
+
+    var playPromise = sound.play();
+
+    // Edge does not return a promise, so we need to check.
+    if (playPromise) {
     // If we don't wait for the play request to complete before calling pause() we will get an exception:
     // Uncaught (in promise) DOMException: The play() request was interrupted by a call to pause().
     // See more: https://developers.google.com/web/updates/2017/06/play-request-was-interrupted
-    sound.play().then(sound.pause).catch(function() {
+      playPromise.then(sound.pause).catch(function() {
       // Play without user interaction was prevented.
     });
+    } else {
+      sound.pause();
+    }
+
     // iOS can only process one sound at a time.  Trying to load more than one
     // corrupts the earlier ones.  Just load one and leave the others uncached.
     if (goog.userAgent.IPAD || goog.userAgent.IPHONE) {

--- a/core/workspace_audio.js
+++ b/core/workspace_audio.js
@@ -112,8 +112,12 @@ Blockly.WorkspaceAudio.prototype.preload = function() {
   for (var name in this.SOUNDS_) {
     var sound = this.SOUNDS_[name];
     sound.volume = 0.01;
-    sound.play().catch(function() {});
-    sound.pause();
+    // If we don't wait for the play request to complete before calling pause() we will get an exception:
+    // Uncaught (in promise) DOMException: The play() request was interrupted by a call to pause().
+    // See more: https://developers.google.com/web/updates/2017/06/play-request-was-interrupted
+    sound.play().then(sound.pause).catch(() => {
+      // Play without user interaction was prevented.
+    });
     // iOS can only process one sound at a time.  Trying to load more than one
     // corrupts the earlier ones.  Just load one and leave the others uncached.
     if (goog.userAgent.IPAD || goog.userAgent.IPHONE) {

--- a/core/workspace_audio.js
+++ b/core/workspace_audio.js
@@ -116,12 +116,12 @@ Blockly.WorkspaceAudio.prototype.preload = function() {
 
     // Edge does not return a promise, so we need to check.
     if (playPromise) {
-    // If we don't wait for the play request to complete before calling pause() we will get an exception:
-    // Uncaught (in promise) DOMException: The play() request was interrupted by a call to pause().
-    // See more: https://developers.google.com/web/updates/2017/06/play-request-was-interrupted
-      playPromise.then(sound.pause).catch(function() {
-      // Play without user interaction was prevented.
-    });
+      // If we don't wait for the play request to complete before calling pause() we will get an exception:
+      // Uncaught (in promise) DOMException: The play() request was interrupted by a call to pause().
+      // See more: https://developers.google.com/web/updates/2017/06/play-request-was-interrupted
+        playPromise.then(sound.pause).catch(function() {
+        // Play without user interaction was prevented.
+      });
     } else {
       sound.pause();
     }


### PR DESCRIPTION
Since my colleague Michael is on vacation, I added the requested changes to [his pull request](https://github.com/LLK/scratch-blocks/pull/1942).

### Resolves

audio play() called before user interaction [Blockly fix](https://github.com/google/blockly/pull/2162)

### Proposed Changes

Handle promise rejection for sound.play() in preload.

### Reason for Changes

This removes the error, "play() failed because the user didn't interact with the document first."
This is good in itself, but that exception turned out to be the reason for a several seconds delay after the first interaction on iOS.

### Test Coverage

None