### PR TITLE
Separate variable and list categories

### DIFF
--- a/blocks_vertical/default_toolbox.js
+++ b/blocks_vertical/default_toolbox.js
@@ -518,11 +518,14 @@ Blockly.Blocks.defaultToolbox = '<xml id="toolbox-categories" style="display: no
       '</value>' +
     '</block>' +
   '</category>' +
-  '<category name="%{BKY_CATEGORY_VARIABLES}" id="variables" colour="#FF8C1A" secondaryColour="#DB6E00" custom="VARIABLE">' +
+  '<category name="%{BKY_CATEGORY_VARIABLES}" id="variables" colour="#FF8C1A" secondaryColour="#DB6E00" ' +
+    'custom="VARIABLE">' +
   '</category>' +
-  '<category name="%{BKY_CATEGORY_LISTS}" id="lists" colour="#FF661A" secondaryColour="#FF5500" custom="LIST">' +
+  '<category name="%{BKY_CATEGORY_LISTS}" id="lists" colour="#FF661A" secondaryColour="#FF5500" ' +
+    'custom="LIST">' +
   '</category>' +
-  '<category name="%{BKY_CATEGORY_MYBLOCKS}" id="more" colour="#FF6680" secondaryColour="#FF4D6A" custom="PROCEDURE">' +
+  '<category name="%{BKY_CATEGORY_MYBLOCKS}" id="more" colour="#FF6680" secondaryColour="#FF4D6A" ' +
+    'custom="PROCEDURE">' +
   '</category>' +
   '<category name="Extensions" id="extensions" colour="#FF6680" secondaryColour="#FF4D6A" ' +
     'iconURI="../media/extensions/wedo2-block-icon.svg" showStatusButton="true">' +

--- a/blocks_vertical/default_toolbox.js
+++ b/blocks_vertical/default_toolbox.js
@@ -518,7 +518,9 @@ Blockly.Blocks.defaultToolbox = '<xml id="toolbox-categories" style="display: no
       '</value>' +
     '</block>' +
   '</category>' +
-  '<category name="%{BKY_CATEGORY_VARIABLES}" id="data" colour="#FF8C1A" secondaryColour="#DB6E00" custom="VARIABLE">' +
+  '<category name="%{BKY_CATEGORY_VARIABLES}" id="variables" colour="#FF8C1A" secondaryColour="#DB6E00" custom="VARIABLE">' +
+  '</category>' +
+  '<category name="%{BKY_CATEGORY_LISTS}" id="lists" colour="#FF661A" secondaryColour="#FF5500" custom="LIST">' +
   '</category>' +
   '<category name="%{BKY_CATEGORY_MYBLOCKS}" id="more" colour="#FF6680" secondaryColour="#FF4D6A" custom="PROCEDURE">' +
   '</category>' +

--- a/core/constants.js
+++ b/core/constants.js
@@ -303,6 +303,14 @@ Blockly.VARIABLE_CATEGORY_NAME = 'VARIABLE';
 /**
  * String for use in the "custom" attribute of a category in toolbox xml.
  * This string indicates that the category should be dynamically populated with
+ * list blocks.
+ * @const {string}
+ */
+Blockly.LIST_CATEGORY_NAME = 'LIST';
+
+/**
+ * String for use in the "custom" attribute of a category in toolbox xml.
+ * This string indicates that the category should be dynamically populated with
  * procedure blocks.
  * @const {string}
  */

--- a/core/data_category.js
+++ b/core/data_category.js
@@ -25,9 +25,21 @@
 'use strict';
 
 /**
- * @name Blockly.DataCategory
+ * @name Blockly.VariableCategory
  * @namespace
  **/
+goog.provide('Blockly.VariableCategory');
+
+/**
+ * @name Blockly.ListCategory
+ * @namespace
+ */
+goog.provide('Blockly.ListCategory');
+
+/**
+ * @name Blockly.DataCategory
+ * @namespace
+ */
 goog.provide('Blockly.DataCategory');
 
 goog.require('Blockly.Blocks');
@@ -36,11 +48,16 @@ goog.require('Blockly.Variables');
 goog.require('Blockly.Workspace');
 
 /**
+ * No-op; used as namespace for utilities common across data categories.
+ */
+Blockly.DataCategory = function() {};
+
+/**
  * Construct the blocks required by the flyout for the variable category.
  * @param {!Blockly.Workspace} workspace The workspace containing variables.
  * @return {!Array.<!Element>} Array of XML block elements.
  */
-Blockly.DataCategory = function(workspace) {
+Blockly.VariableCategory = function(workspace) {
   var variableModelList = workspace.getVariablesOfType('');
   variableModelList.sort(Blockly.VariableModel.compareByName);
   var xmlList = [];
@@ -48,45 +65,56 @@ Blockly.DataCategory = function(workspace) {
   Blockly.DataCategory.addCreateButton(xmlList, workspace, 'VARIABLE');
 
   for (var i = 0; i < variableModelList.length; i++) {
-    Blockly.DataCategory.addDataVariable(xmlList, variableModelList[i]);
+    Blockly.VariableCategory.addDataVariable(xmlList, variableModelList[i]);
   }
 
   if (variableModelList.length > 0) {
     xmlList[xmlList.length - 1].setAttribute('gap', 24);
     var firstVariable = variableModelList[0];
 
-    Blockly.DataCategory.addSetVariableTo(xmlList, firstVariable);
-    Blockly.DataCategory.addChangeVariableBy(xmlList, firstVariable);
-    Blockly.DataCategory.addShowVariable(xmlList, firstVariable);
-    Blockly.DataCategory.addHideVariable(xmlList, firstVariable);
+    Blockly.VariableCategory.addSetVariableTo(xmlList, firstVariable);
+    Blockly.VariableCategory.addChangeVariableBy(xmlList, firstVariable);
+    Blockly.VariableCategory.addShowVariable(xmlList, firstVariable);
+    Blockly.VariableCategory.addHideVariable(xmlList, firstVariable);
   }
 
-  // Now add list variables to the flyout
-  Blockly.DataCategory.addCreateButton(xmlList, workspace, 'LIST');
-  variableModelList = workspace.getVariablesOfType(Blockly.LIST_VARIABLE_TYPE);
+  return xmlList;
+};
+
+/**
+ * Construct the blocks required by the flyout for the list category.
+ * @param {!Blockly.Workspace} workspace The workspace containing (list type) variables.
+ * @return {!Array.<!Element>} Array of XML block elements.
+ */
+Blockly.ListCategory = function(workspace) {
+  var variableModelList = workspace.getVariablesOfType(Blockly.LIST_VARIABLE_TYPE);
   variableModelList.sort(Blockly.VariableModel.compareByName);
+  var xmlList = [];
+
+  Blockly.DataCategory.addCreateButton(xmlList, workspace, 'LIST');
+
   for (var i = 0; i < variableModelList.length; i++) {
-    Blockly.DataCategory.addDataList(xmlList, variableModelList[i]);
+    Blockly.ListCategory.addDataList(xmlList, variableModelList[i]);
   }
 
   if (variableModelList.length > 0) {
     xmlList[xmlList.length - 1].setAttribute('gap', 24);
     var firstVariable = variableModelList[0];
 
-    Blockly.DataCategory.addAddToList(xmlList, firstVariable);
+    Blockly.ListCategory.addAddToList(xmlList, firstVariable);
     Blockly.DataCategory.addSep(xmlList);
-    Blockly.DataCategory.addDeleteOfList(xmlList, firstVariable);
-    Blockly.DataCategory.addDeleteAllOfList(xmlList, firstVariable);
-    Blockly.DataCategory.addInsertAtList(xmlList, firstVariable);
-    Blockly.DataCategory.addReplaceItemOfList(xmlList, firstVariable);
+    Blockly.ListCategory.addDeleteOfList(xmlList, firstVariable);
+    Blockly.ListCategory.addDeleteAllOfList(xmlList, firstVariable);
+    Blockly.ListCategory.addInsertAtList(xmlList, firstVariable);
+    Blockly.ListCategory.addReplaceItemOfList(xmlList, firstVariable);
     Blockly.DataCategory.addSep(xmlList);
-    Blockly.DataCategory.addItemOfList(xmlList, firstVariable);
-    Blockly.DataCategory.addItemNumberOfList(xmlList, firstVariable);
-    Blockly.DataCategory.addLengthOfList(xmlList, firstVariable);
-    Blockly.DataCategory.addListContainsItem(xmlList, firstVariable);
+    Blockly.ListCategory.addItemOfList(xmlList, firstVariable);
+    Blockly.ListCategory.addItemNumberOfList(xmlList, firstVariable);
+    Blockly.ListCategory.addLengthOfList(xmlList, firstVariable);
+    Blockly.ListCategory.addListContainsItem(xmlList, firstVariable);
     Blockly.DataCategory.addSep(xmlList);
-    Blockly.DataCategory.addShowList(xmlList, firstVariable);
-    Blockly.DataCategory.addHideList(xmlList, firstVariable);
+    Blockly.ListCategory.addShowList(xmlList, firstVariable);
+    Blockly.ListCategory.addHideList(xmlList, firstVariable);
   }
 
   return xmlList;
@@ -97,7 +125,7 @@ Blockly.DataCategory = function(workspace) {
  * @param {!Array.<!Element>} xmlList Array of XML block elements.
  * @param {?Blockly.VariableModel} variable Variable to select in the field.
  */
-Blockly.DataCategory.addDataVariable = function(xmlList, variable) {
+Blockly.VariableCategory.addDataVariable = function(xmlList, variable) {
   // <block id="variableId" type="data_variable">
   //    <field name="VARIABLE">variablename</field>
   // </block>
@@ -111,7 +139,7 @@ Blockly.DataCategory.addDataVariable = function(xmlList, variable) {
  * @param {!Array.<!Element>} xmlList Array of XML block elements.
  * @param {?Blockly.VariableModel} variable Variable to select in the field.
  */
-Blockly.DataCategory.addSetVariableTo = function(xmlList, variable) {
+Blockly.VariableCategory.addSetVariableTo = function(xmlList, variable) {
   // <block type="data_setvariableto" gap="20">
   //   <value name="VARIABLE">
   //    <shadow type="data_variablemenu"></shadow>
@@ -131,7 +159,7 @@ Blockly.DataCategory.addSetVariableTo = function(xmlList, variable) {
  * @param {!Array.<!Element>} xmlList Array of XML block elements.
  * @param {?Blockly.VariableModel} variable Variable to select in the field.
  */
-Blockly.DataCategory.addChangeVariableBy = function(xmlList, variable) {
+Blockly.VariableCategory.addChangeVariableBy = function(xmlList, variable) {
   // <block type="data_changevariableby">
   //   <value name="VARIABLE">
   //    <shadow type="data_variablemenu"></shadow>
@@ -151,7 +179,7 @@ Blockly.DataCategory.addChangeVariableBy = function(xmlList, variable) {
  * @param {!Array.<!Element>} xmlList Array of XML block elements.
  * @param {?Blockly.VariableModel} variable Variable to select in the field.
  */
-Blockly.DataCategory.addShowVariable = function(xmlList, variable) {
+Blockly.VariableCategory.addShowVariable = function(xmlList, variable) {
   // <block type="data_showvariable">
   //   <value name="VARIABLE">
   //     <shadow type="data_variablemenu"></shadow>
@@ -166,7 +194,7 @@ Blockly.DataCategory.addShowVariable = function(xmlList, variable) {
  * @param {!Array.<!Element>} xmlList Array of XML block elements.
  * @param {?Blockly.VariableModel} variable Variable to select in the field.
  */
-Blockly.DataCategory.addHideVariable = function(xmlList, variable) {
+Blockly.VariableCategory.addHideVariable = function(xmlList, variable) {
   // <block type="data_hidevariable">
   //   <value name="VARIABLE">
   //     <shadow type="data_variablemenu"></shadow>
@@ -181,7 +209,7 @@ Blockly.DataCategory.addHideVariable = function(xmlList, variable) {
  * @param {!Array.<!Element>} xmlList Array of XML block elements.
  * @param {?Blockly.VariableModel} variable Variable to select in the field.
  */
-Blockly.DataCategory.addDataList = function(xmlList, variable) {
+Blockly.ListCategory.addDataList = function(xmlList, variable) {
   // <block id="variableId" type="data_listcontents">
   //    <field name="LIST">variablename</field>
   // </block>
@@ -195,7 +223,7 @@ Blockly.DataCategory.addDataList = function(xmlList, variable) {
  * @param {!Array.<!Element>} xmlList Array of XML block elements.
  * @param {?Blockly.VariableModel} variable Variable to select in the field.
  */
-Blockly.DataCategory.addAddToList = function(xmlList, variable) {
+Blockly.ListCategory.addAddToList = function(xmlList, variable) {
   // <block type="data_addtolist">
   //   <field name="LIST" variabletype="list" id="">variablename</field>
   //   <value name="ITEM">
@@ -213,7 +241,7 @@ Blockly.DataCategory.addAddToList = function(xmlList, variable) {
  * @param {!Array.<!Element>} xmlList Array of XML block elements.
  * @param {?Blockly.VariableModel} variable Variable to select in the field.
  */
-Blockly.DataCategory.addDeleteOfList = function(xmlList, variable) {
+Blockly.ListCategory.addDeleteOfList = function(xmlList, variable) {
   // <block type="data_deleteoflist">
   //   <field name="LIST" variabletype="list" id="">variablename</field>
   //   <value name="INDEX">
@@ -231,7 +259,7 @@ Blockly.DataCategory.addDeleteOfList = function(xmlList, variable) {
  * @param {!Array.<!Element>} xmlList Array of XML block elements.
  * @param {?Blockly.VariableModel} variable Variable to select in the field.
  */
-Blockly.DataCategory.addDeleteAllOfList = function(xmlList, variable) {
+Blockly.ListCategory.addDeleteAllOfList = function(xmlList, variable) {
   // <block type="data_deletealloflist">
   //   <field name="LIST" variabletype="list" id="">variablename</field>
   // </block>
@@ -244,7 +272,7 @@ Blockly.DataCategory.addDeleteAllOfList = function(xmlList, variable) {
  * @param {!Array.<!Element>} xmlList Array of XML block elements.
  * @param {?Blockly.VariableModel} variable Variable to select in the field.
  */
-Blockly.DataCategory.addInsertAtList = function(xmlList, variable) {
+Blockly.ListCategory.addInsertAtList = function(xmlList, variable) {
   // <block type="data_insertatlist">
   //   <field name="LIST" variabletype="list" id="">variablename</field>
   //   <value name="INDEX">
@@ -267,7 +295,7 @@ Blockly.DataCategory.addInsertAtList = function(xmlList, variable) {
  * @param {!Array.<!Element>} xmlList Array of XML block elements.
  * @param {?Blockly.VariableModel} variable Variable to select in the field.
  */
-Blockly.DataCategory.addReplaceItemOfList = function(xmlList, variable) {
+Blockly.ListCategory.addReplaceItemOfList = function(xmlList, variable) {
   // <block type="data_replaceitemoflist">
   //   <field name="LIST" variabletype="list" id="">variablename</field>
   //   <value name="INDEX">
@@ -290,7 +318,7 @@ Blockly.DataCategory.addReplaceItemOfList = function(xmlList, variable) {
  * @param {!Array.<!Element>} xmlList Array of XML block elements.
  * @param {?Blockly.VariableModel} variable Variable to select in the field.
  */
-Blockly.DataCategory.addItemOfList = function(xmlList, variable) {
+Blockly.ListCategory.addItemOfList = function(xmlList, variable) {
   // <block type="data_itemoflist">
   //   <field name="LIST" variabletype="list" id="">variablename</field>
   //   <value name="INDEX">
@@ -307,7 +335,7 @@ Blockly.DataCategory.addItemOfList = function(xmlList, variable) {
  * @param {!Array.<!Element>} xmlList Array of XML block elements.
  * @param {?Blockly.VariableModel} variable Variable to select in the field.
  */
-Blockly.DataCategory.addItemNumberOfList = function(xmlList, variable) {
+Blockly.ListCategory.addItemNumberOfList = function(xmlList, variable) {
   // <block type="data_itemnumoflist">
   //   <value name="ITEM">
   //     <shadow type="text">
@@ -325,7 +353,7 @@ Blockly.DataCategory.addItemNumberOfList = function(xmlList, variable) {
  * @param {!Array.<!Element>} xmlList Array of XML block elements.
  * @param {?Blockly.VariableModel} variable Variable to select in the field.
  */
-Blockly.DataCategory.addLengthOfList = function(xmlList, variable) {
+Blockly.ListCategory.addLengthOfList = function(xmlList, variable) {
   // <block type="data_lengthoflist">
   //   <field name="LIST" variabletype="list" id="">variablename</field>
   // </block>
@@ -337,7 +365,7 @@ Blockly.DataCategory.addLengthOfList = function(xmlList, variable) {
  * @param {!Array.<!Element>} xmlList Array of XML block elements.
  * @param {?Blockly.VariableModel} variable Variable to select in the field.
  */
-Blockly.DataCategory.addListContainsItem = function(xmlList, variable) {
+Blockly.ListCategory.addListContainsItem = function(xmlList, variable) {
   // <block type="data_listcontainsitem">
   //   <field name="LIST" variabletype="list" id="">variablename</field>
   //   <value name="ITEM">
@@ -355,7 +383,7 @@ Blockly.DataCategory.addListContainsItem = function(xmlList, variable) {
  * @param {!Array.<!Element>} xmlList Array of XML block elements.
  * @param {?Blockly.VariableModel} variable Variable to select in the field.
  */
-Blockly.DataCategory.addShowList = function(xmlList, variable) {
+Blockly.ListCategory.addShowList = function(xmlList, variable) {
   // <block type="data_showlist">
   //   <field name="LIST" variabletype="list" id="">variablename</field>
   // </block>
@@ -367,7 +395,7 @@ Blockly.DataCategory.addShowList = function(xmlList, variable) {
  * @param {!Array.<!Element>} xmlList Array of XML block elements.
  * @param {?Blockly.VariableModel} variable Variable to select in the field.
  */
-Blockly.DataCategory.addHideList = function(xmlList, variable) {
+Blockly.ListCategory.addHideList = function(xmlList, variable) {
   // <block type="data_hidelist">
   //   <field name="LIST" variabletype="list" id="">variablename</field>
   // </block>

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -31,16 +31,17 @@ goog.provide('Blockly.WorkspaceSvg');
 goog.require('Blockly.Colours');
 goog.require('Blockly.ConnectionDB');
 goog.require('Blockly.constants');
-goog.require('Blockly.DataCategory');
 goog.require('Blockly.DropDownDiv');
 goog.require('Blockly.Events.BlockCreate');
 goog.require('Blockly.Gesture');
 goog.require('Blockly.Grid');
+goog.require('Blockly.ListCategory');
 goog.require('Blockly.Options');
 goog.require('Blockly.scratchBlocksUtils');
 goog.require('Blockly.ScrollbarPair');
 goog.require('Blockly.Touch');
 goog.require('Blockly.Trashcan');
+goog.require('Blockly.VariableCategory');
 //goog.require('Blockly.VerticalFlyout');
 goog.require('Blockly.Workspace');
 goog.require('Blockly.WorkspaceAudio');
@@ -112,7 +113,9 @@ Blockly.WorkspaceSvg = function(options, opt_blockDragSurface, opt_wsDragSurface
       new Blockly.Grid(options.gridPattern, options.gridOptions) : null;
 
   this.registerToolboxCategoryCallback(Blockly.VARIABLE_CATEGORY_NAME,
-      Blockly.DataCategory);
+      Blockly.VariableCategory);
+  this.registerToolboxCategoryCallback(Blockly.LIST_CATEGORY_NAME,
+      Blockly.ListCategory);
   this.registerToolboxCategoryCallback(Blockly.PROCEDURE_CATEGORY_NAME,
       Blockly.Procedures.flyoutCategory);
 };

--- a/msg/messages.js
+++ b/msg/messages.js
@@ -288,6 +288,7 @@ Blockly.Msg.CATEGORY_CONTROL = 'Control';
 Blockly.Msg.CATEGORY_SENSING = 'Sensing';
 Blockly.Msg.CATEGORY_OPERATORS = 'Operators';
 Blockly.Msg.CATEGORY_VARIABLES = 'Variables';
+Blockly.Msg.CATEGORY_LISTS = 'Lists';
 Blockly.Msg.CATEGORY_MYBLOCKS = 'My Blocks';
 
 // Context menus


### PR DESCRIPTION
### Resolves

This is a proof-of-concept pull request; it resolves #1874.

Follow-up pull request LLK/scratch-gui#6079 should be merged simultaneously so that the GUI reflects these changes as well.

### Proposed Changes

This PR takes the existing "Data"\* category and breaks up into two new ones: "Variables" and "Lists". Two new functions are added, `VariableCategory` and `ListCategory`. They are based upon the original function `DataCategory`, which has been kept as a no-op namespace for functions common across the two categories. There is also one new translation string, `Blockly.Msg.CATEGORY_LISTS`, whose English/default value is "Lists".

(\* today the Data category is shown in the flyout and toolbox category menu under the name under the name "Variables", but it contains both scalar variables and lists.)

### Reason for Changes

This pull request (as well as the follow-up GUI PR) exist as a proof of concept for the feature request, so that it can be tested in practice, so that there is an implementation ready to go if the feature is accepted, and to draw attention and discussion to the request in general.

As for the request itself: In projects including lots of (non-list) variables, it can be tiring to scroll all the way down the variable list just to access a block or two from the lists category. As a workaround, some have found it easier to scroll to the *following* category, My Blocks, and then scroll *up* to find the list blocks they are looking for. But this is an unnatural workaround, as categories are normally scrolled down, not up, and anyway are accessed by their button and not some odd workaround.

From a design perspective, the Lists "category" is in fact the only portion of the block palette which is distinctly colored from other blocks in the palette, and yet is not truly considered its own category: there is neither a "Lists" heading nor a button to jump to these blocks. Merging this quality of life change would have the extra benefit of getting rid of that unnecessary inconsistency.

Changing the categories in the flyout menu is a decision which historically hasn't been taken lightly; in fact, besides the "add extension" menu button new to 3.0, the menu has only changed *once*, during the transition from 1.4 to 2.0. But that change is worth considering, since it's actually analogous to this feature request. Specifically, the "Control" category of 1.4, which was so long it didn't typically fit in a single screen's worth of vertical space, was broken up into two categories: "Events" and "Control". They're similar categorizations that one could readily argue "worked fine" as a single category, yet in the end it was decided that they would be separate. So, we have to ask: *why?* - And, how do those reasons compare with this request?

There were probably two main reasons: the first, as a subjective way of teaching the fundamentals of the language better; the distinct categories highlight their difference, making it easier to both teach and learn how the two categories are uniquely useful. I think it's fair to say that as far as lists and variables go, people already regard the two as all but genuinely distinct categories; even the user interface colors the blocks different shades of orange-red. Breaking the categories up would assist educators and learners alike; the action of "scrolling to the list category" would no longer be a two-step motion requiring some workaround (like discussed above), and the formal recognition as separate would further encourage learners to explore the ways the two groupings of blocks are distinctly useful. (Though I don't have statistics on how often lists are used in projects as compared to variables, it is easier for inexperienced users to set aside a translucent "Make a List" button than to pretend an entire category altogether does not exist. In general, the presence of a distinct symbol for a feature (which cannot easily be mentally "set aside") has a tendency to eventually pique a user's interest, encouraging them to explore that feature. Changes like this have already been seen in Scratch, like in the newly highlighted add-extension button (present but woefully underutilized in 2.0), and in the animated pop-up menus for adding sprites, costumes, etc.)

The second reason is obviously directly related to this request: breaking the categories up means less time spent scrolling to frequently accessed blocks. This was an obvious reason for separating Events and Control, since both are fundamental parts of coding any Scratch project; possibly having to scroll down the palette, or if not then "visually scroll" with your eyes past a great variety of unrelated blocks, every time you wanted to access such simple structures as the "if" block, is really an unnecessary and flagrantly frustrating inconvenience. Lists (and data blocks in general) are less commonly used in projects than control blocks, so one could argue that this is less of a significant benefit than in that earlier category separation... but it's worth considering that one part of the reason people don't use lists may simply be that list blocks are inconveniently positioned in the palette, the inaccessibility a barrier of really internalizing that palette as a part of one's programming workflow. (That's on top of the basic lack of exposure, which, like discussed above, would be reaped inherently by breaking the large category up.)

So, at least from this discussion, the parallels between that past change and what is being proposed today would suggest that separating one category into two would be a precedented change based upon precedented reasoning. What are some reasons *against* this request, then? And, against all the above discussion, do they hold up?

The classic argument against making any addition to Scratch is based in the entire language and environment's design philosophy, "low floor, high ceiling, wide walls". Particularly, it's the "low floor" aspect which many feel warrants caution: "will adding this feature (i.e, a new visual or functional capability of the Scratch software or language) increase the apparent complexity that comes to using Scratch, so that inexperienced users are more likely to be intimidated and stop using Scratch?" Or, more simply, "will this scare away new users?"

It's a reasonable concern when adding something to a core part of the UI, like the flyout category menu. And, as discussed, adding a new category button *would* expose that part of the language to users old and new - so it's definitely possible new users will be exposed to stuff that confuses them. But I'd argue that, all things considered, it genuinely isn't that large of an addition. The new category button is sandwiched between the existing categories Variables and My Blocks at the very bottom of the palette, and purely visually, the color itself matches the surrounding buttons well enough. And the only additions to the content of the flyout itself is the heading for the Lists category, which I'd further argue only makes it *easier* to pay attention to approaching one category at a time - reducing the barrier of entry for both lists and variables.

A final argument would be that the only precedented case of modifying the category list has been during the transition from one major release to the next; shouldn't such another change be saved for the next major overhaul of the UI? But that's both impractical and contrary to 3.0's fundamental design: delaying at minimum several *years* an otherwise greenlit quality of life change would be tremendously frustrating for all who would benefit, and 3.0 was designed from the ground up as something to be developed incrementally, rather than designed and released all at once. As far as any are aware, there is at present no plan for a major reimplementation of the editor going forward. It follows that even core aspects of the UI, like the block palette, may not have reached their perfected or final form by the day of release; for an incremental project, design changes like this should always be considered within scope.

### Test Coverage

This has been tested manually (both in the scratch-blocks vertical playground and in the GUI alongside the follow-up PR): adding/removing/renaming variables/lists all still work, so does switching between sprites & retaining changes in the VM (tested through the GUI).

Also, existing projects were opened and tested in the GUI, and confirmed to still work.