### PR TITLE
docs: add Windows build instructions, WSL recommendation, Node version requirements, and troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,109 @@ npm install -g commitizen@latest cz-conventional-changelog@latest
 ```
 
 Now you're ready to make commits using `git cz`.
+
+## Building Scratch Blocks on Windows (Known Issues & Workarounds)
+
+Scratch Blocks uses an older build pipeline based on the Google Closure Compiler, Python 2, and Node.js v10.
+Because of this, building on Windows is known to fail due to OS command-length limits and deprecated tooling.
+
+## Common Windows Errors
+
+You may encounter:
+
+```bash
+The command line is too long
+```
+
+or: 
+
+```bash
+Module not found: Error: Can't resolve '../blockly_compressed_horizontal'
+```
+
+These issues are caused by:
+- Windows’ 8191-character command length limit
+- Deprecated Closure Compiler dependencies
+- Python 2 syntax in build.py
+- Incompatibility with modern Node.js versions
+- Differences in Windows path handling
+
+Related issue:  
+**[#2080: Some build steps fail with "The command line is too long"](https://github.com/LLK/scratch-blocks/issues/2080)**
+
+
+## Recommended: Build Using WSL 2 (Windows Subsystem for Linux)
+
+For Windows users, the Scratch development team and community highly recommend using WSL 2.
+This avoids Windows path limitations and provides a Linux-compatible build environment.
+
+### Steps to Build Using WSL 2
+
+1. Install WSL:
+```powershell
+wsl --install
+```
+2. Launch Ubuntu (WSL)
+3. Install Node.js v10 inside WSL:
+```bash
+curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
+sudo apt install -y nodejs
+```
+4. Install Python 2 (required for build.py).
+Ubuntu 24.04 removed Python 2, so install it using pyenv:
+```bash
+curl https://pyenv.run | bash
+pyenv install 2.7.18
+pyenv local 2.7.18
+```
+5. Install dependencies:
+```bash
+npm install
+```
+6. Build:
+```bash
+python2 build.py
+npm run prepublish
+```
+This method avoids all Windows-specific build errors.
+
+## Node.js Version Requirements
+
+Scratch Blocks requires Node.js 8–10.
+Newer versions (12, 14, 16, 18+) will fail due to incompatible build tooling.
+
+Check your Node version:
+```bash
+node -v
+```
+
+## Python Requirement (Python 2 Only)
+
+The build.py script relies on Python 2 syntax and older regex patterns.
+Running it under Python 3 may show warnings such as:
+
+```bash
+SyntaxWarning: invalid escape sequence
+```
+
+Install Python 2 using pyenv:
+```bash
+Install Python 2 using pyenv:
+```
+
+## Troubleshooting (For Windows)
+
+❗ “The command line is too long”
+
+Occurs only on Windows.
+Solution: Build using WSL 2.
+
+❗ Missing blockly_compressed_horizontal.js or vertical.js
+
+Caused by outdated Closure Compiler behavior on Windows.
+Solution: Use WSL 2.
+
+❗ Deprecation warnings during npm install
+
+Expected — scratch-blocks uses legacy dependencies.
+These warnings do not affect functionality inside WSL.


### PR DESCRIPTION
### Summary

This PR improves the README by adding clear, detailed documentation for Windows users who experience build failures when running `npm install` or `python build.py`.

Building scratch-blocks currently fails on native Windows due to long command-line limits, deprecated Closure Compiler tooling, Python 2 syntax, and modern Node.js incompatibilities. These issues are well-documented but not yet mentioned in the README.

### What This PR Adds

- A new section: **Building Scratch Blocks on Windows (Known Issues & Workarounds)**
- Recommended workflow using **WSL 2**
- **Node.js 8–10 requirement**
- **Python 2 requirement** (`build.py` uses Python 2 syntax)
- Step-by-step instructions to build inside WSL 2
- Troubleshooting section for common Windows errors
- Reference to **Issue #2080** (“The command line is too long”)

### Why This Is Needed

Many contributors on Windows encounter errors like:

```bash
The command line is too long
UNKNOWN ERROR
Module not found: Error: Can't resolve '../blockly_compressed_horizontal'
```

These issues are still present and reproducible.  
Adding this documentation helps developers avoid failed builds and guides them toward the officially recommended WSL workflow.

### Related Issues

- Documents the problem reported in 
  https://github.com/LLK/scratch-blocks/issues/2080

### Notes

This PR does *not* modify any existing information — it only appends new documentation sections that help Windows users build the project successfully.
