### PR TITLE
replaced calls to deprecated goog.isX() functions

### DIFF
--- a/core/block.js
+++ b/core/block.js
@@ -837,7 +837,7 @@ Blockly.Block.prototype.makeColour_ = function(colour) {
   var hue = Number(colour);
   if (!isNaN(hue)) {
     return Blockly.hueToRgb(hue);
-  } else if (goog.isString(colour) && colour.match(/^#[0-9a-fA-F]{6}$/)) {
+  } else if ((typeof colour == 'string') && colour.match(/^#[0-9a-fA-F]{6}$/)) {
     return colour;
   } else {
     throw 'Invalid colour: ' + colour;
@@ -1299,7 +1299,7 @@ Blockly.Block.prototype.jsonInit = function(json) {
     var localizedValue = Blockly.utils.replaceMessageReferences(rawValue);
     this.setHelpUrl(localizedValue);
   }
-  if (goog.isString(json['extensions'])) {
+  if (typeof json['extensions'] == 'string') {
     console.warn('JSON attribute \'extensions\' should be an array of ' +
       'strings. Found raw string in JSON for \'' + json['type'] + '\' block.');
     json['extensions'] = [json['extensions']];  // Correct and continue.
@@ -1338,7 +1338,7 @@ Blockly.Block.prototype.jsonInit = function(json) {
  * @param {boolean=} opt_disableCheck Option flag to disable overwrite checks.
  */
 Blockly.Block.prototype.mixin = function(mixinObj, opt_disableCheck) {
-  if (goog.isDef(opt_disableCheck) && !goog.isBoolean(opt_disableCheck)) {
+  if ((opt_disableCheck !== undefined) && !(typeof opt_disableCheck == 'boolean')) {
     throw new Error("opt_disableCheck must be a boolean if provided");
   }
   if (!opt_disableCheck) {
@@ -1368,11 +1368,11 @@ Blockly.Block.prototype.mixin = function(mixinObj, opt_disableCheck) {
  */
 Blockly.Block.prototype.setColourFromRawValues_ = function(primary, secondary,
     tertiary) {
-  primary = goog.isString(primary) ?
+  primary = (typeof primary == 'string') ?
       Blockly.utils.replaceMessageReferences(primary) : primary;
-  secondary = goog.isString(secondary) ?
+  secondary = (typeof secondary == 'string') ?
       Blockly.utils.replaceMessageReferences(secondary) : secondary;
-  tertiary = goog.isString(tertiary) ?
+  tertiary = (typeof tertiary == 'string') ?
       Blockly.utils.replaceMessageReferences(tertiary) : tertiary;
 
   this.setColour(primary, secondary, tertiary);

--- a/core/block.js
+++ b/core/block.js
@@ -1338,7 +1338,7 @@ Blockly.Block.prototype.jsonInit = function(json) {
  * @param {boolean=} opt_disableCheck Option flag to disable overwrite checks.
  */
 Blockly.Block.prototype.mixin = function(mixinObj, opt_disableCheck) {
-  if ((opt_disableCheck !== undefined) && !(typeof opt_disableCheck == 'boolean')) {
+  if ((opt_disableCheck !== undefined) && (typeof opt_disableCheck != 'boolean')) {
     throw new Error("opt_disableCheck must be a boolean if provided");
   }
   if (!opt_disableCheck) {

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -894,7 +894,7 @@ Blockly.BlockSvg.prototype.getCommentText = function() {
 Blockly.BlockSvg.prototype.setCommentText = function(text, commentId,
     commentX, commentY, minimized) {
   var changedState = false;
-  if (goog.isString(text)) {
+  if (typeof text == 'string') {
     if (!this.comment) {
       this.comment = new Blockly.ScratchBlockComment(this, text, commentId,
           commentX, commentY, minimized);
@@ -910,7 +910,7 @@ Blockly.BlockSvg.prototype.setCommentText = function(text, commentId,
   }
   if (changedState && this.rendered) {
     this.render();
-    if (goog.isString(text)) {
+    if (typeof text == 'string') {
       this.comment.setVisible(true);
     }
     // Adding or removing a comment icon will cause the block to change shape.
@@ -959,7 +959,7 @@ Blockly.BlockSvg.prototype.setWarningText = function(text, opt_id) {
   }
 
   var changedState = false;
-  if (goog.isString(text)) {
+  if (typeof text == 'string') {
     if (!this.warning) {
       this.warning = new Blockly.Warning(this);
       changedState = true;

--- a/core/extensions.js
+++ b/core/extensions.js
@@ -56,7 +56,7 @@ Blockly.Extensions.ALL_ = {};
  *     registered, or extensionFn is not a function.
  */
 Blockly.Extensions.register = function(name, initFn) {
-  if (!goog.isString(name) || goog.string.isEmptyOrWhitespace(name)) {
+  if (!(typeof name == 'string') || goog.string.isEmptyOrWhitespace(name)) {
     throw new Error('Error: Invalid extension name "' + name + '"');
   }
   if (Blockly.Extensions.ALL_[name]) {

--- a/core/extensions.js
+++ b/core/extensions.js
@@ -56,7 +56,7 @@ Blockly.Extensions.ALL_ = {};
  *     registered, or extensionFn is not a function.
  */
 Blockly.Extensions.register = function(name, initFn) {
-  if (!(typeof name == 'string') || goog.string.isEmptyOrWhitespace(name)) {
+  if ((typeof name != 'string') || goog.string.isEmptyOrWhitespace(name)) {
     throw new Error('Error: Invalid extension name "' + name + '"');
   }
   if (Blockly.Extensions.ALL_[name]) {

--- a/core/field.js
+++ b/core/field.js
@@ -81,7 +81,7 @@ Blockly.Field.TYPE_MAP_ = {};
  *     object containing a fromJson function.
  */
 Blockly.Field.register = function(type, fieldClass) {
-  if (!(typeof type == 'string') || goog.string.isEmptyOrWhitespace(type)) {
+  if ((typeof type != 'string') || goog.string.isEmptyOrWhitespace(type)) {
     throw new Error('Invalid field type "' + type + '"');
   }
   if (!goog.isObject(fieldClass) || !goog.isFunction(fieldClass.fromJson)) {

--- a/core/field.js
+++ b/core/field.js
@@ -81,7 +81,7 @@ Blockly.Field.TYPE_MAP_ = {};
  *     object containing a fromJson function.
  */
 Blockly.Field.register = function(type, fieldClass) {
-  if (!goog.isString(type) || goog.string.isEmptyOrWhitespace(type)) {
+  if (!(typeof type == 'string') || goog.string.isEmptyOrWhitespace(type)) {
     throw new Error('Invalid field type "' + type + '"');
   }
   if (!goog.isObject(fieldClass) || !goog.isFunction(fieldClass.fromJson)) {

--- a/core/flyout_horizontal.js
+++ b/core/flyout_horizontal.js
@@ -128,7 +128,7 @@ Blockly.HorizontalFlyout.prototype.setMetrics_ = function(xyRatio) {
     return;
   }
 
-  if (typeof xyRatio.x === 'number') {
+  if (typeof xyRatio.x == 'number') {
     this.workspace_.scrollX = -metrics.contentWidth * xyRatio.x;
   }
 

--- a/core/flyout_horizontal.js
+++ b/core/flyout_horizontal.js
@@ -128,7 +128,7 @@ Blockly.HorizontalFlyout.prototype.setMetrics_ = function(xyRatio) {
     return;
   }
 
-  if (goog.isNumber(xyRatio.x)) {
+  if (typeof xyRatio.x === 'number') {
     this.workspace_.scrollX = -metrics.contentWidth * xyRatio.x;
   }
 

--- a/core/flyout_vertical.js
+++ b/core/flyout_vertical.js
@@ -294,7 +294,7 @@ Blockly.VerticalFlyout.prototype.setMetrics_ = function(xyRatio) {
   if (!metrics) {
     return;
   }
-  if (typeof xyRatio.y === 'number') {
+  if (typeof xyRatio.y == 'number') {
     this.workspace_.scrollY = -metrics.contentHeight * xyRatio.y;
   }
   this.workspace_.translate(this.workspace_.scrollX + metrics.absoluteLeft,

--- a/core/flyout_vertical.js
+++ b/core/flyout_vertical.js
@@ -294,7 +294,7 @@ Blockly.VerticalFlyout.prototype.setMetrics_ = function(xyRatio) {
   if (!metrics) {
     return;
   }
-  if (goog.isNumber(xyRatio.y)) {
+  if (typeof xyRatio.y === 'number') {
     this.workspace_.scrollY = -metrics.contentHeight * xyRatio.y;
   }
   this.workspace_.translate(this.workspace_.scrollX + metrics.absoluteLeft,

--- a/core/generator.js
+++ b/core/generator.js
@@ -186,7 +186,7 @@ Blockly.Generator.prototype.blockToCode = function(block) {
     goog.asserts.assert(block.outputConnection,
         'Expecting string from statement block "%s".', block.type);
     return [this.scrub_(block, code[0]), code[1]];
-  } else if (goog.isString(code)) {
+  } else if (typeof code == 'string') {
     var id = block.id.replace(/\$/g, '$$$$');  // Issue 251.
     if (this.STATEMENT_PREFIX) {
       code = this.STATEMENT_PREFIX.replace(/%1/g, '\'' + id + '\'') +

--- a/core/inject.js
+++ b/core/inject.js
@@ -46,7 +46,7 @@ goog.require('goog.userAgent');
  * @return {!Blockly.Workspace} Newly created main workspace.
  */
 Blockly.inject = function(container, opt_options) {
-  if (goog.isString(container)) {
+  if (typeof container == 'string') {
     container = document.getElementById(container) ||
         document.querySelector(container);
   }

--- a/core/input.js
+++ b/core/input.js
@@ -111,7 +111,7 @@ Blockly.Input.prototype.insertFieldAt = function(index, field, opt_name) {
     return this;
   }
   // Generate a FieldLabel when given a plain text field.
-  if (goog.isString(field)) {
+  if (typeof field == 'string') {
     field = new Blockly.FieldLabel(/** @type {string} */ (field));
   }
   field.setSourceBlock(this.sourceBlock_);

--- a/core/scratch_block_comment.js
+++ b/core/scratch_block_comment.js
@@ -102,7 +102,7 @@ Blockly.ScratchBlockComment = function(block, text, id, x, y, minimized) {
    * @type {string}
    * @package
    */
-  this.id = goog.isString(id) && !this.workspace.getCommentById(id) ?
+  this.id = (typeof id == 'string') && !this.workspace.getCommentById(id) ?
       id : Blockly.utils.genUid();
   this.workspace.addTopComment(this);
 

--- a/core/toolbox.js
+++ b/core/toolbox.js
@@ -782,7 +782,7 @@ Blockly.Toolbox.Category.prototype.getContents = function() {
 Blockly.Toolbox.Category.prototype.setColour = function(node) {
   var colour = node.getAttribute('colour');
   var secondaryColour = node.getAttribute('secondaryColour');
-  if (goog.isString(colour)) {
+  if (typeof colour == 'string') {
     if (colour.match(/^#[0-9a-fA-F]{6}$/)) {
       this.colour_ = colour;
     } else {

--- a/core/tooltip.js
+++ b/core/tooltip.js
@@ -167,7 +167,7 @@ Blockly.Tooltip.onMouseOver_ = function(e) {
   // If the tooltip is an object, treat it as a pointer to the next object in
   // the chain to look at.  Terminate when a string or function is found.
   var element = e.target;
-  while (!goog.isString(element.tooltip) && !goog.isFunction(element.tooltip)) {
+  while (!(typeof element.tooltip == 'string') && !goog.isFunction(element.tooltip)) {
     element = element.tooltip;
   }
   if (Blockly.Tooltip.element_ != element) {

--- a/core/tooltip.js
+++ b/core/tooltip.js
@@ -167,7 +167,7 @@ Blockly.Tooltip.onMouseOver_ = function(e) {
   // If the tooltip is an object, treat it as a pointer to the next object in
   // the chain to look at.  Terminate when a string or function is found.
   var element = e.target;
-  while (!(typeof element.tooltip == 'string') && !goog.isFunction(element.tooltip)) {
+  while ((typeof element.tooltip != 'string') && !goog.isFunction(element.tooltip)) {
     element = element.tooltip;
   }
   if (Blockly.Tooltip.element_ != element) {

--- a/core/utils.js
+++ b/core/utils.js
@@ -433,7 +433,7 @@ Blockly.utils.tokenizeInterpolation = function(message) {
  * @return {!string} String with message references replaced.
  */
 Blockly.utils.replaceMessageReferences = function(message) {
-  if (!goog.isString(message)) {
+  if (!(typeof message == 'string')) {
     return message;
   }
   var interpolatedResult = Blockly.utils.tokenizeInterpolation_(message, false);
@@ -552,7 +552,7 @@ Blockly.utils.tokenizeInterpolation_ = function(message,
               keyUpper.substring(4) : null;
           if (bklyKey && bklyKey in Blockly.Msg) {
             var rawValue = Blockly.Msg[bklyKey];
-            if (goog.isString(rawValue)) {
+            if (typeof rawValue == 'string') {
               // Attempt to dereference substrings, too, appending to the end.
               Array.prototype.push.apply(tokens,
                   Blockly.utils.tokenizeInterpolation(rawValue));

--- a/core/utils.js
+++ b/core/utils.js
@@ -433,7 +433,7 @@ Blockly.utils.tokenizeInterpolation = function(message) {
  * @return {!string} String with message references replaced.
  */
 Blockly.utils.replaceMessageReferences = function(message) {
-  if (!(typeof message == 'string')) {
+  if ((typeof message != 'string')) {
     return message;
   }
   var interpolatedResult = Blockly.utils.tokenizeInterpolation_(message, false);

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -2048,10 +2048,10 @@ Blockly.WorkspaceSvg.setTopLevelWorkspaceMetrics_ = function(xyRatio) {
     throw 'Attempt to set top level workspace scroll without scrollbars.';
   }
   var metrics = this.getMetrics();
-  if (goog.isNumber(xyRatio.x)) {
+  if (typeof xyRatio.x === 'number') {
     this.scrollX = -metrics.contentWidth * xyRatio.x - metrics.contentLeft;
   }
-  if (goog.isNumber(xyRatio.y)) {
+  if (typeof xyRatio.y === 'number') {
     this.scrollY = -metrics.contentHeight * xyRatio.y - metrics.contentTop;
   }
   var x = this.scrollX + metrics.absoluteLeft;

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -2048,10 +2048,10 @@ Blockly.WorkspaceSvg.setTopLevelWorkspaceMetrics_ = function(xyRatio) {
     throw 'Attempt to set top level workspace scroll without scrollbars.';
   }
   var metrics = this.getMetrics();
-  if (typeof xyRatio.x === 'number') {
+  if (typeof xyRatio.x == 'number') {
     this.scrollX = -metrics.contentWidth * xyRatio.x - metrics.contentLeft;
   }
-  if (typeof xyRatio.y === 'number') {
+  if (typeof xyRatio.y == 'number') {
     this.scrollY = -metrics.contentHeight * xyRatio.y - metrics.contentTop;
   }
   var x = this.scrollX + metrics.absoluteLeft;


### PR DESCRIPTION
### Resolves

https://github.com/LLK/scratch-blocks/issues/2031

### Proposed Changes

This commit replaces function calls to goog.isString, goog.isBoolean, goog.isDef and goog.isNumber with their native equivalents as specified in https://github.com/google/closure-library/commit/9325ce1bbebcfe8c7aa54f8342959c73a1762a77

### Reason for Changes

Calls to the functions goog.isString, goog.isBoolean, goog.isDef and goog.isNumber were deprecated and have recently been removed entirely. This causes errors that prevents scratch-blocks from running correctly.

### Test Coverage

No additional test coverage required as no functionality was added. Search in Github identified all files affected by all deprecated functions. Search for all six impacted functions was performed for all affected files, and all instances were replaced with the native function equivalents. Recompile and test showed no errors.
