### PR TITLE
Call updateMovable when changing shadow flag

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -789,6 +789,7 @@ Blockly.BlockSvg.prototype.setEditable = function(editable) {
 Blockly.BlockSvg.prototype.setShadow = function(shadow) {
   Blockly.BlockSvg.superClass_.setShadow.call(this, shadow);
   this.updateColour();
+  this.updateMovable();
 };
 
 /**


### PR DESCRIPTION
### Resolves

Fixes #1875.

### Proposed Changes

This simple patch makes `setShadow` call `updateMovable` on `BlockSvg`s.

### Reason for Changes

Whether a block gets the `blocklyDraggable` class depends (in part) on if it isn't a shadow block. So, when the shadow flag changes, we should call `updateMovable`, so that that change is immediately reflected in the block having the class or not.

This fixes an issue in Scratch where custom block arguments, which are shadow blocks in XML when duplicated (and thus when `initSvg`'d -> `updateMovable`'d), would not get the draggable class. This didn't actually prevent the blocks from being moved, but it did mean appropriate CSS for draggable blocks (particularly `cursor: grab`) was not being applied.

### Test Coverage

Tested manually through the custom procedure playground.
