### PR TITLE
Connection highlight fixes

### DIFF
--- a/src/renderer/constants.ts
+++ b/src/renderer/constants.ts
@@ -54,6 +54,53 @@ export class ConstantProvider extends Blockly.zelos.ConstantProvider {
     super.setTheme(theme);
   }
 
+  /**
+   * Returns the shape for the given connection.
+   *
+   * For OUTPUT_VALUE connections, the block's explicit output shape takes
+   * priority (e.g. a Boolean reporter gets a hexagonal output connector).
+   * For INPUT_VALUE connections, we use only the connection's type checks so
+   * that input slots inside a Boolean reporter (like `<a = b>`) are still
+   * drawn with the rounded shape that matches what they accept, not the
+   * hexagonal shape of their parent block's output.
+   */
+  override shapeFor(connection: Blockly.RenderedConnection) {
+    let checks = connection.getCheck();
+    if (!checks && connection.targetConnection) {
+      checks = connection.targetConnection.getCheck();
+    }
+
+    if (connection.type === Blockly.ConnectionType.OUTPUT_VALUE) {
+      const outputShape = connection.getSourceBlock().getOutputShape();
+      if (outputShape !== null) {
+        switch (outputShape) {
+          case this.SHAPES.HEXAGONAL:
+            return this.HEXAGONAL;
+          case this.SHAPES.ROUND:
+            return this.ROUNDED;
+          case this.SHAPES.SQUARE:
+            return this.SQUARED;
+        }
+      }
+    }
+
+    // For INPUT_VALUE (and OUTPUT_VALUE fallthrough), use connection checks.
+    if (checks?.includes("Boolean")) return this.HEXAGONAL;
+    if (checks?.includes("Number")) return this.ROUNDED;
+    if (checks?.includes("String")) return this.ROUNDED;
+    // For INPUT_VALUE or OUTPUT_VALUE with unrecognized checks, default to
+    // ROUNDED. Don't call super.shapeFor() here: the base implementation
+    // uses getSourceBlock().getOutputShape(), which would incorrectly return
+    // HEXAGONAL for inputs inside Boolean reporters (e.g. `<a = b>`).
+    if (
+      connection.type === Blockly.ConnectionType.INPUT_VALUE ||
+      connection.type === Blockly.ConnectionType.OUTPUT_VALUE
+    ) {
+      return this.ROUNDED;
+    }
+    return super.shapeFor(connection);
+  }
+
   override createDom(svg: SVGElement, tagName: string, selector: string) {
     super.createDom(svg, tagName, selector);
     this.selectedGlowFilterId = "";

--- a/src/renderer/drawer.ts
+++ b/src/renderer/drawer.ts
@@ -60,4 +60,45 @@ export class Drawer extends Blockly.zelos.Drawer {
       return this.constants_.makeBowlerHatPath(this.info_.width);
     }
   }
+
+  /**
+   * Draw the connection highlight path for the given connection measurable.
+   *
+   * For rounded (non-hexagonal) input slots we expand the outline by 1px in
+   * every direction so the white highlight stroke sits just outside the input
+   * slot's background and remains visible rather than merging with it.
+   */
+  override drawConnectionHighlightPath(
+    measurable: Blockly.blockRendering.Connection
+  ) {
+    const conn = measurable.connectionModel;
+    if (
+      conn.type === Blockly.ConnectionType.INPUT_VALUE &&
+      measurable.isDynamicShape
+    ) {
+      const input = measurable as Blockly.blockRendering.InlineInput;
+      const EXPAND_X = 0.5;
+      const EXPAND_Y = 2;
+      const xPos = input.connectionWidth - EXPAND_X;
+      const yPos = -input.height / 2 - EXPAND_Y;
+      const width = input.width - input.connectionWidth * 2 + 2 * EXPAND_X;
+      const height = input.height + 2 * EXPAND_Y;
+      const shape = input.shape as Blockly.blockRendering.DynamicShape;
+      const path =
+        Blockly.utils.svgPaths.moveTo(xPos, yPos) +
+        Blockly.utils.svgPaths.lineOnAxis("h", width) +
+        shape.pathRightDown(height) +
+        Blockly.utils.svgPaths.lineOnAxis("h", -width) +
+        shape.pathUp(height) +
+        "z";
+      const block = conn.getSourceBlock();
+      return block.pathObject.addConnectionHighlight?.(
+        conn,
+        path,
+        conn.getOffsetInBlock(),
+        block.RTL
+      );
+    }
+    return super.drawConnectionHighlightPath(measurable);
+  }
 }

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -77,8 +77,7 @@ export class ScratchRenderer extends Blockly.zelos.Renderer {
    */
   override shouldHighlightConnection(connection: Blockly.RenderedConnection): boolean {
     return (
-      connection.type === Blockly.ConnectionType.INPUT_VALUE &&
-      connection.getCheck()?.includes("Boolean")
+      connection.type === Blockly.ConnectionType.INPUT_VALUE
     );
   }
 }


### PR DESCRIPTION
### Proposed Changes

Several changes to connection highlights:
- Make sure connection highlights appear regardless of the input type
- Base the shape of a connection highlight on the shape of the input
- Slightly increase the size of connection highlights such that a thin border of the block is visible between the input and the highlight

### Reason for Changes

These changes make connection highlights look and behave more like the current production version of Scratch.
