### PR TITLE
More touchable comments, and a few RTL bugfixes

### DIFF
--- a/core/scratch_bubble.js
+++ b/core/scratch_bubble.js
@@ -257,8 +257,7 @@ Blockly.ScratchBubble.prototype.createTopBarIcons_ = function() {
         'x': xInset,
         'y': topBarMiddleY - Blockly.ScratchBubble.MINIMIZE_ICON_SIZE / 2,
         'width': Blockly.ScratchBubble.MINIMIZE_ICON_SIZE,
-        'height': Blockly.ScratchBubble.MINIMIZE_ICON_SIZE,
-        'style' : 'cursor: pointer;'
+        'height': Blockly.ScratchBubble.MINIMIZE_ICON_SIZE
       }, this.bubbleGroup_);
 
   // Delete Icon in Comment Top Bar
@@ -267,8 +266,7 @@ Blockly.ScratchBubble.prototype.createTopBarIcons_ = function() {
         'x': xInset,
         'y': topBarMiddleY - Blockly.ScratchBubble.DELETE_ICON_SIZE / 2,
         'width': Blockly.ScratchBubble.DELETE_ICON_SIZE,
-        'height': Blockly.ScratchBubble.DELETE_ICON_SIZE,
-        'style' : 'cursor: pointer;'
+        'height': Blockly.ScratchBubble.DELETE_ICON_SIZE
       }, this.bubbleGroup_);
   this.deleteIcon_.setAttributeNS('http://www.w3.org/1999/xlink',
       'xlink:href', Blockly.mainWorkspace.options.pathToMedia + 'delete-x.svg');

--- a/core/scratch_bubble.js
+++ b/core/scratch_bubble.js
@@ -138,19 +138,19 @@ Blockly.ScratchBubble.TOP_BAR_HEIGHT = 32;
  * The size of the minimize arrow icon in the comment top bar.
  * @private
  */
-Blockly.ScratchBubble.MINIMIZE_ICON_SIZE = 16;
+Blockly.ScratchBubble.MINIMIZE_ICON_SIZE = 32;
 
 /**
  * The size of the delete icon in the comment top bar.
  * @private
  */
-Blockly.ScratchBubble.DELETE_ICON_SIZE = 12;
+Blockly.ScratchBubble.DELETE_ICON_SIZE = 32;
 
 /**
  * The inset for the top bar icons.
  * @private
  */
-Blockly.ScratchBubble.TOP_BAR_ICON_INSET = 6;
+Blockly.ScratchBubble.TOP_BAR_ICON_INSET = 0;
 
 /**
  * Create the bubble's DOM.

--- a/core/scratch_bubble.js
+++ b/core/scratch_bubble.js
@@ -152,6 +152,27 @@ Blockly.ScratchBubble.DELETE_ICON_SIZE = 32;
  */
 Blockly.ScratchBubble.TOP_BAR_ICON_INSET = 0;
 
+
+/**
+ * The inset for the top bar icons.
+ * @private
+ */
+Blockly.ScratchBubble.RESIZE_SIZE = 16;
+
+/**
+ * The bottom corner padding of the resize handle touch target.
+ * Extends slightly outside the comment box.
+ * @private
+ */
+Blockly.ScratchBubble.RESIZE_CORNER_PAD = 4;
+
+/**
+ * The top/side padding around resize handle touch target.
+ * Extends about one extra "diagonal" above resize handle.
+ * @private
+ */
+Blockly.ScratchBubble.RESIZE_OUTER_PAD = 8;
+
 /**
  * Create the bubble's DOM.
  * @param {!Element} content SVG content for the bubble.
@@ -236,7 +257,8 @@ Blockly.ScratchBubble.prototype.createTopBarIcons_ = function() {
         'x': xInset,
         'y': topBarMiddleY - Blockly.ScratchBubble.MINIMIZE_ICON_SIZE / 2,
         'width': Blockly.ScratchBubble.MINIMIZE_ICON_SIZE,
-        'height': Blockly.ScratchBubble.MINIMIZE_ICON_SIZE
+        'height': Blockly.ScratchBubble.MINIMIZE_ICON_SIZE,
+        'style' : 'cursor: pointer;'
       }, this.bubbleGroup_);
 
   // Delete Icon in Comment Top Bar
@@ -245,7 +267,8 @@ Blockly.ScratchBubble.prototype.createTopBarIcons_ = function() {
         'x': xInset,
         'y': topBarMiddleY - Blockly.ScratchBubble.DELETE_ICON_SIZE / 2,
         'width': Blockly.ScratchBubble.DELETE_ICON_SIZE,
-        'height': Blockly.ScratchBubble.DELETE_ICON_SIZE
+        'height': Blockly.ScratchBubble.DELETE_ICON_SIZE,
+        'style' : 'cursor: pointer;'
       }, this.bubbleGroup_);
   this.deleteIcon_.setAttributeNS('http://www.w3.org/1999/xlink',
       'xlink:href', Blockly.mainWorkspace.options.pathToMedia + 'delete-x.svg');
@@ -279,9 +302,19 @@ Blockly.ScratchBubble.prototype.createResizeHandle_ = function() {
       {'class': this.workspace_.RTL ?
                 'scratchCommentResizeSW' : 'scratchCommentResizeSE'},
       this.bubbleGroup_);
-  var resizeSize = 12 * Blockly.ScratchBubble.BORDER_WIDTH;
+  var resizeSize = Blockly.ScratchBubble.RESIZE_SIZE;
+  var outerPad = Blockly.ScratchBubble.RESIZE_OUTER_PAD;
+  var cornerPad = Blockly.ScratchBubble.RESIZE_CORNER_PAD;
+  // Build an (invisible) triangle that will catch resizes. It is padded on the
+  // top/left by outerPad, and padded down/right by cornerPad.
   Blockly.utils.createSvgElement('polygon',
-      {'points': '0,x x,x x,0'.replace(/x/g, resizeSize.toString())},
+      {
+        'points': [
+          -outerPad, resizeSize + cornerPad,
+          resizeSize + cornerPad, resizeSize + cornerPad,
+          resizeSize + cornerPad, -outerPad
+        ].join(' ')
+      },
       this.resizeGroup_);
   Blockly.utils.createSvgElement('line',
       {
@@ -547,7 +580,7 @@ Blockly.ScratchBubble.prototype.setBubbleSize = function(width, height) {
         Blockly.ScratchBubble.TOP_BAR_ICON_INSET);
   }
   if (this.resizeGroup_) {
-    var resizeSize = 12 * Blockly.ScratchBubble.BORDER_WIDTH;
+    var resizeSize = Blockly.ScratchBubble.RESIZE_SIZE;
     if (this.workspace_.RTL) {
       // Mirror the resize group.
       this.resizeGroup_.setAttribute('transform', 'translate(' +

--- a/core/workspace_comment_render_svg.js
+++ b/core/workspace_comment_render_svg.js
@@ -42,7 +42,7 @@ Blockly.WorkspaceCommentSvg.BORDER_WIDTH = 1;
  * @const
  * @private
  */
-Blockly.WorkspaceCommentSvg.RESIZE_SIZE = 12 * Blockly.WorkspaceCommentSvg.BORDER_WIDTH;
+Blockly.WorkspaceCommentSvg.RESIZE_SIZE = 16;
 
 /**
  * Offset from the foreignobject edge to the textarea edge.
@@ -75,6 +75,20 @@ Blockly.WorkspaceCommentSvg.DELETE_ICON_SIZE = 32;
  * @private
  */
 Blockly.WorkspaceCommentSvg.TOP_BAR_ICON_INSET = 0;
+
+/**
+ * The bottom corner padding of the resize handle touch target.
+ * Extends slightly outside the comment box.
+ * @private
+ */
+Blockly.WorkspaceCommentSvg.RESIZE_CORNER_PAD = 4;
+
+/**
+ * The top/side padding around resize handle touch target.
+ * Extends about one extra "diagonal" above resize handle.
+ * @private
+ */
+Blockly.WorkspaceCommentSvg.RESIZE_OUTER_PAD = 8;
 
 /**
  * Width that a minimized comment should have.
@@ -214,9 +228,18 @@ Blockly.WorkspaceCommentSvg.prototype.addResizeDom_ = function() {
       },
       this.svgGroup_);
   var resizeSize = Blockly.WorkspaceCommentSvg.RESIZE_SIZE;
-  Blockly.utils.createSvgElement(
-      'polygon',
-      {'points': '0,x x,x x,0'.replace(/x/g, resizeSize.toString())},
+  var outerPad = Blockly.ScratchBubble.RESIZE_OUTER_PAD;
+  var cornerPad = Blockly.ScratchBubble.RESIZE_CORNER_PAD;
+  // Build an (invisible) triangle that will catch resizes. It is padded on the
+  // top/left by outerPad, and padded down/right by cornerPad.
+  Blockly.utils.createSvgElement('polygon',
+      {
+        'points': [
+          -outerPad, resizeSize + cornerPad,
+          resizeSize + cornerPad, resizeSize + cornerPad,
+          resizeSize + cornerPad, -outerPad
+        ].join(' ')
+      },
       this.resizeGroup_);
   Blockly.utils.createSvgElement(
       'line',

--- a/core/workspace_comment_render_svg.js
+++ b/core/workspace_comment_render_svg.js
@@ -572,7 +572,6 @@ Blockly.WorkspaceCommentSvg.prototype.setSize = function(width, height) {
         (Blockly.WorkspaceCommentSvg.MINIMIZE_ICON_SIZE) -
         Blockly.WorkspaceCommentSvg.TOP_BAR_ICON_INSET);
     this.deleteIcon_.setAttribute('x', (-width +
-        Blockly.WorkspaceCommentSvg.DELETE_ICON_SIZE -
         Blockly.WorkspaceCommentSvg.TOP_BAR_ICON_INSET));
     this.svgRect_.setAttribute('transform', 'scale(-1 1)');
     this.svgHandleTarget_.setAttribute('transform', 'scale(-1 1)');

--- a/core/workspace_comment_render_svg.js
+++ b/core/workspace_comment_render_svg.js
@@ -589,7 +589,8 @@ Blockly.WorkspaceCommentSvg.prototype.setSize = function(width, height) {
     if (this.RTL) {
       // Mirror the resize group.
       this.resizeGroup_.setAttribute('transform', 'translate(' +
-        (-width + resizeSize) + ',' + (height - resizeSize) + ') scale(-1 1)');
+        (-width + doubleBorderWidth + resizeSize) + ',' +
+        (height - doubleBorderWidth - resizeSize) + ') scale(-1 1)');
     } else {
       this.resizeGroup_.setAttribute('transform', 'translate(' +
         (width - doubleBorderWidth - resizeSize) + ',' +

--- a/core/workspace_comment_render_svg.js
+++ b/core/workspace_comment_render_svg.js
@@ -601,6 +601,8 @@ Blockly.WorkspaceCommentSvg.prototype.setSize = function(width, height) {
     this.svgHandleTarget_.setAttribute('transform', 'translate(' + -width + ', 1)');
     this.minimizeArrow_.setAttribute('transform', 'translate(' + -width + ', 1)');
     this.deleteIcon_.setAttribute('tranform', 'translate(' + -width + ', 1)');
+    this.svgRectTarget_.setAttribute('transform', 'translate(' + -width + ', 1)');
+    this.topBarLabel_.setAttribute('transform', 'translate(' + -width + ', 1)');
   } else {
     this.deleteIcon_.setAttribute('x', width -
         Blockly.WorkspaceCommentSvg.DELETE_ICON_SIZE -

--- a/core/workspace_comment_render_svg.js
+++ b/core/workspace_comment_render_svg.js
@@ -62,19 +62,19 @@ Blockly.WorkspaceCommentSvg.TOP_BAR_HEIGHT = 32;
  * The size of the minimize arrow icon in the comment top bar.
  * @private
  */
-Blockly.WorkspaceCommentSvg.MINIMIZE_ICON_SIZE = 16;
+Blockly.WorkspaceCommentSvg.MINIMIZE_ICON_SIZE = 32;
 
 /**
  * The size of the delete icon in the comment top bar.
  * @private
  */
-Blockly.WorkspaceCommentSvg.DELETE_ICON_SIZE = 12;
+Blockly.WorkspaceCommentSvg.DELETE_ICON_SIZE = 32;
 
 /**
  * The inset for the top bar icons.
  * @private
  */
-Blockly.WorkspaceCommentSvg.TOP_BAR_ICON_INSET = 6;
+Blockly.WorkspaceCommentSvg.TOP_BAR_ICON_INSET = 0;
 
 /**
  * Width that a minimized comment should have.

--- a/media/comment-arrow-down.svg
+++ b/media/comment-arrow-down.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="12px" height="12px" viewBox="0 0 12 12" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg width="32px" height="32px" viewBox="-4.5 -6 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <!-- Generator: Sketch 50.2 (55047) - http://www.bohemiancoding.com/sketch -->
     <title>dropdown-caret-up</title>
     <desc>Created with Sketch.</desc>

--- a/media/comment-arrow-up.svg
+++ b/media/comment-arrow-up.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="12px" height="12px" viewBox="0 0 12 12" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg width="32px" height="32px" viewBox="-4.5 -6 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <!-- Generator: Sketch 50.2 (55047) - http://www.bohemiancoding.com/sketch -->
     <title>dropdown-caret-down</title>
     <desc>Created with Sketch.</desc>

--- a/media/delete-x.svg
+++ b/media/delete-x.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="12px" height="12px" viewBox="0 0 12 12" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg width="32px" height="32px" viewBox="-14 -10 32 32" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <!-- Generator: Sketch 50.2 (55047) - http://www.bohemiancoding.com/sketch -->
     <title>delete-x</title>
     <desc>Created with Sketch.</desc>


### PR DESCRIPTION
Best read commit-by-commit. This increases the size of the touchable areas on comment minimize, delete and resize. Along the way, there are a couple RTL bugfixes that were uncovered by changing layout params. 

Here is the increased touch area (previously bounded tightly around each image)
![image](https://user-images.githubusercontent.com/654102/62145256-173fcc00-b2c1-11e9-8f3e-d8fba725a746.png)

Fixes #1796
Fixes https://github.com/LLK/scratch-blocks/issues/1789
