### PR TITLE
Update operators.js

### DIFF
--- a/blocks_vertical/operators.js
+++ b/blocks_vertical/operators.js
@@ -468,3 +468,17 @@ Blockly.Blocks['operator_mathop'] = {
     });
   }
 };
+
+Blockly.Blocks['operator_tofixed'] = {
+  "message0": Blockly.Msg.OPERATORS_TOFIXED,
+  "args0": [
+    {
+      "type": "input_value",
+      "name": "NUM1",
+    },
+    {
+      "type": "input_value",
+      "name": "NUM2",
+    }
+  ]
+}


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

### Proposed Changes

_Describe what this Pull Request does_
This Pull Request adds a toFixed block to fix decimals to a certain number in any case that are variables, or regular numerical inputs.

### Reason for Changes

_Explain why these changes should be made_
These changes are to be made so that users do not have to make their toFixed workarounds due to the limitations of not having a toFixed block built into Scratch.

### Test Coverage

_Please show how you have added tests to cover your changes_
This was mainly tested as a custom extension that I made that includes this new block on PenguinMod to confirm that it works as intended, do note that when developing this block, do not return the fixed decimal as a float value, it breaks it, I found this out the hard way.