### PR TITLE
Use quiet inputs/numpad for touch interaction instead of based on user agent

### DIFF
--- a/core/field.js
+++ b/core/field.js
@@ -174,6 +174,14 @@ Blockly.Field.prototype.argType_ = null;
 Blockly.Field.prototype.validator_ = null;
 
 /**
+ * Whether to assume user is using a touch device for interactions.
+ * Used to show different UI for touch interactions, e.g.
+ * @type {boolean}
+ * @private
+ */
+Blockly.Field.prototype.useTouchInteraction_ = false;
+
+/**
  * Non-breaking space.
  * @const
  */
@@ -740,6 +748,7 @@ Blockly.Field.prototype.onMouseDown_ = function(e) {
   if (gesture) {
     gesture.setStartField(this);
   }
+  this.useTouchInteraction_ = Blockly.Touch.getTouchIdentifierFromEvent(event) !== 'mouse';
 };
 
 /**

--- a/core/field_angle.js
+++ b/core/field_angle.js
@@ -168,10 +168,8 @@ Blockly.FieldAngle.prototype.dispose_ = function() {
  * @private
  */
 Blockly.FieldAngle.prototype.showEditor_ = function() {
-  var noFocus =
-      goog.userAgent.MOBILE || goog.userAgent.ANDROID || goog.userAgent.IPAD;
   // Mobile browsers have issues with in-line textareas (focus & keyboards).
-  Blockly.FieldAngle.superClass_.showEditor_.call(this, noFocus);
+  Blockly.FieldAngle.superClass_.showEditor_.call(this, this.useTouchInteraction_);
   // If there is an existing drop-down someone else owns, hide it immediately and clear it.
   Blockly.DropDownDiv.hideWithoutAnimation();
   Blockly.DropDownDiv.clearContent();

--- a/core/field_note.js
+++ b/core/field_note.js
@@ -381,10 +381,8 @@ Blockly.FieldNote.prototype.dispose_ = function() {
  * @private
  */
 Blockly.FieldNote.prototype.showEditor_ = function() {
-  var noFocus =
-      goog.userAgent.MOBILE || goog.userAgent.ANDROID || goog.userAgent.IPAD;
   // Mobile browsers have issues with in-line textareas (focus & keyboards).
-  Blockly.FieldNote.superClass_.showEditor_.call(this, noFocus);
+  Blockly.FieldNote.superClass_.showEditor_.call(this, this.useTouchInteraction_);
 
   // If there is an existing drop-down someone else owns, hide it immediately and clear it.
   Blockly.DropDownDiv.hideWithoutAnimation();

--- a/core/field_number.js
+++ b/core/field_number.js
@@ -165,8 +165,7 @@ Blockly.FieldNumber.prototype.setConstraints_ = function(opt_min, opt_max,
 Blockly.FieldNumber.prototype.showEditor_ = function() {
   Blockly.FieldNumber.activeField_ = this;
   // Do not focus on mobile devices so we can show the num-pad
-  var showNumPad =
-      goog.userAgent.MOBILE || goog.userAgent.ANDROID || goog.userAgent.IPAD;
+  var showNumPad = this.useTouchInteraction_;
   Blockly.FieldNumber.superClass_.showEditor_.call(this, false, showNumPad);
 
   // Show a numeric keypad in the drop-down on touch


### PR DESCRIPTION
Instead of using user agent detection for showing the numpad and deciding whether or not to use quiet inputs, use the original interaction on the field to determine that. The goal is to show the touch ui for anyone interacting via touch, not based on device.

/ht to @picklesrus  for pairing on this