### PR TITLE
Match Travis config to scratch-gui

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 language: node_js
 node_js:
 - "8"
-sudo: required
+env:
+  global:
+  - NPM_TAG=latest
+  - RELEASE_VERSION="0.1.0-prerelease.$(date +'%Y%m%d%H%M%S')"
 addons:
   chrome: stable
 cache:
@@ -13,28 +16,36 @@ before_install:
 - ln -s $(npm root)/google-closure-library ../closure-library
 
 before_script:
-  - if [[ $TRAVIS_NODE_VERSION == 8 ]]; then i18n/sync_translations.sh; fi
   - export DISPLAY=:99.0
   - tests/scripts/setup_linux_env.sh
   - sleep 2
-
-after_script:
-- |
-  # RELEASE_BRANCHES and NPM_TOKEN defined in Travis settings panel
-  declare exitCode
-  if [[
-    # Only release on release branches
-    $RELEASE_BRANCHES =~ $TRAVIS_BRANCH &&
-    # Don't release on PR builds
-    $TRAVIS_PULL_REQUEST = "false"
-  ]]; then
-    # Authenticate NPM
-    echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" > .npmrc
-    # Set version to timestamp
-    npm --no-git-tag-version version $($(npm bin)/json -f package.json version)-prerelease.$(date +%s)
-    npm publish
-    # Publish to gh-pages as most recent committer
+script:
+  - i18n/sync_translations.sh
+  - npm test
+before_deploy:
+- >
+  if [ -z "$BEFORE_DEPLOY_RAN" ]; then
+    npm --no-git-tag-version version $RELEASE_VERSION
+    if [[ "$TRAVIS_BRANCH" == hotfix/* ]]; then export NPM_TAG=hotfix; fi # double brackets are important for matching the wildcard
     git config --global user.email $(git log --pretty=format:"%ae" -n1)
     git config --global user.name $(git log --pretty=format:"%an" -n1)
-    npm run --silent deploy -- -x -r https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git
+    export BEFORE_DEPLOY_RAN=true
   fi
+deploy:
+- provider: npm
+  on:
+    branch:
+    - master
+    - develop
+    - hotfix/*
+  skip_cleanup: true
+  email: $NPM_EMAIL
+  api_key: $NPM_TOKEN
+  tag: $NPM_TAG
+- provider: script
+  on:
+    all_branches: true
+    condition: $TRAVIS_EVENT_TYPE != cron && ! $TRAVIS_BRANCH =~ ^greenkeeper/
+    tags: false # Don't push tags to gh-pages
+  skip_cleanup: true
+  script: npm run --silent deploy -- -x -r https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git


### PR DESCRIPTION
Simplify the Travis config by using the built-in deploy steps, rather than after_script which seemed to be misbehaving