### PR TITLE
Use "python2 build.py" instead of "python build.py"

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "browser": "./shim/vertical.js",
   "scripts": {
     "deploy": "rimraf gh-pages/closure-library/scripts/ci/CloseAdobeDialog.exe && gh-pages -t -d gh-pages -m \"Build for $(git log --pretty=format:%H -n1)\"",
-    "prepublish": "python build.py && webpack",
+    "prepublish": "python2 build.py && webpack",
     "test:unit": "node tests/jsunit/test_runner.js",
     "test:lint": "eslint .",
     "test:messages": "npm run translate && node i18n/test_scratch_msgs.js",


### PR DESCRIPTION
I tried "npm install" and it failed. It turned out that it was because I was using nodeenv, and "python" was set to python3. Replacing "python build.py" with "python2 build.py" solved the problem. I don't think it should cause any trouble.

### Resolves

https://github.com/LLK/scratch-blocks/issues/2092

### Proposed Changes

Instead of running "python build.py", run "python2 build.py", so it will always be python2, instead of whatever "python" is.

### Reason for Changes

build.py only supports python2. When "python" is python3, running "python build.py" fails, while running "python2 build.py" succeeds.

### Test Coverage

None.
