### PR TITLE
Fix MoveEvent.oldCoordinate to be in language-agnostic position

### DIFF
--- a/core/block_dragger.js
+++ b/core/block_dragger.js
@@ -326,6 +326,7 @@ Blockly.BlockDragger.prototype.fireMoveEvent_ = function() {
   var event = new Blockly.Events.BlockMove(this.draggingBlock_);
   // The X position in the block move event should be the language agnostic
   // position of the block. I.e. it should not be different in LTR vs. RTL.
+  var workspace = Blockly.Workspace.getById(event.workspaceId);
   var rtlAwareX = workspace.RTL ? workspace.getWidth() - this.startXY_.x : this.startXY_.x;
   event.oldCoordinate = new goog.math.Coordinate(rtlAwareX, this.startXY_.y);
   event.recordNew();

--- a/core/block_dragger.js
+++ b/core/block_dragger.js
@@ -324,7 +324,10 @@ Blockly.BlockDragger.prototype.fireEndDragEvent_ = function(isOutside) {
  */
 Blockly.BlockDragger.prototype.fireMoveEvent_ = function() {
   var event = new Blockly.Events.BlockMove(this.draggingBlock_);
-  event.oldCoordinate = this.startXY_;
+  // The X position in the block move event should be the language agnostic
+  // position of the block. I.e. it should not be different in LTR vs. RTL.
+  var rtlAwareX = workspace.RTL ? workspace.getWidth() - this.startXY_.x : this.startXY_.x;
+  event.oldCoordinate = new goog.math.Coordinate(rtlAwareX, this.startXY_.y);
   event.recordNew();
   Blockly.Events.fire(event);
 };


### PR DESCRIPTION
### Resolves

https://github.com/LLK/scratch-blocks/issues/2094

### Proposed Changes

Make MoveEvent.oldCoordinate be in language-agnostic position of the block. I.e. it should not be different in LTR vs. RTL. This makes it compatible with MoveEvent.newCoordinate. This is the same calculation as in block_event.js:Blockly.Events.Move.prototype.currentLocation_, which is what calculates MoveEvent.newCoordinate.

### Reason for Changes

This fixes the attached issue, where dragging a block outside the area puts it in a wrong position, instead of in its source position.

### Test Coverage

I haven't added tests. With some guidance I can try to write a test.
