### PR TITLE
Add power (exponentiation) operator

### DIFF
--- a/blocks_vertical/default_toolbox.js
+++ b/blocks_vertical/default_toolbox.js
@@ -397,6 +397,18 @@ Blockly.Blocks.defaultToolbox = '<xml id="toolbox-categories" style="display: no
         '</shadow>' +
       '</value>' +
     '</block>' +
+    '<block type="operator_power" id="operator_power">' +
+      '<value name="NUM1">' +
+        '<shadow type="math_number">' +
+          '<field name="NUM"></field>' +
+        '</shadow>' +
+      '</value>' +
+      '<value name="NUM2">' +
+        '<shadow type="math_number">' +
+          '<field name="NUM"></field>' +
+        '</shadow>' +
+      '</value>' +
+    '</block>' +
     '<block type="operator_random" id="operator_random">' +
       '<value name="FROM">' +
         '<shadow type="math_number">' +

--- a/blocks_vertical/operators.js
+++ b/blocks_vertical/operators.js
@@ -124,6 +124,30 @@ Blockly.Blocks['operator_divide'] = {
   }
 };
 
+Blockly.Blocks['operator_power'] = {
+  /**
+   * Block for exponentiation of two numbers.
+   * @this Blockly.Block
+   */
+  init: function() {
+    this.jsonInit({
+      "message0": Blockly.Msg.OPERATORS_POWER,
+      "args0": [
+        {
+          "type": "input_value",
+          "name": "NUM1"
+        },
+        {
+          "type": "input_value",
+          "name": "NUM2"
+        }
+      ],
+      "category": Blockly.Categories.operators,
+      "extensions": ["colours_operators", "output_number"]
+    });
+  }
+};
+
 Blockly.Blocks['operator_random'] = {
   /**
    * Block for picking a random number.

--- a/msg/json/en.json
+++ b/msg/json/en.json
@@ -140,6 +140,7 @@
     "OPERATORS_SUBTRACT": "%1 - %2",
     "OPERATORS_MULTIPLY": "%1 * %2",
     "OPERATORS_DIVIDE": "%1 / %2",
+    "OPERATORS_POWER": "%1 ^ %2",
     "OPERATORS_RANDOM": "pick random %1 to %2",
     "OPERATORS_GT": "%1 > %2",
     "OPERATORS_LT": "%1 < %2",

--- a/tests/vertical_playground_compressed.html
+++ b/tests/vertical_playground_compressed.html
@@ -496,6 +496,18 @@
           </shadow>
         </value>
       </block>
+      <block type="operator_power">
+        <value name="NUM1">
+          <shadow type="math_number">
+            <field name="NUM"></field>
+          </shadow>
+        </value>
+        <value name="NUM2">
+          <shadow type="math_number">
+            <field name="NUM"></field>
+          </shadow>
+        </value>
+      </block>
       <block type="operator_random">
         <value name="FROM">
           <shadow type="math_number">


### PR DESCRIPTION
### Proposed Changes

It adds power (exponentiation) operator to Scratch. It now supports an easy way to do exponentiations.

### Reason for Changes

Scratch does not support exponentiation. Although there are some ways to "simulate" it, they are very hard to do, especially for young users.

This was also requested a long time ago on [Scracth Forum](https://scratch.mit.edu/discuss/topic/70660/) and [Scratch Wiki](https://en.scratch-wiki.info/wiki/Solving_Exponents)

### Test Coverage

I didn't do any new "advanced" tests. I mostly copied things that are used for existing operator blocks to create a new block.

### Related PRs

Other PRs that are needed for this implementation are:

* LLK/scratch-vm#2296
* LLK/scratch-blocks#2007
* LLK/scratch-gui#5266
