### PR TITLE
Now using correct delete count to check if should show dialog

### DIFF
--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1500,7 +1500,7 @@ Blockly.WorkspaceSvg.prototype.showContextMenu_ = function(e) {
       if (ws.currentGesture_) {
         ws.currentGesture_.cancel();
       }
-      if (deleteList.length < 2 ) {
+      if (deleteCount < 2 ) {
         deleteNext();
       } else {
         Blockly.confirm(


### PR DESCRIPTION
# Proposed Changes

Checks the same delete count var, which is shown in the confirmation dialog.

### Reason for Changes

Currently we check if deleteList.length < 2 and then show a dialog with deleteCount if its above.
deleteList.length and deleteCount are not always the same. In a block with input, each input gets added to the deleteList, hence the size is larger than the amount og blocks.
Therefore it's the wrong value to check.
