### PR TITLE
Bump Travis Node version to 12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-- "8"
+- "12"
 env:
   global:
   - NPM_TAG=latest


### PR DESCRIPTION
From @chrisgarrity:
> The chrome driver cannot be updated to the latest (81) because they stopped supporting node 8 in 80.0.2. I've pinned it to 80.0.1, but this is only going to last until it's incompatible with the currently installed chrome on travis.
