### PR TITLE
Fix freeze workspace when delete comments

### DIFF
--- a/core/scratch_bubble.js
+++ b/core/scratch_bubble.js
@@ -354,6 +354,7 @@ Blockly.ScratchBubble.prototype.minimizeArrowMouseUp_ = function(e) {
     }
   }
   e.stopPropagation();
+  Blockly.Touch.clearTouchIdentifier();
 };
 
 /**
@@ -393,6 +394,7 @@ Blockly.ScratchBubble.prototype.deleteMouseUp_ = function(e) {
     }
   }
   e.stopPropagation();
+  Blockly.Touch.clearTouchIdentifier();
 };
 
 /**

--- a/core/workspace_comment_render_svg.js
+++ b/core/workspace_comment_render_svg.js
@@ -337,6 +337,7 @@ Blockly.WorkspaceCommentSvg.prototype.minimizeArrowMouseUp_ = function(e) {
     this.toggleMinimize_();
   }
   e.stopPropagation();
+  Blockly.Touch.clearTouchIdentifier();
 };
 
 /**
@@ -374,6 +375,7 @@ Blockly.WorkspaceCommentSvg.prototype.deleteMouseUp_ = function(e) {
     this.dispose();
   }
   e.stopPropagation();
+  Blockly.Touch.clearTouchIdentifier();
 };
 
 /**


### PR DESCRIPTION
This PR resolves one part of https://github.com/LLK/scratch-blocks/issues/1762, where clicking to delete or minimize a comment on touch would freeze the workspace. 

We were stopping event propagation but not clearing the touch identifier, resulting in a gesture sequence that never terminated.
