### PR TITLE
Renovate: reduce PR SPAM

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -15,6 +15,11 @@
       "matchCurrentVersion": "!/^0/", // SemVer spec says pre-1.0.0 can make breaking changes at any time
       "matchUpdateTypes": ["minor", "patch"],
       "automerge": true
+    },
+    // Closure compiler & library releases are always "major" so separating them leads to PR SPAM
+    {
+      "matchPackageNames": ["google-closure-compiler", "google-closure-library"],
+      "separateMultipleMajor": false
     }
   ]
 }

--- a/renovate.json5
+++ b/renovate.json5
@@ -9,6 +9,10 @@
   // no limit on open Renovate PR count
   "prConcurrentLimit": 0,
 
+  // a package can be unpublished for up to 3 days, so wait 3 days before automerging from outside our org
+  // consider using merge confidence instead if/when that's supported: https://docs.renovatebot.com/merge-confidence/
+  "stabilityDays": 3,
+
   "packageRules": [
     // automerge minor & patch updates for most dependencies
     {
@@ -20,6 +24,11 @@
     {
       "matchPackageNames": ["google-closure-compiler", "google-closure-library"],
       "separateMultipleMajor": false
+    },
+    // Don't enforce stability days on our own packages
+    {
+      "matchSourceUrlPrefixes": ["https://github.com/LLK/"],
+      "stabilityDays": 0
     }
   ]
 }


### PR DESCRIPTION
### Proposed Changes

Two refinements to our Renovate configuration:
1. Don't publish a separate PR for every major version of `google-closure-*`
2. Set `stabilityDays` to 3 for all dependency packages outside of our organization

### Reason for Changes

1. The `google-closure-*` repositories publish every change as a "major" version bump, so using `separateMultipleMajor` for those packages leads to excessive open PRs.
2. NPM allows a package to be un-published for up to 72 hours (3 days) after its publication. Waiting for 3 "stability" days before automerging means that we won't update to a version that later becomes un-published. To avoid slowing down our own development process, exempt packages coming from our organization.

Renovate also measures what they call [merge confidence](https://docs.renovatebot.com/merge-confidence/), which is currently in beta. Once Renovate supports gating automerge on merge confidence, we should consider using that instead of `stabilityDays`.

### Test Coverage

These changes pass [`renovate-config-validator`](https://docs.renovatebot.com/reconfigure-renovate/#reconfigure-via-pr)