### PR TITLE
fix: properly escape "%" in procCode

### DIFF
--- a/blocks_vertical/procedures.js
+++ b/blocks_vertical/procedures.js
@@ -572,7 +572,7 @@ Blockly.ScratchBlocks.ProcedureUtils.updateDeclarationProcCode_ = function() {
     }
     var input = this.inputList[i];
     if (input.type == Blockly.DUMMY_INPUT) {
-      this.procCode_ += input.fieldRow[0].getValue();
+      this.procCode_ += input.fieldRow[0].getValue().replaceAll('%', '\\%');
     } else if (input.type == Blockly.INPUT_VALUE) {
       // Inspect the argument editor.
       var target = input.connection.targetBlock();


### PR DESCRIPTION
### Resolves

Fixes #1368.

### Proposed Changes

This PR updates adds escaping logic for "%" in procedure procCodes.

Users can now create procedures with "%s" in the name.