### PR TITLE
Don't scroll workspace when clearing it upon reloading from XML

### DIFF
--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -2097,11 +2097,14 @@ Blockly.WorkspaceSvg.prototype.setToolboxRefreshEnabled = function(enabled) {
 
 /**
  * Dispose of all blocks in workspace, with an optimization to prevent resizes.
+ * @param {boolean} [resizeAfterwards=true] Whether the workspace should be resized after clearing.
  */
-Blockly.WorkspaceSvg.prototype.clear = function() {
-  this.setResizesEnabled(false);
+Blockly.WorkspaceSvg.prototype.clear = function(resizeAfterwards) {
+  // Default resizeAfterwards to true if not explicitly passed
+  resizeAfterwards = resizeAfterwards !== false;
+  if (resizeAfterwards) this.setResizesEnabled(false);
   Blockly.WorkspaceSvg.superClass_.clear.call(this);
-  this.setResizesEnabled(true);
+  if (resizeAfterwards) this.setResizesEnabled(true);
 };
 
 /**

--- a/core/xml.js
+++ b/core/xml.js
@@ -408,7 +408,9 @@ Blockly.Xml.textToDom = function(text) {
 Blockly.Xml.clearWorkspaceAndLoadFromXml = function(xml, workspace) {
   workspace.setResizesEnabled(false);
   workspace.setToolboxRefreshEnabled(false);
-  workspace.clear();
+  // If we clear the workspace and allow it to resize, the scroll position will be clamped around (0, 0)
+  // because the workspace will be empty when it is resized.
+  workspace.clear(false /* resizeAfterwards */);
   var blockIds = Blockly.Xml.domToWorkspace(xml, workspace);
   workspace.setResizesEnabled(true);
   workspace.setToolboxRefreshEnabled(true);


### PR DESCRIPTION
### Resolves

Resolves https://github.com/LLK/scratch-gui/issues/4615

(See also [this discussion on scratch-gui#4400](https://github.com/LLK/scratch-gui/issues/4400#issuecomment-462994133))

### Proposed Changes

This PR adds a parameter to `WorkspaceSvg.clear` that allows callers to specify whether the workspace should be resized afterwards. It defaults to true, meaning workspaces will be resized by default as they currently are.

When `clearWorkspaceAndLoadFromXml` calls `clear`, it will now tell it *not* to resize the workspace, however.

### Reason for Changes

`clearWorkspaceAndLoadFromXml` removes all items from the workspace and then places new ones into it. When doing this, the scroll position should be preserved.

However, `clear` would cause the scroll position to be reset by resizing the workspace after clearing it. This manifested as the workspace being scrolled back up to the top left every time it was reloaded from XML, as changing the menu in the "() of ()" block did.