### PR TITLE
Fix collapse when creating a custom procedure with % in label

### DIFF
--- a/blocks_vertical/procedures.js
+++ b/blocks_vertical/procedures.js
@@ -572,7 +572,7 @@ Blockly.ScratchBlocks.ProcedureUtils.updateDeclarationProcCode_ = function() {
     }
     var input = this.inputList[i];
     if (input.type == Blockly.DUMMY_INPUT) {
-      this.procCode_ += input.fieldRow[0].getValue();
+      this.procCode_ += input.fieldRow[0].getValue().replace('%', '\\%');
     } else if (input.type == Blockly.INPUT_VALUE) {
       // Inspect the argument editor.
       var target = input.connection.targetBlock();


### PR DESCRIPTION
### Resolves

- #2107
- #1368 

### Proposed Changes

Add a escape for `%` when adding a label in procedure declaration block.

### Reason for Changes

This pull request fixed the collapse when creating a custom procedure with `%` in a label. In the function `Blockly.ScratchBlocks.ProcedureUtils.updateDeclarationProcCode_`, I add escape for `%` when adding a label to ensure all `%`s in label should be `\%` in procCode, because Scratch treats `\%` in procCode as a escape of `%`. (see [blocks_vertical/procedures.js#L207](https://github.com/scratchfoundation/scratch-blocks/blob/6df15928d23928443cbed1685995ccee47defdee/blocks_vertical/procedures.js#L207))

### Test Coverage

None.
