### PR TITLE
fix a typo in the Renovate config

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -2,7 +2,7 @@
   "extends": [
     "config:base",
     ":semanticCommits",
-    ":separateMultipleMajor"
+    ":separateMultipleMajorReleases"
   ],
   "timezone": "America/New_York",
 


### PR DESCRIPTION
### Proposed Changes

Tell Renovate to extend `:separateMultipleMajorReleases` instead of `:separateMultipleMajor`.

### Reason for Changes

The `:separateMultipleMajor` config does not exist. The config is called `:separateMultipleMajorReleases`, even though it sets the setting called `separateMultipleMajor`.

### Test Coverage

Unfortunately the Renovate config file validator did not catch this error, so I believe the only real way to test this is to merge it into the main development branch.
