### PR TITLE
move {ex,im}ports-loader back to dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -799,8 +799,7 @@
     "amdefine": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
-      "dev": true
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
     },
     "ansi-escapes": {
       "version": "3.2.0",
@@ -1219,8 +1218,7 @@
     "big.js": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
-      "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==",
-      "dev": true
+      "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q=="
     },
     "binary-extensions": {
       "version": "1.13.1",
@@ -2313,8 +2311,7 @@
     "emojis-list": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
-      "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
-      "dev": true
+      "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
     },
     "end-of-stream": {
       "version": "1.4.4",
@@ -2584,7 +2581,6 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/exports-loader/-/exports-loader-0.6.3.tgz",
       "integrity": "sha1-V9x4kX9wm5byR/qR5ptVTIVQE8g=",
-      "dev": true,
       "requires": {
         "loader-utils": "0.2.x",
         "source-map": "0.1.x"
@@ -3612,7 +3608,6 @@
       "version": "0.6.5",
       "resolved": "https://registry.npmjs.org/imports-loader/-/imports-loader-0.6.5.tgz",
       "integrity": "sha1-rnRlMDHVnjezwvslRKxhrq41MKY=",
-      "dev": true,
       "requires": {
         "loader-utils": "0.2.x",
         "source-map": "0.1.x"
@@ -3934,8 +3929,7 @@
     "json5": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
-      "dev": true
+      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
     },
     "jsonfile": {
       "version": "4.0.0",
@@ -4002,7 +3996,6 @@
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
       "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
-      "dev": true,
       "requires": {
         "big.js": "^3.1.3",
         "emojis-list": "^2.0.0",
@@ -4246,6 +4239,7 @@
         "debug": "3.1.0",
         "diff": "3.3.1",
         "escape-string-regexp": "1.0.5",
+        "glob": "7.1.2",
         "growl": "1.10.3",
         "he": "1.1.1",
         "mkdirp": "0.5.1",
@@ -4256,6 +4250,19 @@
           "version": "2.11.0",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
           "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
+        },
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
         },
         "has-flag": {
           "version": "2.0.0",
@@ -4422,8 +4429,7 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-copy": {
       "version": "0.1.0",
@@ -5616,7 +5622,6 @@
       "version": "0.1.43",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
       "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
-      "dev": true,
       "requires": {
         "amdefine": ">=0.0.4"
       }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
     "translate:update": "npm run translate:sync:src && npm run translate:sync:translations"
   },
   "dependencies": {
+    "exports-loader": "0.6.3",
     "google-closure-library": "20190301.0.0",
+    "imports-loader": "0.6.5",
     "scratch-l10n": "3.13.20210713031546"
   },
   "devDependencies": {
@@ -34,12 +36,10 @@
     "copy-webpack-plugin": "4.6.0",
     "eslint": "4.19.1",
     "event-stream": "3.3.5",
-    "exports-loader": "0.6.3",
     "gh-pages": "0.12.0",
     "glob": "7.1.7",
     "google-closure-compiler": "20180402.0.0",
     "graceful-fs": "4.2.6",
-    "imports-loader": "0.6.5",
     "json": "9.0.4",
     "rimraf": "2.7.1",
     "selenium-webdriver": "4.0.0-beta.4",


### PR DESCRIPTION
### Proposed Changes

Move `exports-loader` and `imports-loader` from `devDependencies` back into `dependencies`.

### Reason for Changes

This fixes the `scratch-gui` build. Since we specify the unprocessed `shim/vertical.js` rather than the build output in `dist/web/` as the "browser" field in `package.json`, consumers of this module in a browser context (such as `scratch-gui`) will need these loaders at runtime or build time.

See #2613 for more info on this.