### PR TITLE
ENA-136 Fix context menu closing on the same right-click which opened it

### DIFF
--- a/core/contextmenu.js
+++ b/core/contextmenu.js
@@ -30,6 +30,8 @@
  */
 goog.provide('Blockly.ContextMenu');
 
+goog.provide('Blockly.ContextMenuItem');
+
 goog.require('Blockly.Events.BlockCreate');
 goog.require('Blockly.scratchBlocksUtils');
 goog.require('Blockly.utils');
@@ -96,28 +98,16 @@ Blockly.ContextMenu.populate_ = function(options, rtl) {
   var menu = new goog.ui.Menu();
   menu.setRightToLeft(rtl);
   for (var i = 0, option; option = options[i]; i++) {
-    var menuItem = new goog.ui.MenuItem(option.text);
+    // Use a custom class for the menu item instance. This is a subclass of
+    // goog.ui.MenuItem and has all the same behavior as usual, with minor
+    // tweaks for use in Blockly (and Scratch Blocks).
+    var menuItem = new Blockly.ContextMenuItem(option.text);
     menuItem.setRightToLeft(rtl);
     menu.addChild(menuItem, true);
     menuItem.setEnabled(option.enabled);
     if (option.enabled) {
       goog.events.listen(
           menuItem, goog.ui.Component.EventType.ACTION, option.callback);
-      menuItem.handleContextMenu = function(e) {
-        // Right-clicking on menu option should count as a click.
-        // Call handleMouseUp() so the intended code paths for handling a click
-        // are reached.
-        this.handleMouseUp(e);
-      };
-      menuItem.handleMouseDown = function(e) {
-        // Menu options only respond to left clicking (browser action button).
-        // Override the event to let right clicking work too.
-        e.isMouseActionButton = function() {
-          return this.isButton(goog.events.BrowserEvent.MouseButton.LEFT) ||
-            this.isButton(goog.events.BrowserEvent.MouseButton.RIGHT);
-        };
-        goog.ui.MenuItem.base(this, 'handleMouseDown', e);
-      };
     }
   }
   return menu;
@@ -149,20 +139,6 @@ Blockly.ContextMenu.position_ = function(menu, e, rtl) {
   if (rtl) {
     Blockly.utils.uiMenu.adjustBBoxesForRTL(viewportBBox, anchorBBox, menuSize);
   }
-
-  // Closure Library menu code includes a fix for a bug where a menu option
-  // will respond to the event which was responsible for showing the menu in
-  // the first place.  This fix compares the coordinates of the first mouseup
-  // event with those of the event which created it (made the menu visible).
-  // We can only take advantage of the fix if we specifically provide the
-  // mouse event to the menu, even if we don't otherwise have any reason to
-  // call setVisible (as the menu defaults to visible anyway).
-  // See issue #2085.
-  menu.setVisible(
-    true, // this menu is visible (this is the default anyway)
-    true, // "force" the value and don't emit SHOW & AFTER_SHOW events (avoid side effects)
-    e // provide mouse event so menu.openingCoords gets set (used for the Closure Library fix)
-  );
 
   Blockly.WidgetDiv.positionWithAnchor(viewportBBox, anchorBBox, menuSize, rtl);
   // Calling menuDom.focus() has to wait until after the menu has been placed
@@ -542,3 +518,20 @@ Blockly.ContextMenu.workspaceCommentOption = function(ws, e) {
 };
 
 // End helper functions for creating context menu options.
+
+
+Blockly.ContextMenuItem = function(content) {
+  Blockly.ContextMenuItem.superClass_.constructor.call(this, content);
+};
+goog.inherits(Blockly.ContextMenuItem, goog.ui.MenuItem);
+
+Blockly.ContextMenuItem.prototype.handleMouseDown = function(e) {
+  // Menu options only respond to left clicking (browser action button).
+  // Override the event to let right clicking work too.
+  e.isMouseActionButton = function() {
+    return this.isButton(goog.events.BrowserEvent.MouseButton.LEFT) ||
+      this.isButton(goog.events.BrowserEvent.MouseButton.RIGHT);
+  };
+
+  Blockly.ContextMenuItem.superClass_.handleMouseDown.call(this, e);
+};


### PR DESCRIPTION
### Resolves

Fixes #2085.

### Proposed Changes

**See updated: https://github.com/LLK/scratch-blocks/pull/2834#issuecomment-1217276388.** Original below:

> *[Closure Library already handles the difficult work (keeping track of coordinates).](https://github.com/google/closure-library/commit/afff9cd4e84c38234b24bd72f6d7a2c396ab09fc) This PR changes `handleContextMenu` so that it accesses the same code paths as normal mouse-ups (where the fix is located in Closure) and provides a supporting override which makes right-clicks "count" as the browser action button in this context. It also provides the mouse event which was responsible for creating the menu directly to the menu, which is required for the Closure Library fix to work.*

### Reason for Changes

**See updated: https://github.com/LLK/scratch-blocks/pull/2834#issuecomment-1217276388.** Original below:

> *It's preferable to make use of a fix which was already implemented as part of the library we use, rather than to re-create a similar fix from scratch. The fix in Closure Library includes an automated unit test and was developed professionally (according to Google's standards for Closure Library).*
>
> *Thus, this pull request opts to ensure scratch-blocks accesses the code paths Closure Library expects to be working with.*
>
> *Initially I thought it would be enough to simply set call `menu.setVisible(true, true, e)`, ensuring Closure has access to the event which spawned the context menu (which is all it needs to perform its own fix). Unfortunately in practice, this wasn't enough, as the scratch-blocks code responsible for handling context menus wasn't even reaching the normal code paths in the first place—it was just directly emitting the `ACTION` event, bypassing all particular behavior Closure Library provides. (I feel it's fair to describe this as a "hack", as although it's effective, we probably shouldn't be deliberately skipping any code our UI framework specifically includes to make behavior more nuanced.)*
>
> *So I changed the existing `handleContextMenu` override to instead treat the context menu click as a normal mouse-up event. This almost worked, but the code which decides whether or not to perform an action specifically checks if the event was an "action" button, i.e. a left-click (and without ctrl pressed on Mac). I overrode this function (on the single involved mouse event only) so that all left and right clicks would count as "action" buttons (middle click is still ignored though!).*
>
> *See a full technical summary here if wanted: https://github.com/LLK/scratch-blocks/issues/2085#issuecomment-1160956117*

### Test Coverage

First I created a reliable repro case which works in `tests/vertical_playground.html` to make testing easier:

* Create a lot of variables. You can [import from this XML](https://gist.github.com/towerofnix/d4fdf57a724a5edf5c6ffb7750b0df9c) to make this step quicker.
* Drag out a variable block and position it near the far right edge of the viewport. Vertically it can be basically anywhere (as long as your display isn't super tall)—within the upper half of the display (~1000px) is reliable in this repro.
* Right click the variable.
* The variable should be immediately replaced with a variable of another name with the context menu never made visible.

In the end I tested this manually:

* Old intended behavior is retained.
  * Left clicking activates the menu option.
  * Right clicking activates the menu option.
  * Middle clicking does not activate the menu option.
* This fixes the bug!
  * Above repro case does not close the menu and perform an action immediately.
  * Menu appears and then has no further behavior until the next click.

~~We also get a free [actual unit test](https://github.com/google/closure-library/blob/8f2a4aaa33b31bb8aa07dccb7e33ab67dc756b8b/closure/goog/ui/menuitem_test.js#L641-L651) right from Closure Library!~~