### PR TITLE
removed unused travis-after-all package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6590,12 +6590,6 @@
         "should": "^13.0.0"
       }
     },
-    "travis-after-all": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/travis-after-all/-/travis-after-all-1.4.4.tgz",
-      "integrity": "sha1-xaOW8YQEr2NKZQV7LAcdpYkj5Js=",
-      "dev": true
-    },
     "tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "scratch-l10n": "^3.11.20210127015526",
     "selenium-webdriver": "^4.0.0-alpha.1",
     "transifex": "1.6.6",
-    "travis-after-all": "1.4.4",
     "uglifyjs-webpack-plugin": "^1.2.5",
     "webpack": "^4.22.0",
     "webpack-cli": "^3.1.1"


### PR DESCRIPTION
Follow-on to https://github.com/LLK/scratch-blocks/pull/2061 which removed use of travis-after-all

## Changes

Removes travis-after-all from package.json and package-lock.json