### PR TITLE
Start a new event group when duplicating blocks

### DIFF
--- a/core/scratch_blocks_utils.js
+++ b/core/scratch_blocks_utils.js
@@ -217,6 +217,14 @@ Blockly.scratchBlocksUtils.duplicateAndDragCallback = function(oldBlock, event) 
       } finally {
         Blockly.Events.enable();
       }
+
+      // Start a new event group for the block creation + drag, so that one undo
+      // step will undo both the creation of the duplicated stack and its
+      // placement. endBlockDrag will later end this event group.
+      if (isMouseEvent) {
+        Blockly.Events.setGroup(true);
+      }
+
       if (Blockly.Events.isEnabled()) {
         Blockly.Events.fire(new Blockly.Events.BlockCreate(newBlock));
       }


### PR DESCRIPTION
### Resolves

Resolves #2089

### Proposed Changes

This PR starts a new event group inside `duplicateAndDragCallback` before creating the duplicated block stack.

### Reason for Changes

This will cause undo/redo to operate on both the creation and the placement of the duplicated stack in one step, rather than requiring the user to undo twice to undo both the movement of the duplicated stack and its creation.

### Test Coverage

Tested manually
