### PR TITLE
Fix for failed execution of `npm install` when run on Windows platforms

### DIFF
--- a/build.py
+++ b/build.py
@@ -55,6 +55,7 @@ CLOSURE_COMPILER_NPM = "google-closure-compiler"
 
 # Create powershell command prefix list that will be 
 # prepended to 'google-closure-library' args list
+# Resolves issues #2001, #1981 and #1859 (maybe more)
 POWERSHELL_COMMAND_PREFIX = ['powershell', '/c'] if platform.system() == "Windows" else []
 
 def import_path(fullpath):

--- a/build.py
+++ b/build.py
@@ -53,7 +53,7 @@ CLOSURE_ROOT_NPM = os.path.join("node_modules")
 CLOSURE_LIBRARY_NPM = "google-closure-library"
 CLOSURE_COMPILER_NPM = "google-closure-compiler"
 
-# Set POWERSHELL_COMMEND_PREFIX command if powershell is available for windows 
+# Set POWERSHELL_COMMAND_PREFIX command if powershell is available for windows 
 if platform.system() == "Windows":
   try:
     # Check if powershell is installed for windows systems

--- a/build.py
+++ b/build.py
@@ -39,7 +39,7 @@ if sys.version_info[0] != 2:
   raise Exception("Blockly build only compatible with Python 2.x.\n"
                   "You are using: " + sys.version)
 
-import errno, glob, httplib, json, os, re, subprocess, threading, urllib
+import errno, glob, httplib, json, os, re, subprocess, threading, urllib, platform
 
 REMOTE_COMPILER = "remote"
 

--- a/build.py
+++ b/build.py
@@ -61,7 +61,7 @@ if platform.system() == "Windows":
 
     # If the statement below successfully executes, 'powershell_path' will
     # contain the absolute path to the powershell executable; that path
-    # includes the text 'WindoesPowershell" which we test for in
+    # includes the text 'WindowsPowershell" which we test for in
     # the statement that follows this one.
     (powershell_path, _) = proc.communicate()
 

--- a/build.py
+++ b/build.py
@@ -328,7 +328,7 @@ class Gen_compressed(threading.Thread):
 
       # Build the final args array by prepending google-closure-compiler to
       # dash_args and dropping any falsy members
-      args = []
+      args = POWERSHELL_COMMAND_PREFIX[:]
       for group in [["google-closure-compiler"], dash_args]:
         args.extend(filter(lambda item: item, group))
 
@@ -574,7 +574,7 @@ if __name__ == "__main__":
         closure_root, closure_library, "closure", "bin", "calcdeps.py"))
 
     # Sanity check the local compiler
-    test_args = [closure_compiler, os.path.join("build", "test_input.js")]
+    test_args = POWERSHELL_COMMAND_PREFIX + [closure_compiler, os.path.join("build", "test_input.js")]
     test_proc = subprocess.Popen(test_args, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
     (stdout, _) = test_proc.communicate()
     assert stdout == read(os.path.join("build", "test_expect.js"))

--- a/build.py
+++ b/build.py
@@ -58,11 +58,12 @@ if platform.system() == "Windows":
   try:
     # Check if powershell is installed for windows systems
     proc = subprocess.Popen(['powershell', '/c', '$PsHome'], stdin=subprocess.PIPE, stdout=subprocess.PIPE)
-    (powershell_path, _) = proc.communicate()
 
-    # If the above command was successfully executed, 'powershell_path' will
+    # If the statement below successfully executes, 'powershell_path' will
     # contain the absolute path to the powershell executable; that path
-    # includes the folder 'WindoesPowershell" which we test for below.
+    # includes the text 'WindoesPowershell" which we test for in
+    # the statement that follows this one.
+    (powershell_path, _) = proc.communicate()
 
     # Create powershell command prefix list that will be
     # prepended to 'google-closure-library' args list

--- a/build.py
+++ b/build.py
@@ -53,6 +53,10 @@ CLOSURE_ROOT_NPM = os.path.join("node_modules")
 CLOSURE_LIBRARY_NPM = "google-closure-library"
 CLOSURE_COMPILER_NPM = "google-closure-compiler"
 
+# Create powershell command prefix list that will be 
+# prepended to 'google-closure-library' args list
+POWERSHELL_COMMAND_PREFIX = ['powershell', '/c'] if platform.system() == "Windows" else []
+
 def import_path(fullpath):
   """Import a file with full path specification.
   Allows one to import from any directory, something __import__ does not do.

--- a/build.py
+++ b/build.py
@@ -72,6 +72,7 @@ if platform.system() == "Windows":
     POWERSHELL_COMMAND_PREFIX = ['powershell', '/c'] if "windowspowershell" in powershell_path.lower() else []
   except OSError:
     print("Error: Powershell is not installed on your system.")
+    sys.exit(1)
 else:
   POWERSHELL_COMMAND_PREFIX = []
 

--- a/build.py
+++ b/build.py
@@ -53,11 +53,22 @@ CLOSURE_ROOT_NPM = os.path.join("node_modules")
 CLOSURE_LIBRARY_NPM = "google-closure-library"
 CLOSURE_COMPILER_NPM = "google-closure-compiler"
 
-# Create powershell command prefix list that will be 
-# prepended to 'google-closure-library' args list
-# Resolves the following issues reported on github:
-# #2001, #1981 and #1859 (maybe more)
-POWERSHELL_COMMAND_PREFIX = ['powershell', '/c'] if platform.system() == "Windows" else []
+# Set POWERSHELL_COMMEND_PREFIX command if powershell is available for windows 
+if platform.system() == "Windows":
+  try:
+    # Check if powershell is installed for windows systems
+    proc = subprocess.Popen(['powershell', '/c', '$PsHome'])
+    (powershell_path,_) = proc.communicate()
+
+    # Create powershell command prefix list that will be
+    # prepended to 'google-closure-library' args list
+    # Resolves the following issues reported on github:
+    # #2001, #1981 and #1859 (maybe more)
+    POWERSHELL_COMMAND_PREFIX = ['powershell', '/c'] if "windowspowershell" in powershell_path.lower() else []
+  except OSError:
+    print("Error: Powershell is not installed on your system.")
+else:
+  POWERSHELL_COMMAND_PREFIX = []
 
 def import_path(fullpath):
   """Import a file with full path specification.

--- a/build.py
+++ b/build.py
@@ -62,7 +62,7 @@ if platform.system() == "Windows":
 
     # If the above command was successfully executed, 'powershell_path' will
     # contain the absolute path to the powershell executable; that path
-    # includes a the folder 'WindoesPowershell" which we test for below.
+    # includes the folder 'WindoesPowershell" which we test for below.
 
     # Create powershell command prefix list that will be
     # prepended to 'google-closure-library' args list

--- a/build.py
+++ b/build.py
@@ -56,7 +56,7 @@ CLOSURE_COMPILER_NPM = "google-closure-compiler"
 # Set POWERSHELL_COMMAND_PREFIX command if powershell is available for windows 
 if platform.system() == "Windows":
   try:
-    # Check if powershell is installed for windows systems
+    # Check if powershell is available for windows systems (should be installed by default)
     proc = subprocess.Popen(['powershell', '/c', '$PsHome'], stdin=subprocess.PIPE, stdout=subprocess.PIPE)
 
     # If the statement below successfully executes, 'powershell_path' will
@@ -65,13 +65,16 @@ if platform.system() == "Windows":
     # the statement that follows this one.
     (powershell_path, _) = proc.communicate()
 
-    # Create powershell command prefix list that will be
-    # prepended to 'google-closure-library' args list
-    # Resolves the following issues reported on github:
-    # #2001, #1981 and #1859 (maybe more)
-    POWERSHELL_COMMAND_PREFIX = ['powershell', '/c'] if "windowspowershell" in powershell_path.lower() else []
+    if "windowspowershell" in powershell_path.lower():
+      # Create powershell command prefix list that will be
+      # prepended to 'google-closure-library' args list
+      # Resolves the following issues reported on github:
+      # #2001, #1981 and #1859 (maybe more)
+      POWERSHELL_COMMAND_PREFIX = ['powershell', '/c']
+    else:
+      raise OSError()
   except OSError:
-    print("Error: Powershell is not installed on your system.")
+    print("Error: Powershell was not found on your system.")
     sys.exit(1)
 else:
   POWERSHELL_COMMAND_PREFIX = []

--- a/build.py
+++ b/build.py
@@ -57,8 +57,12 @@ CLOSURE_COMPILER_NPM = "google-closure-compiler"
 if platform.system() == "Windows":
   try:
     # Check if powershell is installed for windows systems
-    proc = subprocess.Popen(['powershell', '/c', '$PsHome'])
-    (powershell_path,_) = proc.communicate()
+    proc = subprocess.Popen(['powershell', '/c', '$PsHome'], stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+    (powershell_path, _) = proc.communicate()
+
+    # If the above command was successfully executed, 'powershell_path' will
+    # contain the absolute path to the powershell executable; that path
+    # includes a the folder 'WindoesPowershell" which we test for below.
 
     # Create powershell command prefix list that will be
     # prepended to 'google-closure-library' args list

--- a/build.py
+++ b/build.py
@@ -55,7 +55,8 @@ CLOSURE_COMPILER_NPM = "google-closure-compiler"
 
 # Create powershell command prefix list that will be 
 # prepended to 'google-closure-library' args list
-# Resolves issues #2001, #1981 and #1859 (maybe more)
+# Resolves the following issues reported on github:
+# #2001, #1981 and #1859 (maybe more)
 POWERSHELL_COMMAND_PREFIX = ['powershell', '/c'] if platform.system() == "Windows" else []
 
 def import_path(fullpath):


### PR DESCRIPTION
### Resolves
Fixes the recurring bug where the execution of `npm install`, and subsequently `python build.py`, fails under Windows OS as cited by the following issues:

- #2001 
- #1981 
- #1859 
- #1620
- possibly others

### Proposed Changes
Modified `build.py` to execute `google-closure-compiler` (initiated as a sub-process from Python)  using `powershell.exe`. This eliminates the character limit constraint alluded to in the aforementioned issue reports.

### Reason for Changes
Compilation fails on windows machines during the build step. This fix resolves that issue.

### Test Coverage
Executed the fix locally and it compiles successfully.

