### PR TITLE
Move call to focus element outside of the the setTimeout. iOS is pick…

### DIFF
--- a/core/workspace_comment_render_svg.js
+++ b/core/workspace_comment_render_svg.js
@@ -685,7 +685,6 @@ Blockly.WorkspaceCommentSvg.prototype.blurFocus = function() {
   // TODO (github.com/google/blockly/issues/1848): Fix warnings when the comment
   // has already been deleted.
   setTimeout(function() {
-
     comment.removeFocus();
     Blockly.utils.removeClass(
         comment.svgRectTarget_, 'scratchCommentTargetFocused');

--- a/core/workspace_comment_render_svg.js
+++ b/core/workspace_comment_render_svg.js
@@ -662,9 +662,9 @@ Blockly.WorkspaceCommentSvg.prototype.disposeInternal_ = function() {
 Blockly.WorkspaceCommentSvg.prototype.setFocus = function() {
   var comment = this;
   this.focused_ = true;
+  comment.textarea_.focus();
   // Defer CSS changes.
   setTimeout(function() {
-    comment.textarea_.focus();
     comment.addFocus();
     Blockly.utils.addClass(
         comment.svgRectTarget_, 'scratchCommentTargetFocused');
@@ -680,11 +680,12 @@ Blockly.WorkspaceCommentSvg.prototype.setFocus = function() {
 Blockly.WorkspaceCommentSvg.prototype.blurFocus = function() {
   var comment = this;
   this.focused_ = false;
+  comment.textarea_.blur();
   // Defer CSS changes.
   // TODO (github.com/google/blockly/issues/1848): Fix warnings when the comment
   // has already been deleted.
   setTimeout(function() {
-    comment.textarea_.blur();
+
     comment.removeFocus();
     Blockly.utils.removeClass(
         comment.svgRectTarget_, 'scratchCommentTargetFocused');


### PR DESCRIPTION
…y about what things you can do outside of a direct user action and I think focus might be one of them.  With this change comments are now editable on iOS.

### Resolves

Part of https://github.com/LLK/scratch-blocks/issues/1762

### Proposed Changes

On workspace comment click, call focus immediately rather than in a set timeout

### Reason for Changes

The call to focus isn't working on iOS in the setTimeout. I think this is because it is no longer part of the user action/click.
