### PR TITLE
Use click event to avoid gesture problems freezing workspace

### DIFF
--- a/core/field_colour_slider.js
+++ b/core/field_colour_slider.js
@@ -341,7 +341,7 @@ Blockly.FieldColourSlider.prototype.showEditor_ = function() {
     button.appendChild(image);
     div.appendChild(button);
     Blockly.FieldColourSlider.eyedropperEventData_ =
-        Blockly.bindEventWithChecks_(button, 'mousedown', this,
+        Blockly.bindEventWithChecks_(button, 'click', this,
             this.activateEyedropperInternal_);
   }
 

--- a/core/field_matrix.js
+++ b/core/field_matrix.js
@@ -348,9 +348,9 @@ Blockly.FieldMatrix.prototype.showEditor_ = function() {
   this.matrixTouchWrapper_ =
       Blockly.bindEvent_(this.matrixStage_, 'mousedown', this, this.onMouseDown);
   this.clearButtonWrapper_ =
-      Blockly.bindEvent_(clearButton, 'mousedown', this, this.clearMatrix_);
+      Blockly.bindEvent_(clearButton, 'click', this, this.clearMatrix_);
   this.fillButtonWrapper_ =
-    Blockly.bindEvent_(fillButton, 'mousedown', this, this.fillMatrix_);
+    Blockly.bindEvent_(fillButton, 'click', this, this.fillMatrix_);
 
   // Update the matrix for the current value
   this.updateMatrix_();


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_
Resolves https://github.com/LLK/scratch-gui/issues/4920 and an unreported issue where you could not use the "clear" and "fill" buttons on the microbit extension.

### Proposed Changes

_Describe what this Pull Request does_
Instead of using `mousedown`, for events, and then having to disable the gestures, use `click` instead, which both works on touch and does not start a gesture. 

This incidentally also fixes a problem with the `field_matrix` where the `e.button` property did not exist for touch, causing those buttons to not work. But the button property does exist for `click` events, even on touch.

/cc @khanning might be interested