### PR TITLE
fix: enable TS strict mode, add checks

### DIFF
--- a/src/block_reporting.ts
+++ b/src/block_reporting.ts
@@ -5,8 +5,8 @@ export function reportValue(id: string, value: string) {
   const block = (Blockly.getMainWorkspace().getBlockById(id) ||
     (Blockly.getMainWorkspace() as Blockly.WorkspaceSvg)
       .getFlyout()
-      .getWorkspace()
-      .getBlockById(id)) as Blockly.BlockSvg;
+      ?.getWorkspace()
+      ?.getBlockById(id)) as Blockly.BlockSvg;
   if (!block) {
     throw "Tried to report value on block that does not exist.";
   }

--- a/src/blocks/control.ts
+++ b/src/blocks/control.ts
@@ -179,8 +179,15 @@ Blockly.Blocks["control_stop"] = {
           [Blockly.Msg.CONTROL_STOP_OTHER, OTHER_SCRIPTS],
         ];
       },
-      function (option) {
-        this.getSourceBlock().setNextStatement(option === OTHER_SCRIPTS);
+      function (this: Blockly.FieldDropdown, option: string) {
+        const sourceBlock = this.getSourceBlock();
+        if (sourceBlock) {
+          sourceBlock.setNextStatement(option === OTHER_SCRIPTS);
+        } else {
+          console.warn(
+            "control_stop dropdown callback: source block not found"
+          );
+        }
         return option;
       }
     );

--- a/src/blocks/data.ts
+++ b/src/blocks/data.ts
@@ -499,9 +499,18 @@ const CUSTOM_CONTEXT_MENU_GET_VARIABLE_MIXIN = {
     if (this.isCollapsed()) {
       return;
     }
-    const currentVarName = (this.getField(fieldName) as ScratchFieldVariable)
-      .getVariable()
-      .getName();
+    const currentVariable = (this.getField(fieldName) as ScratchFieldVariable)
+      .getVariable();
+    if (!currentVariable) {
+      console.warn(
+        "contextMenu_getVariableBlock: no variable found for field",
+        fieldName,
+        "on block",
+        this.type
+      );
+      return;
+    }
+    const currentVarName = currentVariable.getName();
     if (!this.isInFlyout) {
       this.workspace
         .getVariablesOfType(Constants.SCALAR_VARIABLE_TYPE)
@@ -568,9 +577,18 @@ const CUSTOM_CONTEXT_MENU_GET_LIST_MIXIN = {
     if (this.isCollapsed()) {
       return;
     }
-    const currentVarName = (this.getField(fieldName) as ScratchFieldVariable)
-      .getVariable()
-      .getName();
+    const currentVariable = (this.getField(fieldName) as ScratchFieldVariable)
+      .getVariable();
+    if (!currentVariable) {
+      console.warn(
+        "contextMenu_getListBlock: no list variable found for field",
+        fieldName,
+        "on block",
+        this.type
+      );
+      return;
+    }
+    const currentVarName = currentVariable.getName();
     if (!this.isInFlyout) {
       this.workspace
         .getVariablesOfType(Constants.LIST_VARIABLE_TYPE)
@@ -635,6 +653,7 @@ const VARIABLE_OPTION_CALLBACK_FACTORY = function (
     const variableField = block.getField(fieldName);
     if (!variableField) {
       console.log("Tried to get a variable field on the wrong type of block.");
+      return;
     }
     variableField.setValue(id);
   };
@@ -677,6 +696,15 @@ const DELETE_OPTION_CALLBACK_FACTORY = function (
     const variable = (
       block.getField(fieldName) as ScratchFieldVariable
     ).getVariable();
+    if (!variable) {
+      console.warn(
+        "DELETE_OPTION_CALLBACK_FACTORY: no variable to delete for field",
+        fieldName,
+        "on block",
+        block.type
+      );
+      return;
+    }
     Blockly.Variables.deleteVariable(variable.getWorkspace(), variable, block);
   };
 };

--- a/src/blocks/procedures.ts
+++ b/src/blocks/procedures.ts
@@ -33,7 +33,7 @@ type ConnectionMap = {
   [key: string]: {
     shadow: Element;
     block: Blockly.BlockSvg;
-  };
+  } | null;
 };
 
 /**
@@ -68,6 +68,14 @@ class DuplicateOnDragDraggable implements Blockly.IDraggable {
    */
   startDrag(e: PointerEvent) {
     const data = this.block.toCopyData();
+    if (!data) {
+      console.warn(
+        "DuplicateOnDragDraggable.startDrag: failed to serialize block for copy",
+        this.block.type,
+        this.block.id
+      );
+      return;
+    }
     this.copy = Blockly.clipboard.paste(
       data,
       this.block.workspace
@@ -76,9 +84,19 @@ class DuplicateOnDragDraggable implements Blockly.IDraggable {
   }
 
   drag(newLoc: Blockly.utils.Coordinate, e?: PointerEvent) {
-    (
-      this.block.workspace.getGesture(e).getCurrentDragger() as ScratchDragger
-    ).setDraggable(this.copy);
+    const gesture = this.block.workspace.getGesture(e);
+    if (!gesture || !this.copy) {
+      console.warn(
+        "DuplicateOnDragDraggable.drag: missing gesture or copied block",
+        {
+          hasGesture: Boolean(gesture),
+          hasCopy: Boolean(this.copy),
+          blockId: this.block.id,
+        }
+      );
+      return;
+    }
+    (gesture.getCurrentDragger() as ScratchDragger).setDraggable(this.copy);
     this.copy.drag(newLoc, e);
   }
 
@@ -120,12 +138,12 @@ function callerMutationToDom(this: ProcedureCallBlock): Element {
  * @param xmlElement XML storage element.
  */
 function callerDomToMutation(this: ProcedureCallBlock, xmlElement: Element) {
-  this.procCode_ = xmlElement.getAttribute("proccode");
+  this.procCode_ = xmlElement.getAttribute("proccode")!;
   this.generateShadows_ = JSON.parse(
-    xmlElement.getAttribute("generateshadows")
+    xmlElement.getAttribute("generateshadows")!
   );
-  this.argumentIds_ = JSON.parse(xmlElement.getAttribute("argumentids"));
-  this.warp_ = JSON.parse(xmlElement.getAttribute("warp"));
+  this.argumentIds_ = JSON.parse(xmlElement.getAttribute("argumentids")!);
+  this.warp_ = JSON.parse(xmlElement.getAttribute("warp")!);
   this.updateDisplay_();
 }
 
@@ -167,16 +185,16 @@ function definitionDomToMutation(
   this: ProcedurePrototypeBlock | ProcedureDeclarationBlock,
   xmlElement: Element
 ) {
-  this.procCode_ = xmlElement.getAttribute("proccode");
-  this.warp_ = JSON.parse(xmlElement.getAttribute("warp"));
+  this.procCode_ = xmlElement.getAttribute("proccode")!;
+  this.warp_ = JSON.parse(xmlElement.getAttribute("warp")!);
 
   const prevArgIds = this.argumentIds_;
   const prevDisplayNames = this.displayNames_;
 
-  this.argumentIds_ = JSON.parse(xmlElement.getAttribute("argumentids"));
-  this.displayNames_ = JSON.parse(xmlElement.getAttribute("argumentnames"));
+  this.argumentIds_ = JSON.parse(xmlElement.getAttribute("argumentids")!);
+  this.displayNames_ = JSON.parse(xmlElement.getAttribute("argumentnames")!);
   this.argumentDefaults_ = JSON.parse(
-    xmlElement.getAttribute("argumentdefaults")
+    xmlElement.getAttribute("argumentdefaults")!
   );
   this.updateDisplay_();
   if ("updateArgumentReporterNames_" in this) {
@@ -224,7 +242,7 @@ function disconnectOldBlocks_(this: ProcedureBlock): ConnectionMap {
     if (input.connection) {
       const target = input.connection.targetBlock() as Blockly.BlockSvg;
       const saveInfo = {
-        shadow: input.connection.getShadowDom(true),
+        shadow: input.connection.getShadowDom(true) as Element,
         block: target,
       };
       connectionMap[input.name] = saveInfo;
@@ -420,7 +438,7 @@ function attachShadow_(
         new (Blockly.Events.get(Blockly.Events.BLOCK_CREATE))(newBlock)
       );
     }
-    newBlock.outputConnection.connect(input.connection);
+    newBlock.outputConnection!.connect(input.connection!);
   }
 }
 
@@ -486,21 +504,21 @@ function populateArgumentOnCaller_(
   id: string,
   input: Blockly.Input
 ) {
-  let oldBlock: Blockly.BlockSvg;
-  let oldShadow: Element;
+  let oldBlock: Blockly.BlockSvg | undefined;
+  let oldShadow: Element | undefined;
   if (connectionMap && id in connectionMap) {
     const saveInfo = connectionMap[id];
-    oldBlock = saveInfo["block"];
-    oldShadow = saveInfo["shadow"];
+    oldBlock = saveInfo?.["block"];
+    oldShadow = saveInfo?.["shadow"];
   }
 
   if (connectionMap && oldBlock) {
     // Reattach the old block and shadow DOM.
     connectionMap[input.name] = null;
-    oldBlock.outputConnection.connect(input.connection);
+    oldBlock.outputConnection!.connect(input.connection!);
     if (type !== ArgumentType.BOOLEAN && this.generateShadows_) {
       const shadowDom = oldShadow || this.buildShadowDom_(type);
-      input.connection.setShadowDom(shadowDom);
+      input.connection!.setShadowDom(shadowDom);
     }
   } else if (this.generateShadows_) {
     this.attachShadow_(input, type);
@@ -526,10 +544,10 @@ function populateArgumentOnPrototype_(
   id: string,
   input: Blockly.Input
 ) {
-  let oldBlock = null;
+  let oldBlock: Blockly.BlockSvg | null = null;
   if (connectionMap && id in connectionMap) {
     const saveInfo = connectionMap[id];
-    oldBlock = saveInfo["block"];
+    oldBlock = saveInfo?.["block"] ?? null;
   }
 
   const oldTypeMatches = checkOldTypeMatches_(oldBlock, type);
@@ -548,7 +566,7 @@ function populateArgumentOnPrototype_(
   }
 
   // Attach the block.
-  input.connection.connect(argumentReporter.outputConnection);
+  input.connection!.connect(argumentReporter.outputConnection!);
 }
 
 /**
@@ -570,10 +588,10 @@ function populateArgumentOnDeclaration_(
   id: string,
   input: Blockly.Input
 ) {
-  let oldBlock = null;
+  let oldBlock: Blockly.BlockSvg | null = null;
   if (connectionMap && id in connectionMap) {
     const saveInfo = connectionMap[id];
-    oldBlock = saveInfo["block"];
+    oldBlock = saveInfo?.["block"] ?? null;
   }
 
   // TODO: This always returns false, because it checks for argument reporter
@@ -593,7 +611,7 @@ function populateArgumentOnDeclaration_(
   }
 
   // Attach the block.
-  input.connection.connect(argumentEditor.outputConnection);
+  input.connection!.connect(argumentEditor.outputConnection!);
 }
 
 /**
@@ -686,7 +704,7 @@ function updateDeclarationProcCode_(this: ProcedureDeclarationBlock) {
       this.procCode_ += input.fieldRow[0].getValue();
     } else if (input.type === Blockly.inputs.inputTypes.VALUE) {
       // Inspect the argument editor.
-      const target = input.connection.targetBlock();
+      const target = input.connection!.targetBlock()!;
       this.displayNames_.push(target.getFieldValue("TEXT"));
       this.argumentIds_.push(input.name);
       if (target.type === "argument_editor_boolean") {
@@ -712,8 +730,8 @@ function focusLastEditor_(this: ProcedureDeclarationBlock) {
       newInput.fieldRow[0].showEditor();
     } else if (newInput.type === Blockly.inputs.inputTypes.VALUE) {
       // Inspect the argument editor.
-      const target = newInput.connection.targetBlock();
-      target.getField("TEXT").showEditor();
+      const target = newInput.connection!.targetBlock()!;
+      target.getField("TEXT")!.showEditor();
     }
   }
 }
@@ -791,7 +809,7 @@ function removeFieldCallback(
   for (var n = 0; n < this.inputList.length; n++) {
     var input = this.inputList[n];
     if (input.connection) {
-      var target = input.connection.targetBlock();
+      var target = input.connection!.targetBlock()!;
       if (field.name && target.getField(field.name) === field) {
         inputNameToRemove = input.name;
       }

--- a/src/context_menu_items.ts
+++ b/src/context_menu_items.ts
@@ -12,20 +12,20 @@ import * as Blockly from "blockly/core";
 export function registerDeleteBlock() {
   const deleteOption = {
     displayText(scope: Blockly.ContextMenuRegistry.Scope) {
-      const descendantCount = getDeletableBlocksInStack(scope.block).length;
+      const descendantCount = getDeletableBlocksInStack(scope.block!).length;
       return descendantCount === 1
         ? Blockly.Msg["DELETE_BLOCK"]
         : Blockly.Msg["DELETE_X_BLOCKS"].replace("%1", `${descendantCount}`);
     },
     preconditionFn(scope: Blockly.ContextMenuRegistry.Scope) {
-      if (!scope.block.isInFlyout && scope.block.isDeletable()) {
+      if (!scope.block!.isInFlyout && scope.block!.isDeletable()) {
         return "enabled";
       }
       return "hidden";
     },
     callback(scope: Blockly.ContextMenuRegistry.Scope) {
       Blockly.Events.setGroup(true);
-      scope.block.dispose(true, true);
+      scope.block!.dispose(true, true);
       Blockly.Events.setGroup(false);
     },
     scopeType: Blockly.ContextMenuRegistry.ScopeType.BLOCK,
@@ -42,7 +42,7 @@ function getDeletableBlocksInStack(
   if (block.getNextBlock()) {
     // Next blocks are not deleted.
     const nextDescendants = block
-      .getNextBlock()
+      .getNextBlock()!
       .getDescendants(false)
       .filter(isDeletable);
     descendants = descendants.filter((b) => !nextDescendants.includes(b));
@@ -161,10 +161,10 @@ function deleteNext(deleteList: Blockly.BlockSvg[], eventGroup?: string) {
  */
 export function registerDuplicateBlock() {
   const original =
-    Blockly.ContextMenuRegistry.registry.getItem("blockDuplicate");
+    Blockly.ContextMenuRegistry.registry.getItem("blockDuplicate")!;
   const duplicateOption = {
-    displayText: original.displayText,
-    preconditionFn: original.preconditionFn,
+    displayText: original.displayText!,
+    preconditionFn: original.preconditionFn!,
     callback(scope: Blockly.ContextMenuRegistry.Scope) {
       if (!scope.block) return;
       const data = scope.block.toCopyData(true);

--- a/src/data_category.ts
+++ b/src/data_category.ts
@@ -481,14 +481,14 @@ function addCreateButton(
   let msg = Blockly.Msg.NEW_VARIABLE;
   let callbackKey = "CREATE_VARIABLE";
   let callback = function (button: Blockly.FlyoutButton) {
-    createVariable(button.getTargetWorkspace(), null, SCALAR_VARIABLE_TYPE);
+    createVariable(button.getTargetWorkspace(), undefined, SCALAR_VARIABLE_TYPE);
   };
 
   if (type === "LIST") {
     msg = Blockly.Msg.NEW_LIST;
     callbackKey = "CREATE_LIST";
     callback = function (button: Blockly.FlyoutButton) {
-      createVariable(button.getTargetWorkspace(), null, LIST_VARIABLE_TYPE);
+      createVariable(button.getTargetWorkspace(), undefined, LIST_VARIABLE_TYPE);
     };
   }
   button.setAttribute("text", msg);
@@ -551,7 +551,7 @@ function addBlock(
           ${secondValueField}
         </block>
       </xml>`;
-    var block = Blockly.utils.xml.textToDom(blockText).firstElementChild;
+    var block = Blockly.utils.xml.textToDom(blockText).firstElementChild!;
     xmlList.push(block);
   }
 }
@@ -617,6 +617,6 @@ function createValue(valueName: string, type: string, value: string): string {
  */
 function addSep(xmlList: Element[]) {
   const sepText = `<xml><sep gap="36"/></xml>`;
-  const sep = Blockly.utils.xml.textToDom(sepText).firstElementChild;
+  const sep = Blockly.utils.xml.textToDom(sepText).firstElementChild!;
   xmlList.push(sep);
 }

--- a/src/events/events_block_comment_base.ts
+++ b/src/events/events_block_comment_base.ts
@@ -9,9 +9,9 @@ import type { ScratchCommentBubble } from "../scratch_comment_bubble";
 
 export class BlockCommentBase extends Blockly.Events.Abstract {
   isBlank = true;
-  commentId: string;
-  blockId: string;
-  workspaceId: string;
+  commentId!: string;
+  blockId!: string;
+  workspaceId!: string;
 
   constructor(opt_blockComment?: ScratchCommentBubble) {
     super();
@@ -20,8 +20,11 @@ export class BlockCommentBase extends Blockly.Events.Abstract {
     if (!opt_blockComment) return;
 
     this.commentId = opt_blockComment.getId();
-    this.blockId = opt_blockComment.getSourceBlock()?.id;
-    this.workspaceId = opt_blockComment.getSourceBlock()?.workspace.id;
+    const sourceBlock = opt_blockComment.getSourceBlock();
+    if (sourceBlock) {
+      this.blockId = sourceBlock.id;
+      this.workspaceId = sourceBlock.workspace.id;
+    }
   }
 
   toJson(): BlockCommentBaseJson {

--- a/src/events/events_block_comment_change.ts
+++ b/src/events/events_block_comment_change.ts
@@ -12,8 +12,8 @@ import {
 import type { ScratchCommentBubble } from "../scratch_comment_bubble";
 
 class BlockCommentChange extends BlockCommentBase {
-  oldContents_: string;
-  newContents_: string;
+  oldContents_!: string;
+  newContents_!: string;
 
   constructor(
     opt_blockComment?: ScratchCommentBubble,
@@ -22,8 +22,8 @@ class BlockCommentChange extends BlockCommentBase {
   ) {
     super(opt_blockComment);
     this.type = "block_comment_change";
-    this.oldContents_ = oldContents;
-    this.newContents_ = newContents;
+    if (oldContents !== undefined) this.oldContents_ = oldContents;
+    if (newContents !== undefined) this.newContents_ = newContents;
     // Disable undo because Blockly already tracks changes to comment text for
     // undo purposes; this event exists solely to keep the Scratch VM apprised
     // of the state of things.

--- a/src/events/events_block_comment_collapse.ts
+++ b/src/events/events_block_comment_collapse.ts
@@ -12,12 +12,12 @@ import {
 import type { ScratchCommentBubble } from "../scratch_comment_bubble";
 
 class BlockCommentCollapse extends BlockCommentBase {
-  newCollapsed: boolean;
+  newCollapsed!: boolean;
 
   constructor(opt_blockComment?: ScratchCommentBubble, collapsed?: boolean) {
     super(opt_blockComment);
     this.type = "block_comment_collapse";
-    this.newCollapsed = collapsed;
+    if (collapsed !== undefined) this.newCollapsed = collapsed;
   }
 
   toJson(): BlockCommentCollapseJson {
@@ -45,7 +45,19 @@ class BlockCommentCollapse extends BlockCommentBase {
   run(forward: boolean) {
     const workspace = this.getEventWorkspace_();
     const block = workspace.getBlockById(this.blockId);
+    if (!block) {
+      console.warn(
+        "BlockCommentCollapse.run: block not found",
+        this.blockId,
+        this.workspaceId
+      );
+      return;
+    }
     const comment = block.getIcon(Blockly.icons.IconType.COMMENT);
+    if (!comment) {
+      console.warn("BlockCommentCollapse.run: comment icon not found", block.id);
+      return;
+    }
     comment.setBubbleVisible(forward ? !this.newCollapsed : this.newCollapsed);
   }
 }

--- a/src/events/events_block_comment_create.ts
+++ b/src/events/events_block_comment_create.ts
@@ -12,7 +12,7 @@ import {
 import type { ScratchCommentBubble } from "../scratch_comment_bubble";
 
 class BlockCommentCreate extends BlockCommentBase {
-  json: {
+  json!: {
     x: number;
     y: number;
     width: number;
@@ -22,6 +22,9 @@ class BlockCommentCreate extends BlockCommentBase {
   constructor(opt_blockComment?: ScratchCommentBubble) {
     super(opt_blockComment);
     this.type = "block_comment_create";
+    // opt_blockComment is absent when this class is instantiated by fromJson.
+    // In that case fromJson sets this.json directly, so return early here.
+    if (!opt_blockComment) return;
     const size = opt_blockComment.getSize();
     const location = opt_blockComment.getRelativeToSurfaceXY();
     this.json = {

--- a/src/events/events_block_comment_delete.ts
+++ b/src/events/events_block_comment_delete.ts
@@ -15,8 +15,10 @@ class BlockCommentDelete extends BlockCommentBase {
   ) {
     super(opt_blockComment);
     this.type = "block_comment_delete";
-    this.blockId = sourceBlock.id;
-    this.workspaceId = sourceBlock.workspace.id;
+    if (sourceBlock) {
+      this.blockId = sourceBlock.id;
+      this.workspaceId = sourceBlock.workspace.id;
+    }
     // Disable undo because Blockly already tracks comment deletion for
     // undo purposes; this event exists solely to keep the Scratch VM apprised
     // of the state of things.

--- a/src/events/events_block_comment_move.ts
+++ b/src/events/events_block_comment_move.ts
@@ -12,8 +12,8 @@ import {
 import type { ScratchCommentBubble } from "../scratch_comment_bubble";
 
 class BlockCommentMove extends BlockCommentBase {
-  oldCoordinate_: Blockly.utils.Coordinate;
-  newCoordinate_: Blockly.utils.Coordinate;
+  oldCoordinate_!: Blockly.utils.Coordinate;
+  newCoordinate_!: Blockly.utils.Coordinate;
 
   constructor(
     opt_blockComment?: ScratchCommentBubble,
@@ -22,8 +22,8 @@ class BlockCommentMove extends BlockCommentBase {
   ) {
     super(opt_blockComment);
     this.type = "block_comment_move";
-    this.oldCoordinate_ = oldCoordinate;
-    this.newCoordinate_ = newCoordinate;
+    if (oldCoordinate !== undefined) this.oldCoordinate_ = oldCoordinate;
+    if (newCoordinate !== undefined) this.newCoordinate_ = newCoordinate;
   }
 
   toJson(): BlockCommentMoveJson {

--- a/src/events/events_block_comment_resize.ts
+++ b/src/events/events_block_comment_resize.ts
@@ -12,8 +12,8 @@ import {
 import type { ScratchCommentBubble } from "../scratch_comment_bubble";
 
 class BlockCommentResize extends BlockCommentBase {
-  oldSize: Blockly.utils.Size;
-  newSize: Blockly.utils.Size;
+  oldSize!: Blockly.utils.Size;
+  newSize!: Blockly.utils.Size;
 
   constructor(
     opt_blockComment?: ScratchCommentBubble,
@@ -22,8 +22,8 @@ class BlockCommentResize extends BlockCommentBase {
   ) {
     super(opt_blockComment);
     this.type = "block_comment_resize";
-    this.oldSize = oldSize;
-    this.newSize = newSize;
+    if (oldSize !== undefined) this.oldSize = oldSize;
+    if (newSize !== undefined) this.newSize = newSize;
   }
 
   toJson(): BlockCommentResizeJson {

--- a/src/events/events_block_drag_end.ts
+++ b/src/events/events_block_drag_end.ts
@@ -7,15 +7,15 @@
 import * as Blockly from "blockly/core";
 
 export class BlockDragEnd extends Blockly.Events.BlockBase {
-  isOutside: boolean;
-  xml: Element | DocumentFragment;
+  isOutside!: boolean;
+  xml!: Element | DocumentFragment;
 
   constructor(block?: Blockly.Block, isOutside?: boolean) {
     super(block);
     this.type = "endDrag";
-    this.isOutside = isOutside;
+    if (isOutside !== undefined) this.isOutside = isOutside;
     this.recordUndo = false;
-    this.xml = Blockly.Xml.blockToDom(block, true);
+    if (block) this.xml = Blockly.Xml.blockToDom(block, true);
   }
 
   toJson(): BlockDragEndJson {

--- a/src/events/events_block_drag_outside.ts
+++ b/src/events/events_block_drag_outside.ts
@@ -7,12 +7,12 @@
 import * as Blockly from "blockly/core";
 
 export class BlockDragOutside extends Blockly.Events.BlockBase {
-  isOutside: boolean;
+  isOutside!: boolean;
 
   constructor(block?: Blockly.Block, isOutside?: boolean) {
     super(block);
     this.type = "dragOutside";
-    this.isOutside = isOutside;
+    if (isOutside !== undefined) this.isOutside = isOutside;
     this.recordUndo = false;
   }
 

--- a/src/events/events_scratch_variable_create.ts
+++ b/src/events/events_scratch_variable_create.ts
@@ -8,8 +8,8 @@ import * as Blockly from "blockly/core";
 import { ScratchVariableModel } from "../scratch_variable_model";
 
 class ScratchVariableCreate extends Blockly.Events.VarCreate {
-  isLocal: boolean;
-  isCloud: boolean;
+  isLocal!: boolean;
+  isCloud!: boolean;
 
   constructor(variable?: ScratchVariableModel) {
     super(variable);
@@ -46,6 +46,17 @@ class ScratchVariableCreate extends Blockly.Events.VarCreate {
     const workspace = this.getEventWorkspace_();
     const variableMap = workspace.getVariableMap();
     if (forward) {
+      if (this.varName == null || this.varType == null || this.varId == null) {
+        console.error(
+          "ScratchVariableCreate.run: missing variable data for create",
+          {
+            varName: this.varName,
+            varType: this.varType,
+            varId: this.varId,
+          }
+        );
+        return;
+      }
       const variable = new ScratchVariableModel(
         workspace,
         this.varName,
@@ -59,6 +70,13 @@ class ScratchVariableCreate extends Blockly.Events.VarCreate {
         new (Blockly.Events.get(Blockly.Events.VAR_CREATE))(variable)
       );
     } else {
+      if (this.varId == null) {
+        console.error(
+          "ScratchVariableCreate.run: missing varId for delete",
+          this
+        );
+        return;
+      }
       const variable = variableMap.getVariableById(this.varId);
       if (variable) {
         variableMap.deleteVariable(variable);

--- a/src/fields/field_colour_slider.ts
+++ b/src/fields/field_colour_slider.ts
@@ -41,9 +41,9 @@ export class FieldColourSlider extends FieldColour {
    * The button calls this function with a callback to update the field value.
    * BEWARE: This is not a stable API. It may change.
    */
-  static activateEyedropper_: (
+  static activateEyedropper_?: (
     callback: (colour: string) => void
-  ) => void | null = null;
+  ) => void;
 
   /**
    * Path to the eyedropper svg icon.
@@ -61,9 +61,9 @@ export class FieldColourSlider extends FieldColour {
   private hueReadout_?: Element;
   private saturationReadout_?: Element;
   private brightnessReadout_?: Element;
-  private hue_?: number;
-  private saturation_?: number;
-  private brightness_?: number;
+  private hue_ = 0;
+  private saturation_ = 0;
+  private brightness_ = 0;
   private eyedropperEventData_?: Blockly.browserEvents.Data;
 
   /**
@@ -133,34 +133,58 @@ export class FieldColourSlider extends FieldColour {
    * Update the readouts and slider backgrounds after value has changed.
    */
   private updateDom_() {
-    if (this.hueSlider_) {
-      // Update the slider backgrounds
-      this.setGradient_(this.hueSlider_, ColourChannel.HUE);
-      this.setGradient_(this.saturationSlider_, ColourChannel.SATURATION);
-      this.setGradient_(this.brightnessSlider_, ColourChannel.BRIGHTNESS);
-
-      // Update the readouts
-      this.hueReadout_.textContent = Math.floor(
-        (100 * this.hue_) / 360
-      ).toFixed(0);
-      this.saturationReadout_.textContent = Math.floor(
-        100 * this.saturation_
-      ).toFixed(0);
-      this.brightnessReadout_.textContent = Math.floor(
-        (100 * this.brightness_) / 255
-      ).toFixed(0);
+    const hueSlider = this.hueSlider_;
+    const saturationSlider = this.saturationSlider_;
+    const brightnessSlider = this.brightnessSlider_;
+    const hueReadout = this.hueReadout_;
+    const saturationReadout = this.saturationReadout_;
+    const brightnessReadout = this.brightnessReadout_;
+    if (
+      !hueSlider ||
+      !saturationSlider ||
+      !brightnessSlider ||
+      !hueReadout ||
+      !saturationReadout ||
+      !brightnessReadout
+    ) {
+      console.warn(
+        "FieldColourSlider.updateDom_: slider/readout DOM is not fully initialized"
+      );
+      return;
     }
+
+    this.setGradient_(hueSlider, ColourChannel.HUE);
+    this.setGradient_(saturationSlider, ColourChannel.SATURATION);
+    this.setGradient_(brightnessSlider, ColourChannel.BRIGHTNESS);
+
+    hueReadout.textContent = Math.floor(
+      (100 * this.hue_) / 360
+    ).toFixed(0);
+    saturationReadout.textContent = Math.floor(
+      100 * this.saturation_
+    ).toFixed(0);
+    brightnessReadout.textContent = Math.floor(
+      (100 * this.brightness_) / 255
+    ).toFixed(0);
   }
 
   /**
    * Update the slider handle positions from the current field value.
    */
   private updateSliderHandles_() {
-    if (this.hueSlider_) {
-      this.hueSlider_.value = `${this.hue_}`;
-      this.saturationSlider_.value = `${this.saturation_}`;
-      this.brightnessSlider_.value = `${this.brightness_}`;
+    const hueSlider = this.hueSlider_;
+    const saturationSlider = this.saturationSlider_;
+    const brightnessSlider = this.brightnessSlider_;
+    if (!hueSlider || !saturationSlider || !brightnessSlider) {
+      console.warn(
+        "FieldColourSlider.updateSliderHandles_: slider DOM is not fully initialized"
+      );
+      return;
     }
+
+    hueSlider.value = `${this.hue_}`;
+    saturationSlider.value = `${this.saturation_}`;
+    brightnessSlider.value = `${this.brightness_}`;
   }
 
   /**
@@ -219,7 +243,7 @@ export class FieldColourSlider extends FieldColour {
    * Activate the eyedropper, passing in a callback for setting the field value.
    */
   private activateEyedropperInternal_() {
-    FieldColourSlider.activateEyedropper_((chosenColour: string) => {
+    FieldColourSlider.activateEyedropper_?.((chosenColour: string) => {
       // Update the internal hue/saturation/brightness values so sliders update.
       const components = Blockly.utils.colour.hexToRgb(chosenColour);
       const { hue, saturation, value } = this.rgbToHsv(
@@ -245,7 +269,8 @@ export class FieldColourSlider extends FieldColour {
 
     // Init color component values that are used while the editor is open
     // in order to keep the slider values stable.
-    const components = Blockly.utils.colour.hexToRgb(this.getValue());
+    const currentValue = this.getValue() ?? "#000000";
+    const components = Blockly.utils.colour.hexToRgb(currentValue);
     const { hue, saturation, value } = this.rgbToHsv(
       components[0],
       components[1],
@@ -314,7 +339,7 @@ export class FieldColourSlider extends FieldColour {
 
     // Set value updates the slider positions
     // Do this before attaching callbacks to avoid extra events from initial set
-    this.setValue(this.getValue());
+    this.setValue(this.getValue() ?? currentValue);
 
     this.hueChangeEventKey_ = Blockly.browserEvents.bind(
       this.hueSlider_,

--- a/src/fields/field_matrix.ts
+++ b/src/fields/field_matrix.ts
@@ -39,7 +39,7 @@ enum LEDState {
  * Class for a matrix field.
  */
 class FieldMatrix extends Blockly.Field<string> {
-  private originalStyle?: string;
+  private originalStyle = "";
 
   /**
    * Array of SVGElement<rect> for matrix thumbnail image on block field.
@@ -215,7 +215,7 @@ class FieldMatrix extends Blockly.Field<string> {
       this.arrow_.setAttributeNS(
         "http://www.w3.org/1999/xlink",
         "xlink:href",
-        this.getConstants().FIELD_DROPDOWN_SVG_ARROW_DATAURI
+        this.getConstants()!.FIELD_DROPDOWN_SVG_ARROW_DATAURI
       );
       this.arrow_.style.cursor = "default";
     }
@@ -348,7 +348,7 @@ class FieldMatrix extends Blockly.Field<string> {
   }
 
   dropdownDispose_() {
-    const sourceBlock = this.getSourceBlock();
+    const sourceBlock = this.getSourceBlock()!;
     if (sourceBlock.isShadow()) {
       sourceBlock.setStyle(this.originalStyle);
     }
@@ -396,8 +396,8 @@ class FieldMatrix extends Blockly.Field<string> {
    * Redraw the matrix with the current value.
    */
   private updateMatrix_() {
-    const matrix = this.getValue();
-    const sourceBlock = this.getSourceBlock() as Blockly.BlockSvg;
+    const matrix = this.getValue()!;
+    const sourceBlock = this.getSourceBlock()! as Blockly.BlockSvg;
     for (let i = 0; i < matrix.length; i++) {
       if (matrix[i] === LEDState.OFF) {
         this.fillMatrixNode_(
@@ -451,7 +451,7 @@ class FieldMatrix extends Blockly.Field<string> {
 
   setLEDNode_(led: number, state: LEDState) {
     if (led < 0 || led > 24) return;
-    const oldMatrix = this.getValue();
+    const oldMatrix = this.getValue()!;
     const newMatrix =
       oldMatrix.substr(0, led) + state + oldMatrix.substr(led + 1);
     this.setValue(newMatrix);
@@ -469,7 +469,7 @@ class FieldMatrix extends Blockly.Field<string> {
 
   toggleLEDNode_(led: number) {
     if (led < 0 || led > 24) return;
-    if (this.getValue().charAt(led) === LEDState.OFF) {
+    if (this.getValue()!.charAt(led) === LEDState.OFF) {
       this.setLEDNode_(led, LEDState.ON);
     } else {
       this.setLEDNode_(led, LEDState.OFF);
@@ -496,7 +496,7 @@ class FieldMatrix extends Blockly.Field<string> {
     );
     const ledHit = this.checkForLED_(e);
     if (ledHit > -1) {
-      if (this.getValue().charAt(ledHit) === LEDState.OFF) {
+      if (this.getValue()!.charAt(ledHit) === LEDState.OFF) {
         this.paintStyle_ = PaintStyle.FILL;
       } else {
         this.paintStyle_ = PaintStyle.CLEAR;
@@ -548,6 +548,7 @@ class FieldMatrix extends Blockly.Field<string> {
    * @returns The matching matrix node or -1 for none.
    */
   checkForLED_(e: PointerEvent): number {
+    if (!this.matrixStage_) return -1;
     const bBox = this.matrixStage_.getBoundingClientRect();
     const nodeSize = FieldMatrix.MATRIX_NODE_SIZE;
     const nodePad = FieldMatrix.MATRIX_NODE_PAD;

--- a/src/fields/field_note.ts
+++ b/src/fields/field_note.ts
@@ -369,7 +369,7 @@ export class FieldNote extends Blockly.FieldTextInput {
       "line",
       {
         stroke: (
-          this.sourceBlock_.getParent() as Blockly.BlockSvg
+          this.sourceBlock_!.getParent() as Blockly.BlockSvg
         ).getColourTertiary(),
         x1: 0,
         y1: FieldNote.TOP_MENU_HEIGHT,
@@ -407,7 +407,7 @@ export class FieldNote extends Blockly.FieldTextInput {
       octaveDownButton,
       "mousedown",
       this,
-      function () {
+      () => {
         this.changeOctaveBy_(-1);
       }
     );
@@ -415,14 +415,14 @@ export class FieldNote extends Blockly.FieldTextInput {
       octaveUpButton,
       "mousedown",
       this,
-      function () {
+      () => {
         this.changeOctaveBy_(1);
       }
     );
     const sourceBlock = this.getSourceBlock() as Blockly.BlockSvg;
     Blockly.DropDownDiv.setColour(
-      sourceBlock.getParent().getColour(),
-      sourceBlock.getParent().getColourTertiary()
+      (sourceBlock.getParent() as Blockly.BlockSvg).getColour(),
+      (sourceBlock.getParent() as Blockly.BlockSvg).getColourTertiary()
     );
     Blockly.DropDownDiv.showPositionedByBlock(this, sourceBlock);
 
@@ -441,7 +441,7 @@ export class FieldNote extends Blockly.FieldTextInput {
     x: number,
     whiteKeyGroup: SVGElement,
     blackKeyGroup: SVGElement,
-    keySVGarray: SVGElement[]
+    keySVGarray: SVGElement[] | null
   ) {
     let xIncrement, width, height, fill, stroke, group;
     x += FieldNote.EDGE_PADDING / 2;
@@ -463,7 +463,7 @@ export class FieldNote extends Blockly.FieldTextInput {
         height = FieldNote.WHITE_KEY_HEIGHT;
         fill = FieldNote.WHITE_KEY_COLOR;
         stroke = (
-          this.sourceBlock_.getParent() as Blockly.BlockSvg
+          this.sourceBlock_!.getParent() as Blockly.BlockSvg
         ).getColourTertiary();
         group = whiteKeyGroup;
       }
@@ -594,7 +594,7 @@ export class FieldNote extends Blockly.FieldTextInput {
       "line",
       {
         stroke: (
-          this.sourceBlock_.getParent() as Blockly.BlockSvg
+          this.sourceBlock_!.getParent() as Blockly.BlockSvg
         ).getColourTertiary(),
         x1: x - FieldNote.INSET,
         y1: 0,
@@ -643,13 +643,15 @@ export class FieldNote extends Blockly.FieldTextInput {
    * @param visible If true, set labels to be visible.
    */
   private setCKeyLabelsVisible_(visible: boolean) {
-    if (visible) {
-      this.fadeSvgToOpacity_(this.lowCText_, 1);
-      this.fadeSvgToOpacity_(this.highCText_, 1);
-    } else {
-      this.fadeSvgToOpacity_(this.lowCText_, 0);
-      this.fadeSvgToOpacity_(this.highCText_, 0);
+    if (!this.lowCText_ || !this.highCText_) {
+      console.warn(
+        "FieldNote.setCKeyLabelsVisible_: C-key label DOM is not fully initialized"
+      );
+      return;
     }
+    const opacity = visible ? 1 : 0;
+    this.fadeSvgToOpacity_(this.lowCText_, opacity);
+    this.fadeSvgToOpacity_(this.highCText_, opacity);
   }
 
   /**
@@ -686,8 +688,10 @@ export class FieldNote extends Blockly.FieldTextInput {
    */
   private onMouseUp_() {
     this.mouseIsDown_ = false;
-    Blockly.browserEvents.unbind(this.mouseUpWrapper_);
-    this.mouseUpWrapper_ = null;
+    if (this.mouseUpWrapper_) {
+      Blockly.browserEvents.unbind(this.mouseUpWrapper_);
+      this.mouseUpWrapper_ = null;
+    }
   }
 
   /**
@@ -709,7 +713,7 @@ export class FieldNote extends Blockly.FieldTextInput {
   private selectNoteWithMouseEvent_(e: PointerEvent) {
     const newNoteNum =
       Number((e.target as HTMLElement).getAttribute("data-pitch")) +
-      this.displayedOctave_ * 12;
+      (this.displayedOctave_ ?? 0) * 12;
     this.setEditorValue_(newNoteNum);
     this.playNoteInternal_();
   }
@@ -719,7 +723,7 @@ export class FieldNote extends Blockly.FieldTextInput {
    */
   private playNoteInternal_() {
     if (FieldNote.playNote_) {
-      FieldNote.playNote_(Number(this.getValue()), "Music");
+      FieldNote.playNote_(Number(this.getValue()!), "Music");
     }
   }
 
@@ -740,7 +744,7 @@ export class FieldNote extends Blockly.FieldTextInput {
    * @param octaves The number of octaves to change by.
    */
   private changeOctaveBy_(octaves: number) {
-    this.displayedOctave_ += octaves;
+    this.displayedOctave_ = (this.displayedOctave_ ?? 0) + octaves;
     if (this.displayedOctave_ < 0) {
       this.displayedOctave_ = 0;
       return;
@@ -766,7 +770,7 @@ export class FieldNote extends Blockly.FieldTextInput {
   private stepOctaveAnimation_() {
     const absDiff = Math.abs(this.animationPos_ - this.animationTarget_);
     if (absDiff < 1) {
-      this.pianoSVG_.setAttribute("transform", "translate(0, 0)");
+      this.pianoSVG_?.setAttribute("transform", "translate(0, 0)");
       this.setCKeyLabelsVisible_(true);
       this.playNoteInternal_();
       return;
@@ -774,7 +778,7 @@ export class FieldNote extends Blockly.FieldTextInput {
     this.animationPos_ +=
       (this.animationTarget_ - this.animationPos_) *
       FieldNote.ANIMATION_FRACTION;
-    this.pianoSVG_.setAttribute(
+    this.pianoSVG_?.setAttribute(
       "transform",
       "translate(" + this.animationPos_ + ",0)"
     );
@@ -799,7 +803,7 @@ export class FieldNote extends Blockly.FieldTextInput {
    * @returns The index of the piano key.
    */
   private noteNumToKeyIndex_(noteNum: number): number {
-    return Math.floor(noteNum) - this.displayedOctave_ * 12;
+    return Math.floor(noteNum) - (this.displayedOctave_ ?? 0) * 12;
   }
 
   /**
@@ -833,12 +837,15 @@ export class FieldNote extends Blockly.FieldTextInput {
       this.keySVGs_[index].setAttribute("fill", FieldNote.KEY_SELECTED_COLOR);
       // Update the note name text
       const noteName = FieldNote.KEY_INFO[index].name;
-      this.noteNameText_.textContent =
-        noteName + " (" + Math.floor(noteNum) + ")";
+      if (this.noteNameText_) {
+        this.noteNameText_.textContent =
+          noteName + " (" + Math.floor(noteNum) + ")";
+      }
       // Update the low and high C note names
-      const lowCNum = this.displayedOctave_ * 12;
-      this.lowCText_.textContent = "C(" + lowCNum + ")";
-      this.highCText_.textContent = "C(" + (lowCNum + 12) + ")";
+      const lowCNum = (this.displayedOctave_ ?? 0) * 12;
+      if (this.lowCText_) this.lowCText_.textContent = "C(" + lowCNum + ")";
+      if (this.highCText_)
+        this.highCText_.textContent = "C(" + (lowCNum + 12) + ")";
     }
   }
 

--- a/src/fields/field_textinput_removable.ts
+++ b/src/fields/field_textinput_removable.ts
@@ -40,13 +40,13 @@ export class FieldTextInputRemovable extends Blockly.FieldTextInput {
     Blockly.renderManagement.finishQueuedRenders().then(() => {
       super.showEditor_();
 
-      const div = Blockly.WidgetDiv.getDiv();
+      const div = Blockly.WidgetDiv.getDiv()!;
       div.className += " removableTextInput";
       const removeButton = document.createElement("img");
       removeButton.className = "blocklyTextRemoveIcon";
       removeButton.setAttribute(
         "src",
-        this.sourceBlock_.workspace.options.pathToMedia + "icons/remove.svg"
+        this.sourceBlock_!.workspace.options.pathToMedia + "icons/remove.svg"
       );
       this.removeButtonMouseWrapper_ = Blockly.browserEvents.bind(
         removeButton,

--- a/src/fields/field_variable_getter.ts
+++ b/src/fields/field_variable_getter.ts
@@ -78,7 +78,7 @@ class FieldVariableGetter extends Blockly.FieldLabel {
    */
   doValueUpdate_(newVariableId: string) {
     super.doValueUpdate_(newVariableId);
-    const workspace = this.getSourceBlock().workspace;
+    const workspace = this.getSourceBlock()!.workspace;
     this.variable = Blockly.Variables.getVariable(workspace, newVariableId);
   }
 
@@ -97,13 +97,13 @@ class FieldVariableGetter extends Blockly.FieldLabel {
   }
 
   fromXml(element: Element) {
-    this.setValue(element.getAttribute("id"));
+    this.setValue(element.getAttribute("id")!);
   }
 
   toXml(element: Element): Element {
-    element.setAttribute("id", this.variable.getId());
-    element.setAttribute("variabletype", this.variable.getType());
-    element.textContent = this.variable.getName();
+    element.setAttribute("id", this.variable!.getId());
+    element.setAttribute("variabletype", this.variable!.getType());
+    element.textContent = this.variable!.getName();
     return element;
   }
 }

--- a/src/fields/field_vertical_separator.ts
+++ b/src/fields/field_vertical_separator.ts
@@ -76,7 +76,7 @@ class FieldVerticalSeparator extends Blockly.Field {
    * @package
    */
   setLineHeight(newHeight: number) {
-    this.lineElement.setAttribute("y2", `${newHeight}`);
+    this.lineElement!.setAttribute("y2", `${newHeight}`);
   }
 
   /**

--- a/src/fields/scratch_field_angle.ts
+++ b/src/fields/scratch_field_angle.ts
@@ -51,17 +51,17 @@ class ScratchFieldAngle extends Blockly.FieldNumber {
   /**
    * Opaque identifier used to unbind event listener in dispose().
    */
-  private mouseDownWrapper_: Blockly.browserEvents.Data;
+  private mouseDownWrapper_!: Blockly.browserEvents.Data;
 
   /**
    * Opaque identifier used to unbind event listener in dispose().
    */
-  private mouseMoveWrapper: Blockly.browserEvents.Data;
+  private mouseMoveWrapper!: Blockly.browserEvents.Data;
 
   /**
    * Opaque identifier used to unbind event listener in dispose().
    */
-  private mouseUpWrapper: Blockly.browserEvents.Data;
+  private mouseUpWrapper!: Blockly.browserEvents.Data;
 
   /**
    * Round angles to the nearest 15 degrees when using mouse.
@@ -141,7 +141,7 @@ class ScratchFieldAngle extends Blockly.FieldNumber {
    */
   dispose() {
     super.dispose();
-    this.gauge = null;
+    this.gauge = undefined;
     if (this.mouseDownWrapper_) {
       Blockly.browserEvents.unbind(this.mouseDownWrapper_);
     }
@@ -190,10 +190,10 @@ class ScratchFieldAngle extends Blockly.FieldNumber {
         cy: this.HALF,
         r: this.RADIUS,
         fill: (
-          this.getSourceBlock().getParent() as Blockly.BlockSvg
+          this.getSourceBlock()!.getParent() as Blockly.BlockSvg
         ).getColourSecondary(),
         stroke: (
-          this.getSourceBlock().getParent() as Blockly.BlockSvg
+          this.getSourceBlock()!.getParent() as Blockly.BlockSvg
         ).getColourTertiary(),
         class: "blocklyAngleCircle",
       },
@@ -284,9 +284,9 @@ class ScratchFieldAngle extends Blockly.FieldNumber {
     );
 
     Blockly.DropDownDiv.setColour(
-      this.getSourceBlock().getParent().getColour(),
+      (this.getSourceBlock()!.getParent() as Blockly.BlockSvg).getColour(),
       (
-        this.getSourceBlock().getParent() as Blockly.BlockSvg
+        this.getSourceBlock()!.getParent() as Blockly.BlockSvg
       ).getColourTertiary()
     );
     Blockly.DropDownDiv.showPositionedByBlock(
@@ -336,7 +336,7 @@ class ScratchFieldAngle extends Blockly.FieldNumber {
    */
   onMouseMove(e: PointerEvent) {
     e.preventDefault();
-    const bBox = this.gauge.ownerSVGElement.getBoundingClientRect();
+    const bBox = this.gauge!.ownerSVGElement!.getBoundingClientRect();
     const dx = e.clientX - bBox.left - this.HALF;
     const dy = e.clientY - bBox.top - this.HALF;
     let angle = Math.atan(-dy / dx);
@@ -418,12 +418,12 @@ class ScratchFieldAngle extends Blockly.FieldNumber {
       } else {
         imageRotation = -angleDegrees;
       }
-      this.arrow.setAttribute("transform", "rotate(" + imageRotation + ")");
+      this.arrow!.setAttribute("transform", "rotate(" + imageRotation + ")");
     }
-    this.gauge.setAttribute("d", path.join(""));
-    this.line.setAttribute("x2", `${x2}`);
-    this.line.setAttribute("y2", `${y2}`);
-    this.handle.setAttribute("transform", "translate(" + x2 + "," + y2 + ")");
+    this.gauge!.setAttribute("d", path.join(""));
+    this.line!.setAttribute("x2", `${x2}`);
+    this.line!.setAttribute("y2", `${y2}`);
+    this.handle!.setAttribute("transform", "translate(" + x2 + "," + y2 + ")");
   }
 
   /**

--- a/src/fields/scratch_field_dropdown.ts
+++ b/src/fields/scratch_field_dropdown.ts
@@ -7,7 +7,7 @@
 import * as Blockly from "blockly/core";
 
 class ScratchFieldDropdown extends Blockly.FieldDropdown {
-  private originalStyle: string;
+  private originalStyle!: string;
 
   showEditor_(event: PointerEvent) {
     super.showEditor_(event);
@@ -28,7 +28,7 @@ class ScratchFieldDropdown extends Blockly.FieldDropdown {
 
   dropdownDispose_() {
     super.dropdownDispose_();
-    const sourceBlock = this.getSourceBlock();
+    const sourceBlock = this.getSourceBlock()!;
     if (sourceBlock.isShadow()) {
       sourceBlock.setStyle(this.originalStyle);
     }

--- a/src/fields/scratch_field_number.ts
+++ b/src/fields/scratch_field_number.ts
@@ -141,7 +141,7 @@ class ScratchFieldNumber extends Blockly.FieldTextInput {
 
     // Show a numeric keypad in the drop-down on touch
     if (showNumPad) {
-      this.htmlInput_.select();
+      this.htmlInput_!.select();
       this.showNumPad_();
     }
   }
@@ -173,7 +173,7 @@ class ScratchFieldNumber extends Blockly.FieldTextInput {
     // Set colour and size of drop-down
     const sourceBlock = this.getSourceBlock() as Blockly.BlockSvg;
     Blockly.DropDownDiv.setColour(
-      sourceBlock.getParent().getColour(),
+      (sourceBlock.getParent() as Blockly.BlockSvg).getColour(),
       sourceBlock.getColourTertiary()
     );
     contentDiv.style.width = ScratchFieldNumber.DROPDOWN_WIDTH + "px";
@@ -205,11 +205,12 @@ class ScratchFieldNumber extends Blockly.FieldTextInput {
     );
     Blockly.DropDownDiv.show(
       this,
-      this.getSourceBlock().RTL,
+      this.getSourceBlock()!.RTL,
       primaryX,
       primaryY,
       secondaryX,
       secondaryY,
+      false,
       this.onHide_.bind(this)
     );
   }
@@ -222,8 +223,8 @@ class ScratchFieldNumber extends Blockly.FieldTextInput {
    */
   private addButtons_(contentDiv: Element) {
     const sourceBlock = this.getSourceBlock() as Blockly.BlockSvg;
-    const buttonColour = sourceBlock.getParent().getColour();
-    const buttonBorderColour = sourceBlock.getParent().getColourTertiary();
+    const buttonColour = (sourceBlock.getParent() as Blockly.BlockSvg).getColour();
+    const buttonBorderColour = (sourceBlock.getParent() as Blockly.BlockSvg).getColourTertiary();
 
     // Add numeric keypad buttons
     const buttons = ScratchFieldNumber.NUMPAD_BUTTONS;
@@ -298,10 +299,10 @@ class ScratchFieldNumber extends Blockly.FieldTextInput {
     // String of the button (e.g., '7')
     const spliceValue = (e.target as HTMLElement).innerText;
     // Old value of the text field
-    const oldValue = this.htmlInput_.value;
+    const oldValue = this.htmlInput_!.value;
     // Determine the selected portion of the text field
-    const selectionStart = this.htmlInput_.selectionStart;
-    const selectionEnd = this.htmlInput_.selectionEnd;
+    const selectionStart = this.htmlInput_!.selectionStart ?? 0;
+    const selectionEnd = this.htmlInput_!.selectionEnd ?? 0;
 
     // Splice in the new value
     const newValue =
@@ -327,10 +328,10 @@ class ScratchFieldNumber extends Blockly.FieldTextInput {
    */
   numPadEraseButtonTouch(e: PointerEvent) {
     // Old value of the text field
-    const oldValue = this.htmlInput_.value;
+    const oldValue = this.htmlInput_!.value;
     // Determine what is selected to erase (if anything)
-    let selectionStart = this.htmlInput_.selectionStart;
-    const selectionEnd = this.htmlInput_.selectionEnd;
+    let selectionStart = this.htmlInput_!.selectionStart ?? 0;
+    const selectionEnd = this.htmlInput_!.selectionEnd ?? 0;
 
     // If selection is zero-length, shift start to the left 1 character
     if (selectionStart == selectionEnd) {
@@ -359,7 +360,7 @@ class ScratchFieldNumber extends Blockly.FieldTextInput {
   private updateDisplay_(newValue: string, newSelection: number) {
     this.setEditorValue_(newValue);
     // Resize and scroll the text field appropriately
-    const htmlInput = this.htmlInput_;
+    const htmlInput = this.htmlInput_!;
     htmlInput.setSelectionRange(newSelection, newSelection);
     htmlInput.scrollLeft = htmlInput.scrollWidth;
   }

--- a/src/fields/scratch_field_variable.ts
+++ b/src/fields/scratch_field_variable.ts
@@ -29,7 +29,7 @@ import { createVariable, renameVariable } from "../variables";
 import type { ScratchVariableModel } from "../scratch_variable_model";
 
 export class ScratchFieldVariable extends Blockly.FieldVariable {
-  private originalStyle: string;
+  private originalStyle!: string;
 
   constructor(
     varName: string | null | typeof Blockly.Field.SKIP_SETUP,
@@ -39,7 +39,10 @@ export class ScratchFieldVariable extends Blockly.FieldVariable {
     config?: Blockly.FieldVariableConfig
   ) {
     super(varName, validator, variableTypes, defaultType, config);
-    this.menuGenerator_ = ScratchFieldVariable.dropdownCreate;
+    // dropdownCreate returns MenuOption[] rather than Blockly.MenuGenerator's
+    // MenuOption[][] variant; the cast is needed to satisfy FieldVariable's
+    // menuGenerator_ type while the actual runtime shape is compatible.
+    this.menuGenerator_ = ScratchFieldVariable.dropdownCreate as unknown as Blockly.MenuGenerator;
   }
 
   initModel() {
@@ -73,7 +76,7 @@ export class ScratchFieldVariable extends Blockly.FieldVariable {
    */
   initFlyoutBroadcast(
     workspace: Blockly.WorkspaceSvg
-  ): Blockly.IVariableModel<Blockly.IVariableState> {
+  ): Blockly.IVariableModel<Blockly.IVariableState> | undefined {
     const broadcastVars = workspace.getVariablesOfType(
       Constants.BROADCAST_MESSAGE_VARIABLE_TYPE
     );
@@ -154,7 +157,7 @@ export class ScratchFieldVariable extends Blockly.FieldVariable {
 
   showEditor_(event: PointerEvent) {
     super.showEditor_(event);
-    const sourceBlock = this.getSourceBlock();
+    const sourceBlock = this.getSourceBlock()!;
     const styleName = sourceBlock.getStyleName();
     const style = (sourceBlock.workspace as Blockly.WorkspaceSvg)
       .getRenderer()
@@ -175,7 +178,7 @@ export class ScratchFieldVariable extends Blockly.FieldVariable {
 
   dropdownDispose_() {
     super.dropdownDispose_();
-    const sourceBlock = this.getSourceBlock();
+    const sourceBlock = this.getSourceBlock()!;
     if (sourceBlock.isShadow()) {
       sourceBlock.setStyle(this.originalStyle);
     }

--- a/src/flyout_checkbox_icon.ts
+++ b/src/flyout_checkbox_icon.ts
@@ -14,7 +14,7 @@ export class FlyoutCheckboxIcon
   extends Blockly.icons.Icon
   implements Blockly.IHasBubble
 {
-  private checkboxBubble: CheckboxBubble;
+  private checkboxBubble!: CheckboxBubble;
   private type = new Blockly.icons.IconType("checkbox");
 
   constructor(protected override sourceBlock: Blockly.BlockSvg) {

--- a/src/glows.ts
+++ b/src/glows.ts
@@ -17,8 +17,8 @@ export function glowStack(id: string, isGlowingStack: boolean) {
   const block = (Blockly.getMainWorkspace().getBlockById(id) ||
     (Blockly.getMainWorkspace() as Blockly.WorkspaceSvg)
       .getFlyout()
-      .getWorkspace()
-      .getBlockById(id)) as Blockly.BlockSvg;
+      ?.getWorkspace()
+      ?.getBlockById(id)) as Blockly.BlockSvg;
   if (!block) {
     throw "Tried to glow block that does not exist.";
   }

--- a/src/procedures.ts
+++ b/src/procedures.ts
@@ -36,7 +36,7 @@ function allProcedureMutations(root: Blockly.WorkspaceSvg): Element[] {
   const blocks = root.getAllBlocks();
   return blocks
     .filter((b) => b.type === Constants.PROCEDURES_PROTOTYPE_BLOCK_TYPE)
-    .map((b) => b.mutationToDom(/* opt_generateShadows */ true));
+    .map((b) => b.mutationToDom!(/* opt_generateShadows */ true) as Element);
 }
 
 /**
@@ -47,8 +47,8 @@ function allProcedureMutations(root: Blockly.WorkspaceSvg): Element[] {
  */
 function sortProcedureMutations(mutations: Element[]): Element[] {
   return mutations.slice().sort(function (a, b) {
-    const procCodeA = a.getAttribute("proccode");
-    const procCodeB = b.getAttribute("proccode");
+    const procCodeA = a.getAttribute("proccode")!;
+    const procCodeB = b.getAttribute("proccode")!;
 
     return scratchBlocksUtils.compareStrings(procCodeA, procCodeB);
   });
@@ -163,10 +163,10 @@ function mutateCallersAndPrototype(
   callers.push(prototypeBlock);
   Blockly.Events.setGroup(true);
   callers.forEach((caller) => {
-    const oldMutationDom = caller.mutationToDom();
+    const oldMutationDom = caller.mutationToDom!();
     const oldMutation = oldMutationDom && Blockly.Xml.domToText(oldMutationDom);
-    caller.domToMutation(mutation);
-    const newMutationDom = caller.mutationToDom();
+    caller.domToMutation!(mutation);
+    const newMutationDom = caller.mutationToDom!();
     const newMutation = newMutationDom && Blockly.Xml.domToText(newMutationDom);
     if (oldMutation !== newMutation) {
       Blockly.Events.fire(
@@ -197,8 +197,8 @@ function getDefineBlock(
   return workspace.getTopBlocks(false).find((block) => {
     if (block.type === Constants.PROCEDURES_DEFINITION_BLOCK_TYPE) {
       const prototypeBlock = block
-        .getInput("custom_block")
-        .connection.targetBlock() as Blockly.BlockSvg;
+        .getInput("custom_block")!
+        .connection!.targetBlock() as Blockly.BlockSvg;
       return (
         isProcedureBlock(prototypeBlock) &&
         prototypeBlock.getProcCode() === procCode
@@ -222,8 +222,8 @@ function getPrototypeBlock(
   const defineBlock = getDefineBlock(procCode, workspace);
   if (defineBlock) {
     return defineBlock
-      .getInput("custom_block")
-      .connection.targetBlock() as Blockly.BlockSvg;
+      .getInput("custom_block")!
+      .connection!.targetBlock() as Blockly.BlockSvg;
   }
   return undefined;
 }
@@ -243,7 +243,7 @@ function newProcedureMutation(): Element {
         warp="false">
       </mutation>
     </xml>`;
-  return Blockly.utils.xml.textToDom(mutationText).firstElementChild;
+  return Blockly.utils.xml.textToDom(mutationText).firstElementChild!;
 }
 
 /**
@@ -251,7 +251,7 @@ function newProcedureMutation(): Element {
  * @param workspace The workspace to create the new procedure on.
  */
 function createProcedureDefCallback(workspace: Blockly.WorkspaceSvg) {
-  ScratchProcedures.externalProcedureDefCallback(
+  ScratchProcedures.externalProcedureDefCallback!(
     newProcedureMutation(),
     createProcedureCallbackFactory(workspace)
   );
@@ -278,7 +278,7 @@ function createProcedureCallbackFactory(
           </statement>
         </block>
       </xml>`;
-    const blockDom = Blockly.utils.xml.textToDom(blockText).firstElementChild;
+    const blockDom = Blockly.utils.xml.textToDom(blockText).firstElementChild!;
     Blockly.Events.setGroup(true);
     const block = Blockly.Xml.domToBlock(
       blockDom,
@@ -338,15 +338,23 @@ function editProcedureCallback(block: Blockly.BlockSvg) {
     // This is a call block, find the prototype corresponding to the procCode.
     // Make sure to search the correct workspace, call block can be in flyout.
     const workspaceToSearch = block.workspace.isFlyout
-      ? block.workspace.targetWorkspace
+      ? block.workspace.targetWorkspace!
       : block.workspace;
-    prototypeBlock = getPrototypeBlock(block.getProcCode(), workspaceToSearch);
+    const foundBlock = getPrototypeBlock(block.getProcCode(), workspaceToSearch);
+    if (!foundBlock) {
+      console.warn(
+        "editProcedureCallback: could not find prototype for",
+        block.getProcCode()
+      );
+      return;
+    }
+    prototypeBlock = foundBlock;
   } else {
     prototypeBlock = block;
   }
   // Block now refers to the procedure prototype block, it is safe to proceed.
-  ScratchProcedures.externalProcedureDefCallback(
-    prototypeBlock.mutationToDom(),
+  ScratchProcedures.externalProcedureDefCallback!(
+    prototypeBlock.mutationToDom!(),
     editProcedureCallbackFactory(prototypeBlock)
   );
 }

--- a/src/renderer/cat/cat_face.ts
+++ b/src/renderer/cat/cat_face.ts
@@ -36,7 +36,7 @@ const setVisibility = (element: SVGElement, visible: boolean) => {
  * Owned by the PathObject with similar lifetime.
  */
 export class CatFace {
-  faceGroup_: SVGElement;
+  faceGroup_!: SVGElement;
   parts_ = {} as Record<FacePart, SVGElement>;
   pathEarState: CatPathState;
   constants_: ConstantProvider;

--- a/src/renderer/cat/drawer.ts
+++ b/src/renderer/cat/drawer.ts
@@ -12,8 +12,8 @@ import { type RenderInfo } from "./render_info";
 import { CatFace } from "./cat_face";
 
 export class Drawer extends ClassicDrawer {
-  constants_: ConstantProvider;
-  info_: RenderInfo;
+  declare constants_: ConstantProvider;
+  declare info_: RenderInfo;
 
   override draw() {
     // Make sure the face exists if we need it.
@@ -57,7 +57,7 @@ export class Drawer extends ClassicDrawer {
     const pathObject = this.block_.pathObject as PathObject;
     return this.constants_.makeCatPath(
       this.info_.width,
-      pathObject.catFace.pathEarState
+      pathObject.catFace!.pathEarState
     );
   }
 }

--- a/src/renderer/cat/render_info.ts
+++ b/src/renderer/cat/render_info.ts
@@ -10,6 +10,6 @@ import { ConstantProvider } from "./constants";
 import { CatScratchRenderer } from "./renderer";
 
 export class RenderInfo extends ClassicRenderInfo {
-  override constants_: ConstantProvider;
-  override renderer_: CatScratchRenderer;
+  declare constants_: ConstantProvider;
+  declare renderer_: CatScratchRenderer;
 }

--- a/src/renderer/cat/renderer.ts
+++ b/src/renderer/cat/renderer.ts
@@ -18,8 +18,8 @@ export class CatScratchRenderer extends ScratchRenderer {
     return new ConstantProvider();
   }
 
-  override makeDrawer_(block: Blockly.BlockSvg, info: RenderInfo) {
-    return new Drawer(block, info);
+  override makeDrawer_(block: Blockly.BlockSvg, info: Blockly.blockRendering.RenderInfo) {
+    return new Drawer(block, info as RenderInfo);
   }
 
   override makeRenderInfo_(block: Blockly.BlockSvg): RenderInfo {

--- a/src/renderer/constants.ts
+++ b/src/renderer/constants.ts
@@ -64,7 +64,7 @@ export class ConstantProvider extends Blockly.zelos.ConstantProvider {
    * drawn with the rounded shape that matches what they accept, not the
    * hexagonal shape of their parent block's output.
    */
-  override shapeFor(connection: Blockly.RenderedConnection) {
+  override shapeFor(connection: Blockly.RenderedConnection): ReturnType<Blockly.zelos.ConstantProvider["shapeFor"]> {
     let checks = connection.getCheck();
     if (!checks && connection.targetConnection) {
       checks = connection.targetConnection.getCheck();
@@ -75,19 +75,19 @@ export class ConstantProvider extends Blockly.zelos.ConstantProvider {
       if (outputShape !== null) {
         switch (outputShape) {
           case this.SHAPES.HEXAGONAL:
-            return this.HEXAGONAL;
+            return this.HEXAGONAL!;
           case this.SHAPES.ROUND:
-            return this.ROUNDED;
+            return this.ROUNDED!;
           case this.SHAPES.SQUARE:
-            return this.SQUARED;
+            return this.SQUARED!;
         }
       }
     }
 
     // For INPUT_VALUE (and OUTPUT_VALUE fallthrough), use connection checks.
-    if (checks?.includes("Boolean")) return this.HEXAGONAL;
-    if (checks?.includes("Number")) return this.ROUNDED;
-    if (checks?.includes("String")) return this.ROUNDED;
+    if (checks?.includes("Boolean")) return this.HEXAGONAL!;
+    if (checks?.includes("Number")) return this.ROUNDED!;
+    if (checks?.includes("String")) return this.ROUNDED!;
     // For INPUT_VALUE or OUTPUT_VALUE with unrecognized checks, default to
     // ROUNDED. Don't call super.shapeFor() here: the base implementation
     // uses getSourceBlock().getOutputShape(), which would incorrectly return
@@ -96,7 +96,7 @@ export class ConstantProvider extends Blockly.zelos.ConstantProvider {
       connection.type === Blockly.ConnectionType.INPUT_VALUE ||
       connection.type === Blockly.ConnectionType.OUTPUT_VALUE
     ) {
-      return this.ROUNDED;
+      return this.ROUNDED!;
     }
     return super.shapeFor(connection);
   }

--- a/src/renderer/drawer.ts
+++ b/src/renderer/drawer.ts
@@ -9,8 +9,8 @@ import type { RenderInfo } from "./render_info";
 import { ConstantProvider } from "./constants";
 
 export class Drawer extends Blockly.zelos.Drawer {
-  constants_: ConstantProvider;
-  info_: RenderInfo;
+  declare constants_: ConstantProvider;
+  declare info_: RenderInfo;
 
   override drawStatementInput_(row: Blockly.blockRendering.Row) {
     if (this.info_.isBowlerHatBlock()) {

--- a/src/renderer/render_info.ts
+++ b/src/renderer/render_info.ts
@@ -10,7 +10,7 @@ import { BowlerHat } from "./bowler_hat";
 import { ConstantProvider } from "./constants";
 
 export class RenderInfo extends Blockly.zelos.RenderInfo {
-  constants_: ConstantProvider;
+  declare constants_: ConstantProvider;
 
   override populateTopRow_() {
     if (this.isBowlerHatBlock()) {
@@ -41,19 +41,22 @@ export class RenderInfo extends Blockly.zelos.RenderInfo {
     if (this.isBowlerHatBlock()) {
       // Resize the render info to the same width as the widest part of a
       // bowler hat block.
-      const statementRow = this.rows.find((r) => r.hasStatement);
+      // Bowler hat blocks always have exactly one statement row and one input
+      // element, so these find() calls are guaranteed to succeed.
+      const statementRow = this.rows.find((r) => r.hasStatement)!;
       this.width =
         statementRow.widthWithConnectedBlocks -
         statementRow.elements.find((e) =>
           Blockly.blockRendering.Types.isInput(e)
-        ).width +
+        )!.width +
         this.constants_.MEDIUM_PADDING;
 
       // The bowler hat's width is the same as the block's width, so it can't
       // be derived from the constants like a normal hat and has to be set here.
+      // populateTopRow_ always adds a hat element for bowler hat blocks.
       const hat = this.topRow.elements.find((e) =>
         Blockly.blockRendering.Types.isHat(e)
-      );
+      )!;
       hat.width = this.width;
       this.topRow.measure();
     }

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -32,8 +32,8 @@ export class ScratchRenderer extends Blockly.zelos.Renderer {
    *     block.
    * @returns The drawer.
    */
-  override makeDrawer_(block: Blockly.BlockSvg, info: RenderInfo): Drawer {
-    return new Drawer(block, info);
+  override makeDrawer_(block: Blockly.BlockSvg, info: Blockly.blockRendering.RenderInfo): Drawer {
+    return new Drawer(block, info as RenderInfo);
   }
 
   /**

--- a/src/scratch_block_paster.ts
+++ b/src/scratch_block_paster.ts
@@ -36,7 +36,7 @@ class ScratchBlockPaster extends Blockly.clipboard.BlockPaster {
     // fired for blocks with comments, the VM will never receive it, causing its
     // state to get out of sync. Manually fire it here (after suppression has
     // been turned off) if needed.
-    const commentIcon = block.getIcon(Blockly.icons.IconType.COMMENT);
+    const commentIcon = block?.getIcon(Blockly.icons.IconType.COMMENT);
     if (commentIcon) {
       (commentIcon as ScratchCommentIcon).fireCreateEvent();
     }

--- a/src/scratch_comment_bubble.ts
+++ b/src/scratch_comment_bubble.ts
@@ -16,7 +16,7 @@ export class ScratchCommentBubble
   implements Blockly.IBubble, Blockly.ISelectable
 {
   id: string;
-  private sourceBlock: Blockly.BlockSvg;
+  private sourceBlock: Blockly.BlockSvg | null;
   private anchor?: Blockly.utils.Coordinate;
   private anchorChain?: SVGLineElement;
   private dragStartLocation?: Blockly.utils.Coordinate;
@@ -71,7 +71,7 @@ export class ScratchCommentBubble
     const destination =
       xOrCoordinate instanceof Blockly.utils.Coordinate
         ? xOrCoordinate
-        : new Blockly.utils.Coordinate(xOrCoordinate, y);
+        : new Blockly.utils.Coordinate(xOrCoordinate, y!);
     super.moveTo(destination);
     this.redrawAnchorChain();
   }
@@ -79,7 +79,9 @@ export class ScratchCommentBubble
   startGesture(e: PointerEvent) {
     const gesture = this.workspace.getGesture(e);
     if (gesture) {
-      gesture.handleBubbleStart(e, this);
+      // ScratchCommentBubble implements IBubble structurally but TypeScript
+      // cannot verify it because IBubble.drag has a different signature here.
+      gesture.handleBubbleStart(e, this as unknown as Blockly.IBubble);
       Blockly.common.setSelected(this);
     }
   }
@@ -91,7 +93,7 @@ export class ScratchCommentBubble
     Blockly.utils.dom.addClass(this.getSvgRoot(), "blocklyDragging");
   }
 
-  drag(newLocation: Blockly.utils.Coordinate, event: Event) {
+  drag(newLocation: Blockly.utils.Coordinate, event?: PointerEvent) {
     this.moveTo(newLocation);
   }
 
@@ -111,7 +113,7 @@ export class ScratchCommentBubble
   }
 
   revertDrag() {
-    this.moveTo(this.dragStartLocation);
+    this.moveTo(this.dragStartLocation!);
   }
 
   setAnchorLocation(newAnchor: Blockly.utils.Coordinate) {
@@ -122,7 +124,7 @@ export class ScratchCommentBubble
       this.dropAnchor();
     } else {
       const oldLocation = this.getRelativeToSurfaceXY();
-      const delta = Blockly.utils.Coordinate.difference(this.anchor, oldAnchor);
+      const delta = Blockly.utils.Coordinate.difference(this.anchor, oldAnchor!);
       const newLocation = Blockly.utils.Coordinate.sum(oldLocation, delta);
       this.moveTo(newLocation);
     }
@@ -131,18 +133,18 @@ export class ScratchCommentBubble
   dropAnchor() {
     const verticalOffset = 16;
     this.moveTo(
-      this.anchor.x + 40 * (this.workspace.RTL ? -1 : 1),
-      this.anchor.y - verticalOffset
+      this.anchor!.x + 40 * (this.workspace.RTL ? -1 : 1),
+      this.anchor!.y - verticalOffset
     );
     const location = this.getRelativeToSurfaceXY();
     this.anchorChain = Blockly.utils.dom.createSvgElement(
       Blockly.utils.Svg.LINE,
       {
-        x1: this.anchor.x - location.x,
-        y1: this.anchor.y - location.y,
+        x1: this.anchor!.x - location.x,
+        y1: this.anchor!.y - location.y,
         x2: (this.getSize().width / 2) * (this.workspace.RTL ? -1 : 1),
         y2: verticalOffset,
-        style: `stroke: ${this.sourceBlock.getColourTertiary()}; stroke-width: 1`,
+        style: `stroke: ${this.sourceBlock!.getColourTertiary()}; stroke-width: 1`,
       },
       this.getSvgRoot()
     );
@@ -156,8 +158,8 @@ export class ScratchCommentBubble
     if (!this.anchorChain) return;
 
     const location = this.getRelativeToSurfaceXY();
-    this.anchorChain.setAttribute("x1", `${this.anchor.x - location.x}`);
-    this.anchorChain.setAttribute("y1", `${this.anchor.y - location.y}`);
+    this.anchorChain!.setAttribute("x1", `${this.anchor!.x - location.x}`);
+    this.anchorChain!.setAttribute("y1", `${this.anchor!.y - location.y}`);
   }
 
   getId() {
@@ -170,7 +172,7 @@ export class ScratchCommentBubble
 
   dispose() {
     this.disposing = true;
-    Blockly.utils.dom.removeNode(this.anchorChain);
+    Blockly.utils.dom.removeNode(this.anchorChain ?? null);
     if (this.sourceBlock) {
       Blockly.Events.fire(
         new (Blockly.Events.get("block_comment_delete"))(this, this.sourceBlock)

--- a/src/scratch_comment_icon.ts
+++ b/src/scratch_comment_icon.ts
@@ -196,7 +196,7 @@ export class ScratchCommentIcon
     this.commentBubble.setCollapsed(!visible);
   }
 
-  getBubble() {
+  getBubble(): ScratchCommentBubble | null {
     return this.commentBubble;
   }
 

--- a/src/scratch_dragger.ts
+++ b/src/scratch_dragger.ts
@@ -104,8 +104,8 @@ export class ScratchDragger extends Blockly.dragging.Dragger {
       this.wouldDeleteDraggable(event, this.draggable.getRootBlock())
     ) {
       const prototype = this.draggable
-        .getInput("custom_block")
-        .connection.targetBlock();
+        .getInput("custom_block")!
+        .connection!.targetBlock();
       const hasCaller =
         prototype instanceof Blockly.BlockSvg &&
         isProcedureBlock(prototype) &&

--- a/src/scratch_variable_model.ts
+++ b/src/scratch_variable_model.ts
@@ -13,8 +13,8 @@ export class ScratchVariableModel extends Blockly.VariableModel {
   constructor(
     workspace: Blockly.Workspace,
     name: string,
-    type: string,
-    id: string,
+    type?: string,
+    id?: string,
     public isLocal = false,
     public isCloud = false
   ) {

--- a/src/status_indicator_label.ts
+++ b/src/status_indicator_label.ts
@@ -64,11 +64,11 @@ export class StatusIndicatorLabel extends Blockly.FlyoutButton {
     json: Blockly.utils.toolbox.LabelInfo
   ) {
     super(workspace, targetWorkspace, json, true);
-    this.extensionId = json["id"];
+    this.extensionId = json["id"]!;
 
     const heightDelta = 40 - this.height;
     this.height = 40;
-    const text = this.getSvgRoot().querySelector("text");
+    const text = this.getSvgRoot().querySelector("text")!;
     const previousY = Number(text.getAttribute("y"));
 
     text.setAttribute("y", `${previousY + heightDelta / 2}`);
@@ -77,7 +77,7 @@ export class StatusIndicatorLabel extends Blockly.FlyoutButton {
     const marginX = 20;
     const marginY = 5;
     const touchPadding = 16;
-    const flyoutWidth = targetWorkspace.getFlyout().getWidth();
+    const flyoutWidth = targetWorkspace.getFlyout()!.getWidth();
 
     const statusButtonX = workspace.RTL
       ? marginX - flyoutWidth + statusButtonWidth

--- a/src/status_indicator_label_flyout_inflater.ts
+++ b/src/status_indicator_label_flyout_inflater.ts
@@ -26,7 +26,7 @@ class StatusIndicatorLabelFlyoutInflater extends Blockly.LabelFlyoutInflater {
   ): Blockly.FlyoutItem {
     const label = new StatusIndicatorLabel(
       flyout.getWorkspace(),
-      flyout.targetWorkspace,
+      flyout.targetWorkspace!,
       state
     );
     label.show();

--- a/src/variables.ts
+++ b/src/variables.ts
@@ -98,7 +98,7 @@ export function createVariable(
   const validate = nameValidator.bind(null, opt_type);
 
   // Prompt the user to enter a name for the variable
-  prompt(
+  prompt!(
     newMsg,
     "",
     function (
@@ -127,7 +127,7 @@ export function createVariable(
           workspace,
           validatedText,
           opt_type,
-          null,
+          undefined,
           isLocal,
           isCloud
         );
@@ -137,7 +137,7 @@ export function createVariable(
         );
 
         const toolbox = workspace.getToolbox();
-        const flyout = toolbox.getFlyout();
+        const flyout = toolbox?.getFlyout();
         const variableBlockId = variable.getId();
         if (
           toolbox instanceof ScratchContinuousToolbox &&
@@ -154,7 +154,7 @@ export function createVariable(
       } else {
         // User canceled prompt without a value.
         if (opt_callback) {
-          opt_callback(null);
+          opt_callback(undefined);
         }
       }
     },
@@ -193,7 +193,7 @@ function nameValidator(
   additionalVars: string[],
   isCloud: boolean,
   opt_callback?: (id?: string) => void
-): string {
+): string | null {
   // The validators for the different variable types require slightly different
   // arguments. For broadcast messages, if a broadcast message of the provided
   // name already exists, the validator needs to call a function that updates
@@ -345,7 +345,7 @@ export function renameVariable(
     promptDefaultText = promptDefaultText.substring(CLOUD_PREFIX.length);
   }
 
-  prompt(
+  prompt!(
     promptText,
     promptDefaultText,
     (newName: string, additionalVars: string[]) => {
@@ -373,7 +373,7 @@ export function renameVariable(
       } else {
         // User canceled prompt without a value.
         if (opt_callback) {
-          opt_callback(null);
+          opt_callback(undefined);
         }
       }
     },

--- a/src/xml.ts
+++ b/src/xml.ts
@@ -26,8 +26,8 @@ export function clearWorkspaceAndLoadFromXml(
   for (const variable of xml.querySelectorAll("variables variable")) {
     const id = variable.getAttribute("id");
     if (!id) continue;
-    const type = variable.getAttribute("type");
-    const name = variable.textContent;
+    const type = variable.getAttribute("type") ?? "";
+    const name = variable.textContent ?? "";
     const isLocal = variable.getAttribute("islocal") === "true";
     const isCloud = variable.getAttribute("iscloud") === "true";
 
@@ -47,7 +47,7 @@ export function clearWorkspaceAndLoadFromXml(
 
   // Remove the `variables` element from the XML to prevent Blockly from
   // throwing or stomping on the variables we created.
-  xml.querySelector("variables").remove();
+  xml.querySelector("variables")?.remove();
 
   // Defer to core for the rest of the deserialization.
   const blockIds = Blockly.Xml.domToWorkspace(xml, workspace);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     /* Type Checking */
     "noImplicitAny": true,
-    "strict": false, // TODO: try to enable "strict" mode and fix the resulting errors
+    "strict": true,
 
     /* Modules */
     "module": "esnext",


### PR DESCRIPTION
### Proposed Changes

Enable `"strict": true` in `tsconfig.json` and resolve resulting issues.

### Reason for Changes

Enabling strict mode should help catch errors on its own, and it also allows other tools (like `eslint`) to perform additional checks that are otherwise unavailable. Some of the checks inspired by `tsc` strict check failures may even fix current bugs.
