### PR TITLE
Only run sync_translations on node 8 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_install:
 - ln -s $(npm root)/google-closure-library ../closure-library
 
 before_script:
-  - i18n/sync_translations.sh
+  - if [[ $TRAVIS_NODE_VERSION == 8 ]]; then i18n/sync_translations.sh; fi
   - export DISPLAY=:99.0
   - tests/scripts/setup_linux_env.sh
   - sleep 2


### PR DESCRIPTION
Travis runs two builds in parallel. Only run the translation sync and commit on one of them.

I tested it by triggering the build and pasting in a new travis.yml with the changes. 