### PR TITLE
Allow comment textarea to receive focus on touch devices

### DIFF
--- a/core/workspace_comment_render_svg.js
+++ b/core/workspace_comment_render_svg.js
@@ -187,7 +187,7 @@ Blockly.WorkspaceCommentSvg.prototype.createEditor_ = function() {
   this.textarea_ = textarea;
   this.textarea_.style.margin = (Blockly.WorkspaceCommentSvg.TEXTAREA_OFFSET) + 'px';
   this.foreignObject_.appendChild(body);
-  Blockly.bindEventWithChecks_(textarea, 'mousedown', this, function(e) {
+  Blockly.bindEventWithChecks_(textarea, 'mousedown', this, function() {
     textarea.focus();
   });
   // Don't zoom with mousewheel.

--- a/core/workspace_comment_render_svg.js
+++ b/core/workspace_comment_render_svg.js
@@ -187,6 +187,9 @@ Blockly.WorkspaceCommentSvg.prototype.createEditor_ = function() {
   this.textarea_ = textarea;
   this.textarea_.style.margin = (Blockly.WorkspaceCommentSvg.TEXTAREA_OFFSET) + 'px';
   this.foreignObject_.appendChild(body);
+  Blockly.bindEventWithChecks_(textarea, 'mousedown', this, function(e) {
+    textarea.focus();
+  });
   // Don't zoom with mousewheel.
   Blockly.bindEventWithChecks_(textarea, 'wheel', this, function(e) {
     e.stopPropagation();


### PR DESCRIPTION

### Resolves
(partially)
https://github.com/LLK/scratch-blocks/issues/1762

### Proposed Changes

This PR adds a click/touch event handler that programmatically sets focus on the comment textarea.

### Reason for Changes

Behaviour is broken on touch devices as it is impossible to write comments.

### Test Coverage

I have added no additional tests for this
