### PR TITLE
Fix offset of comments in stacks

### DIFF
--- a/core/scratch_block_comment.js
+++ b/core/scratch_block_comment.js
@@ -313,20 +313,17 @@ Blockly.ScratchBlockComment.prototype.autoPosition_ = function() {
         this.iconXY_.x + minimizedOffset;
     this.y_ = this.iconXY_.y - (Blockly.ScratchBubble.TOP_BAR_HEIGHT / 2);
   } else {
-    // Check if the width of this block (and all it's children/descendents) is the
-    // same as the width of just this block
-    var fullStackWidth = Math.floor(this.block_.getHeightWidth().width);
+    // Position comment so that the expanded bubble does not overlap
+    // blocks below it in the stack that are wider than this block
+    // Overhang is the difference between this blocks trailing edge and
+    // the largest block below (zero if this block is the widest)
     var thisBlockWidth = Math.floor(this.block_.svgPath_.getBBox().width);
+    var fullStackWidth = Math.floor(this.block_.getHeightWidth().width);
+    var overhang = fullStackWidth - thisBlockWidth;
     var offset = 8 * Blockly.BlockSvg.GRID_UNIT;
-    if (fullStackWidth == thisBlockWidth && !this.block_.parentBlock_) {
-      this.x_ = this.block_.RTL ?
-          this.iconXY_.x - this.width_ - offset :
-          this.iconXY_.x + offset;
-    } else {
-      this.x_ = this.block_.RTL ?
-          this.iconXY_.x - this.width_ - fullStackWidth - offset :
-          this.iconXY_.x + fullStackWidth + offset;
-    }
+    this.x_ = this.block_.RTL ?
+        this.iconXY_.x - this.width_ - overhang - offset :
+        this.iconXY_.x + overhang + offset;
     this.y_ = this.iconXY_.y - (Blockly.ScratchBubble.TOP_BAR_HEIGHT / 2);
   }
 };


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Resolves https://github.com/LLK/scratch-blocks/issues/2022

### Proposed Changes

_Describe what this Pull Request does_

Instead of bumping comments over by a factor of the stack width, bump comments over by the "overhang", meaning the difference between the width of the stack (this block and all next) and the width of this block. The anchor is already at the right edge so we don't need to offset by a full block width ever.

Thanks @picklesrus for helping pair on this!
### Reason for Changes

_Explain why these changes should be made_
Current behavior
![Screen Shot 2019-12-18 at 3 39 11 PM](https://user-images.githubusercontent.com/654102/71122375-6de56e00-21ae-11ea-9c5b-19758f17ca87.png)

New behavior
![Screen Shot 2019-12-18 at 3 38 29 PM](https://user-images.githubusercontent.com/654102/71122377-7178f500-21ae-11ea-99fb-999d398d8c62.png)
