### PR TITLE
Use placeholders instead of default text for comments, fix focusing

### DIFF
--- a/core/contextmenu.js
+++ b/core/contextmenu.js
@@ -292,7 +292,7 @@ Blockly.ContextMenu.blockCommentOption = function(block) {
     // If there's no comment, add an option to create a comment.
     commentOption.text = Blockly.Msg.ADD_COMMENT;
     commentOption.callback = function() {
-      block.setCommentText(Blockly.Msg.WORKSPACE_COMMENT_DEFAULT_TEXT);
+      block.setCommentText('');
     };
   }
   return commentOption;
@@ -468,8 +468,7 @@ Blockly.ContextMenu.workspaceCommentOption = function(ws, e) {
       disabled = true;
     }
     var comment = new Blockly.WorkspaceCommentSvg(
-        ws, Blockly.Msg.WORKSPACE_COMMENT_DEFAULT_TEXT,
-        Blockly.WorkspaceCommentSvg.DEFAULT_SIZE,
+        ws, '', Blockly.WorkspaceCommentSvg.DEFAULT_SIZE,
         Blockly.WorkspaceCommentSvg.DEFAULT_SIZE, false);
 
     var injectionDiv = ws.getInjectionDiv();

--- a/core/contextmenu.js
+++ b/core/contextmenu.js
@@ -293,6 +293,7 @@ Blockly.ContextMenu.blockCommentOption = function(block) {
     commentOption.text = Blockly.Msg.ADD_COMMENT;
     commentOption.callback = function() {
       block.setCommentText('');
+      block.comment.focus();
     };
   }
   return commentOption;

--- a/core/css.js
+++ b/core/css.js
@@ -695,6 +695,11 @@ Blockly.Css.CONTENT = [
     'overflow: hidden;',
   '}',
 
+  '.scratchCommentTextarea::placeholder {',
+    'color: rgba(0,0,0,0.5);',
+    'font-style: italic;',
+  '}',
+
   '.scratchCommentResizeSE {',
     'cursor: se-resize;',
     'fill: transparent;',

--- a/core/scratch_block_comment.js
+++ b/core/scratch_block_comment.js
@@ -244,9 +244,6 @@ Blockly.ScratchBlockComment.prototype.createEditor_ = function() {
       this.text_ = textarea.value;
     }
   });
-  setTimeout(function() {
-    textarea.focus();
-  }, 0);
 
   // Label for comment top bar when comment is minimized
   this.label_ = this.getLabelText();
@@ -636,4 +633,11 @@ Blockly.ScratchBlockComment.prototype.dispose = function() {
   this.block_.comment = null;
   this.workspace.removeTopComment(this);
   Blockly.Icon.prototype.dispose.call(this);
+};
+
+/**
+ * Focus this comments textarea.
+ */
+Blockly.ScratchBlockComment.prototype.focus = function() {
+  this.textarea_.focus();
 };

--- a/core/scratch_block_comment.js
+++ b/core/scratch_block_comment.js
@@ -227,6 +227,7 @@ Blockly.ScratchBlockComment.prototype.createEditor_ = function() {
   textarea.className = 'scratchCommentTextarea scratchCommentText';
   textarea.setAttribute('dir', this.block_.RTL ? 'RTL' : 'LTR');
   textarea.setAttribute('maxlength', Blockly.ScratchBlockComment.COMMENT_TEXT_LIMIT);
+  textarea.setAttribute('placeholder', Blockly.Msg.WORKSPACE_COMMENT_DEFAULT_TEXT);
   body.appendChild(textarea);
   this.textarea_ = textarea;
   this.textarea_.style.margin = (Blockly.ScratchBlockComment.TEXTAREA_OFFSET) + 'px';

--- a/core/workspace_comment_render_svg.js
+++ b/core/workspace_comment_render_svg.js
@@ -183,6 +183,7 @@ Blockly.WorkspaceCommentSvg.prototype.createEditor_ = function() {
   textarea.className = 'scratchCommentTextarea scratchCommentText';
   textarea.setAttribute('dir', this.RTL ? 'RTL' : 'LTR');
   textarea.setAttribute('maxlength', Blockly.WorkspaceComment.COMMENT_TEXT_LIMIT);
+  textarea.setAttribute('placeholder', Blockly.Msg.WORKSPACE_COMMENT_DEFAULT_TEXT);
   body.appendChild(textarea);
   this.textarea_ = textarea;
   this.textarea_.style.margin = (Blockly.WorkspaceCommentSvg.TEXTAREA_OFFSET) + 'px';


### PR DESCRIPTION
After chatting with @carljbowman, we figured the best behavior w/r/t creating and focusing comments is to use the `placeholder` property for the "say something..." instructions, and to fix block comment focus so they can be focused when created from the contextmenu callback.

Just want to check though, @rachel-fenichel @picklesrus @kchadha was there a reason we went with a default value instead of a placeholder originally?

In addition to fixing the placeholder issue, it also fixes focusing after creation, which does not work on iOS because the element is not attached to the dom during `createEditor`, so we cannot remove the setTimeout to get focus to work. It needs to be called after createEditor is done, with workspace comments this is done explicitly in the contextmenu code, so i followed that pattern.

If you want these as two separate PRs, i can do that.

By moving focus out of `createEditor` and explicitly calling it in the context menu code, this also fixes https://github.com/LLK/scratch-blocks/issues/1601