### PR TITLE
Use FieldColourSlider's internal hue_, saturation_, brightness_ in slider callbacks

### DIFF
--- a/core/field_colour_slider.js
+++ b/core/field_colour_slider.js
@@ -245,19 +245,18 @@ Blockly.FieldColourSlider.prototype.sliderCallbackFactory_ = function(channel) {
   return function(event) {
     if (!thisField.sliderCallbacksEnabled_) return;
     var channelValue = event.target.getValue();
-    var hsv = goog.color.hexToHsv(thisField.getValue());
     switch (channel) {
       case 'hue':
-        hsv[0] = thisField.hue_ = channelValue;
+        thisField.hue_ = channelValue;
         break;
       case 'saturation':
-        hsv[1] = thisField.saturation_ = channelValue;
+        thisField.saturation_ = channelValue;
         break;
       case 'brightness':
-        hsv[2] = thisField.brightness_ = channelValue;
+        thisField.brightness_ = channelValue;
         break;
     }
-    var colour = goog.color.hsvToHex(hsv[0], hsv[1], hsv[2]);
+    var colour = goog.color.hsvToHex(thisField.hue_, thisField.saturation_, thisField.brightness_);
     if (thisField.sourceBlock_) {
       // Call any validation function, and allow it to override.
       colour = thisField.callValidator(colour);


### PR DESCRIPTION
### Resolves

Resolves #2048
Resolves #1858
Resolves https://github.com/LLK/scratch-gui/issues/3985

### Proposed Changes

This PR changes the slider callbacks in `FieldColourSlider` to set the field's color based on the field's internal `hue_`, `saturation_`, and `brightness_` introduced in #1148, rather than converting the field's RGB hex color into HSV and using those values.

### Reason for Changes

If you convert an HSV color value into RGB, it's impossible to determine its hue if its saturation or brightness are 0. By converting the color field's stored RGB color back into HSV every time a slider is changed, the hue will thus be lost and reset to 0 every time the saturation or brightness sliders are dragged down to 0, and the saturation will be lost and reset to 0 when the brightness slider is 0 as well.

To avoid this, just use the HSV values already stored in the field, which are only reinitialized from RGB when the color picker is opened.

### Test Coverage

Tested manually
