### PR TITLE
Scripts for automating translation in travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ before_install:
 - ln -s $(npm root)/google-closure-library ../closure-library
 
 before_script:
+  - i18n/sync_translations.sh
   - export DISPLAY=:99.0
   - tests/scripts/setup_linux_env.sh
   - sleep 2
@@ -30,7 +31,9 @@ after_script:
     # Only release on release branches
     $RELEASE_BRANCHES =~ $TRAVIS_BRANCH &&
     # Don't release on PR builds
-    $TRAVIS_PULL_REQUEST = "false"
+    $TRAVIS_PULL_REQUEST = "false" &&
+    # Don't release on cron build - the cron job kicks off a build that will release
+    $TRAVIS_EVENT_TYPE != "cron"
   ]]; then
     # Authenticate NPM
     echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" > .npmrc

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,9 +31,7 @@ after_script:
     # Only release on release branches
     $RELEASE_BRANCHES =~ $TRAVIS_BRANCH &&
     # Don't release on PR builds
-    $TRAVIS_PULL_REQUEST = "false" &&
-    # Don't release on cron build - the cron job kicks off a build that will release
-    $TRAVIS_EVENT_TYPE != "cron"
+    $TRAVIS_PULL_REQUEST = "false"
   ]]; then
     # Authenticate NPM
     echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" > .npmrc

--- a/i18n/sync_translations.sh
+++ b/i18n/sync_translations.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+if [ "${TRAVIS_EVENT_TYPE}" == "cron" ]
+  then
+    echo "Starting translation sync"
+    set -ev
+    git checkout develop
+    # update translations, and test any updated messages
+    npm run translate
+    npm run translate:update
+    npm run test:messages
+    # stage any changes in the msg directory
+    git add ./msg
+    git commit -m 'update translations from transifex'
+    # add remote, make sure that API token doesn't end up in the log
+    git remote add origin-translation https://${GH_TOKEN}@github.com/LLK/scratch-blocks.git > /dev/null 2>&1
+    git push --set-upstream origin-translation develop
+fi

--- a/i18n/sync_translations.sh
+++ b/i18n/sync_translations.sh
@@ -10,7 +10,7 @@ if [ "${TRAVIS_EVENT_TYPE}" == "cron" ]
     npm run test:messages
     # stage any changes in the msg directory
     git add ./msg
-    git commit -m 'update translations from transifex'
+    git commit -m '[skip ci] Update translations from transifex'
     # add remote, make sure that API token doesn't end up in the log
     git remote add origin-translation https://${GH_TOKEN}@github.com/LLK/scratch-blocks.git > /dev/null 2>&1
     git push --set-upstream origin-translation develop


### PR DESCRIPTION
### Resolves

Fixes #1608 

### Proposed Changes

i18n/sync_translations.sh: doesn’t do anything if it isn’t a cron job. Otherwise, it updates and tests messages, then commits and pushes to develop branch if there are no errors.

.travis.yml: adds syncing translations before the build script. Trying to keep the .travis config changes minimal.

#### Questions
* Does the sync script need to check out develop since that is the branch that is getting built by the cron job?
* For now it's only staging changes in the msg directory (that's where translations show up). Is there any reason to stage more?
* added the redirect to `/dev/null` on the `git remote` command to avoid leaking the $GH_TOKEN, does the `git push` also need the redirect?
* would it be better to do a more major refactor of the travis.yml to have a `jobs` section?
* Since this does a commit on develop, I think it will kick off another travis build (Yes?). I'm assuming that build should be the one to build and release, so the cron job should skip releasing.

### Reason for Changes
Better ergonomics

### Testing

Testing involves getting travis to build and release.
