### PR TITLE
fix: d.setHighlighted is not a function

### DIFF
--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -920,7 +920,7 @@ Blockly.WorkspaceSvg.prototype.highlightBlock = function(id, opt_state) {
   if (opt_state === undefined) {
     // Unhighlight all blocks.
     for (var i = 0, block; block = this.highlightedBlocks_[i]; i++) {
-      block.setHighlighted(false);
+      block.setGlowBlock(false);
     }
     this.highlightedBlocks_.length = 0;
   }
@@ -934,7 +934,7 @@ Blockly.WorkspaceSvg.prototype.highlightBlock = function(id, opt_state) {
     } else if (this.highlightedBlocks_.indexOf(block) == -1) {
       this.highlightedBlocks_.push(block);
     }
-    block.setHighlighted(state);
+    block.setGlowBlock(state);
   }
 };
 


### PR DESCRIPTION
### Resolves

see #1723

when use `workspaceSvg.highlightBlock(blockId)` to highlight the block, it will throw a error:

> Uncaught TypeError: d.setHighlighted is not a function
    at Blockly.WorkspaceSvg.highlightBlock

here is a [demo](https://codepen.io/action-hong/pen/JjrrqbN)

**We know from the source code that `BlocklySvg` did not define `setHighlighted `**, so it will throw a error when invoke `Blockly.WorkspaceSvg.highlightBlock`

```js
Blockly.WorkspaceSvg.prototype.highlightBlock = function(id, opt_state) {
  if (opt_state === undefined) {
    // Unhighlight all blocks.
    for (var i = 0, block; block = this.highlightedBlocks_[i]; i++) {
      // setHighlighted is undefined
      block.setHighlighted(false);
    }
    this.highlightedBlocks_.length = 0;
  }
   ...
   // setHighlighted is undefined
    block.setHighlighted(state);
  }
};
```

### Proposed Changes

Here's a method `Blockly.BlockSvg.prototype.setGlowBlock`  that enables highlighting, so we can use this method instead of the setHighlighted:

```diff
Blockly.WorkspaceSvg.prototype.highlightBlock = function(id, opt_state) {
  if (opt_state === undefined) {
    // Unhighlight all blocks.
    for (var i = 0, block; block = this.highlightedBlocks_[i]; i++) {
-      block.setHighlighted(false);
+     block.setGlowBlock(false);
    }
    this.highlightedBlocks_.length = 0;
  }
   ...
-    block.setHighlighted(state);
+   block.setGlowBlock(state);
  }
};
```

