### PR TITLE
fix: convert prototypes from shadow to regular block

### DIFF
--- a/src/blocks/procedures.ts
+++ b/src/blocks/procedures.ts
@@ -44,6 +44,41 @@ enum ArgumentType {
 }
 
 /**
+ * A drag strategy for the procedures_prototype block that delegates all drag
+ * operations to its parent (the procedures_definition block). This lets the
+ * prototype act as a non-shadow block (so its argument-reporter children can
+ * also be non-shadow and therefore clickable/draggable) while still causing
+ * the entire definition to move when the prototype area is dragged.
+ */
+class DelegateToParentDraggable implements Blockly.IDraggable {
+  constructor(private block: Blockly.BlockSvg) {}
+
+  isMovable(): boolean {
+    return this.block.getParent()?.isMovable() ?? false
+  }
+
+  startDrag(e: PointerEvent) {
+    this.block.getParent()?.startDrag(e)
+  }
+
+  drag(newLoc: Blockly.utils.Coordinate, e?: PointerEvent) {
+    this.block.getParent()?.drag(newLoc, e)
+  }
+
+  endDrag(e: PointerEvent) {
+    this.block.getParent()?.endDrag(e)
+  }
+
+  revertDrag() {
+    this.block.getParent()?.revertDrag()
+  }
+
+  getRelativeToSurfaceXY() {
+    return (this.block.getParent() ?? this.block).getRelativeToSurfaceXY()
+  }
+}
+
+/**
  * Class representing a draggable block that copies itself on drag.
  */
 class DuplicateOnDragDraggable implements Blockly.IDraggable {
@@ -76,6 +111,8 @@ class DuplicateOnDragDraggable implements Blockly.IDraggable {
       return
     }
     this.copy = Blockly.clipboard.paste(data, this.block.workspace) as Blockly.BlockSvg
+    this.copy.setDeletable(true)
+    this.copy.setDragStrategy(new Blockly.dragging.BlockDragStrategy(this.copy))
     this.copy.startDrag(e)
   }
 
@@ -200,7 +237,7 @@ function updateDisplay_(this: ProcedureBlock) {
   const connectionMap = this.disconnectOldBlocks_()
   this.removeAllInputs_()
   this.createAllInputs_(connectionMap)
-  this.deleteShadows_(connectionMap)
+  this.disposeObsoleteBlocks_(connectionMap)
 }
 
 /**
@@ -284,23 +321,27 @@ function createAllInputs_(this: ProcedureBlock, connectionMap: ConnectionMap) {
 }
 
 /**
- * Delete all shadow blocks in the given map.
+ * Dispose of blocks that were disconnected from the block (and not reconnected) during mutation.
+ * This includes:
+ * - shadow blocks for default argument values (on call blocks)
+ * - shadow argument editor blocks (on declaration blocks in the procedure editor)
+ * - non-shadow argument reporter blocks (on the prototype)
  * @param connectionMap An object mapping argument IDs to the blocks that were
  *     connected to those IDs at the beginning of the mutation.
  */
-function deleteShadows_(this: ProcedureBlock, connectionMap: ConnectionMap) {
-  // Get rid of all of the old shadow blocks if they aren't connected.
-  if (connectionMap) {
-    for (const id in connectionMap) {
-      const saveInfo = connectionMap[id]
-      if (saveInfo) {
-        const block = saveInfo.block
-        if (block && block.isShadow()) {
-          block.dispose()
-          connectionMap[id] = null
-          // At this point we know which shadow DOMs are about to be orphaned in
-          // the VM.  What do we do with that information?
-        }
+function disposeObsoleteBlocks_(this: ProcedureBlock, connectionMap: ConnectionMap) {
+  for (const id in connectionMap) {
+    const saveInfo = connectionMap[id]
+    if (saveInfo) {
+      const block = saveInfo.block
+      const isOrphanedArgumentReporter =
+        this.type === 'procedures_prototype' &&
+        (block.type === 'argument_reporter_string_number' || block.type === 'argument_reporter_boolean')
+      if (block.isShadow() || isOrphanedArgumentReporter) {
+        block.dispose()
+        connectionMap[id] = null
+        // At this point we know which shadow DOMs are about to be orphaned in
+        // the VM.  What do we do with that information?
       }
     }
   }
@@ -409,7 +450,7 @@ function createArgumentReporter_(
   let newBlock
   try {
     newBlock = this.workspace.newBlock(blockType)
-    newBlock.setShadow(true)
+    newBlock.setDeletable(false)
     newBlock.setFieldValue(displayName, 'VALUE')
     if (!this.isInsertionMarker()) {
       newBlock.initSvg()
@@ -780,12 +821,13 @@ function updateArgumentReporterNames_(
   if (!definitionBlock) return
 
   // Create a list of argument reporters that are descendants of the definition stack (see above comment)
-  definitionBlock.getDescendants(false).forEach((block: Blockly.BlockSvg) => {
+  // Exclude arg reporters in the prototype block itself (they're owned by the prototype, not the user).
+  const protoDescendants = new Set(this.getDescendants(false))
+  definitionBlock.getDescendants(false).forEach((block) => {
     if (
       (block.type === 'argument_reporter_string_number' || block.type === 'argument_reporter_boolean') &&
-      !block.isShadow()
+      !protoDescendants.has(block)
     ) {
-      // Exclude arg reporters in the prototype block, which are shadows.
       argReporters.push(block)
     }
   })
@@ -848,7 +890,7 @@ Blockly.Blocks.procedures_call = {
     this.getProcCode = getProcCode.bind(this)
     this.removeAllInputs_ = removeAllInputs_.bind(this)
     this.disconnectOldBlocks_ = disconnectOldBlocks_.bind(this)
-    this.deleteShadows_ = deleteShadows_.bind(this)
+    this.disposeObsoleteBlocks_ = disposeObsoleteBlocks_.bind(this)
     this.createAllInputs_ = createAllInputs_.bind(this)
     this.updateDisplay_ = updateDisplay_.bind(this)
 
@@ -874,6 +916,13 @@ Blockly.Blocks.procedures_prototype = {
       extensions: ['colours_more', 'shape_statement'],
     })
 
+    // Previously this block was a shadow, which is non-deletable and
+    // non-movable by default. Now that it's a regular block, explicitly
+    // replicate those properties and add a drag strategy that delegates all
+    // drag operations to the parent (procedures_definition) block.
+    this.setDeletable(false)
+    this.setDragStrategy(new DelegateToParentDraggable(this))
+
     /* Data known about the procedure. */
     this.procCode_ = ''
     this.displayNames_ = []
@@ -885,7 +934,7 @@ Blockly.Blocks.procedures_prototype = {
     this.getProcCode = getProcCode.bind(this)
     this.removeAllInputs_ = removeAllInputs_.bind(this)
     this.disconnectOldBlocks_ = disconnectOldBlocks_.bind(this)
-    this.deleteShadows_ = deleteShadows_.bind(this)
+    this.disposeObsoleteBlocks_ = disposeObsoleteBlocks_.bind(this)
     this.createAllInputs_ = createAllInputs_.bind(this)
     this.updateDisplay_ = updateDisplay_.bind(this)
     // Exist on all three blocks, but have different implementations.
@@ -919,7 +968,7 @@ Blockly.Blocks.procedures_declaration = {
     this.getProcCode = getProcCode.bind(this)
     this.removeAllInputs_ = removeAllInputs_.bind(this)
     this.disconnectOldBlocks_ = disconnectOldBlocks_.bind(this)
-    this.deleteShadows_ = deleteShadows_.bind(this)
+    this.disposeObsoleteBlocks_ = disposeObsoleteBlocks_.bind(this)
     this.createAllInputs_ = createAllInputs_.bind(this)
     this.updateDisplay_ = updateDisplay_.bind(this)
 
@@ -941,6 +990,17 @@ Blockly.Blocks.procedures_declaration = {
     this.addBooleanExternal = addBooleanExternal.bind(this)
     this.addStringNumberExternal = addStringNumberExternal.bind(this)
     this.onChangeFn = updateDeclarationProcCode_.bind(this)
+  },
+  // The procedures_declaration block lives in the ephemeral Custom Procedures
+  // dialog workspace, which is disposed (and unregistered from FocusManager)
+  // when the dialog closes. If FocusManager tracks this block as the focused
+  // node while the WidgetDiv is open, the `returnEphemeralFocus` callback
+  // schedules a setTimeout that tries to re-focus it after the dialog workspace
+  // has been disposed — throwing "Attempted to focus unregistered node". Making
+  // this block non-focusable prevents FocusManager from ever storing it as the
+  // focused node, so the setTimeout is never scheduled.
+  canBeFocused: function () {
+    return false
   },
 }
 
@@ -1023,7 +1083,7 @@ interface ProcedureBlock extends Blockly.BlockSvg {
   getProcCode: () => string
   removeAllInputs_: () => void
   disconnectOldBlocks_: () => ConnectionMap
-  deleteShadows_: (connectionMap: ConnectionMap) => void
+  disposeObsoleteBlocks_: (connectionMap: ConnectionMap) => void
   createAllInputs_: (connectionMap: ConnectionMap) => void
   updateDisplay_: () => void
   populateArgument_: (

--- a/src/procedures.ts
+++ b/src/procedures.ts
@@ -237,9 +237,9 @@ function createProcedureCallbackFactory(workspace: Blockly.WorkspaceSvg): (mutat
       <xml>
         <block type="procedures_definition">
           <statement name="custom_block">
-            <shadow type="procedures_prototype">
+            <block type="procedures_prototype">
               ${Blockly.Xml.domToText(mutation)}
-            </shadow>
+            </block>
           </statement>
         </block>
       </xml>`

--- a/src/renderer/path_object.ts
+++ b/src/renderer/path_object.ts
@@ -17,11 +17,15 @@ export class PathObject extends Blockly.zelos.PathObject {
   override applyColour(block: Blockly.BlockSvg) {
     super.applyColour(block)
 
-    // These blocks are special in that, while they are technically shadow
-    // blocks when contained in a procedure definition/prototype, their parent
-    // (the sample procedure caller block embedded in the definition block) is
-    // also a shadow, so they need to use normal block colors in order to
-    // provide contrast with it.
+    // The prototype block is no longer a Blockly shadow, but it should still
+    // visually appear as one (using colourSecondary, the shadow fill colour).
+    if (block.type === 'procedures_prototype') {
+      this.svgPath.setAttribute('fill', this.style.colourSecondary)
+    }
+
+    // Argument reporter blocks sit inside the prototype (which now renders with
+    // the shadow/secondary colour), so they need the full primary colour to
+    // stand out, just as they did when the prototype was a real shadow block.
     if (block.type === 'argument_reporter_string_number' || block.type === 'argument_reporter_boolean') {
       this.svgPath.setAttribute('fill', this.style.colourPrimary)
     }

--- a/src/scratch_connection_checker.ts
+++ b/src/scratch_connection_checker.ts
@@ -8,6 +8,21 @@ import * as Blockly from 'blockly/core'
  * Custom connection checker to restrict which blocks can be connected.
  */
 class ScratchConnectionChecker extends Blockly.ConnectionChecker {
+  override canConnectWithReason(
+    a: Blockly.Connection | null,
+    b: Blockly.Connection | null,
+    isDragging: boolean,
+    opt_distance?: number,
+  ): number {
+    // The prototype block is visual-only and should not accept any connections.
+    const isPrototypeConnection = (c: Blockly.Connection | null) =>
+      c?.getSourceBlock().type === 'procedures_prototype'
+    if (isPrototypeConnection(a) || isPrototypeConnection(b)) {
+      return Blockly.Connection.REASON_CHECKS_FAILED
+    }
+    return super.canConnectWithReason(a, b, isDragging, opt_distance)
+  }
+
   /**
    * Returns whether or not the two connections should be allowed to connect.
    * @param a One of the connections to check.

--- a/src/scratch_dragger.ts
+++ b/src/scratch_dragger.ts
@@ -84,16 +84,20 @@ export class ScratchDragger extends Blockly.dragging.Dragger {
    * @param event The event that ended the drag.
    */
   onDragEnd(event: PointerEvent) {
+    // When the prototype block is dragged (via its DelegateToParentDraggable
+    // strategy), this.draggable is the prototype, but getDragRoot returns the
+    // definition. Handle both cases for the "procedure is in use" check.
+    const dragRoot = this.getDragRoot(this.draggable)
     if (
-      this.draggable instanceof Blockly.BlockSvg &&
-      this.draggable.type === 'procedures_definition' &&
-      this.wouldDeleteDraggable(event, this.draggable.getRootBlock())
+      dragRoot instanceof Blockly.BlockSvg &&
+      dragRoot.type === 'procedures_definition' &&
+      this.wouldDeleteDraggable(event, dragRoot.getRootBlock())
     ) {
-      const prototype = this.draggable.getInput('custom_block')!.connection!.targetBlock()
+      const prototype = dragRoot.getInput('custom_block')!.connection!.targetBlock()
       const hasCaller =
         prototype instanceof Blockly.BlockSvg &&
         isProcedureBlock(prototype) &&
-        getCallers(prototype.getProcCode(), this.draggable.workspace, this.draggable.getRootBlock(), false).length > 0
+        getCallers(prototype.getProcCode(), dragRoot.workspace, dragRoot.getRootBlock(), false).length > 0
 
       if (hasCaller) {
         Blockly.dialog.alert(Blockly.Msg.PROCEDURE_USED)
@@ -140,8 +144,8 @@ export class ScratchDragger extends Blockly.dragging.Dragger {
   }
 
   /**
-   * Returns the root element being dragged. For shadow blocks, this is the
-   * parent block.
+   * Returns the root element being dragged. For shadow blocks and the
+   * procedures_prototype block, this is the parent block.
    * @param draggable The element being dragged directly.
    * @returns The element being dragged, or its parent.
    */
@@ -149,7 +153,10 @@ export class ScratchDragger extends Blockly.dragging.Dragger {
     // We can't just use getRootBlock() here because, when blocks are detached
     // from a stack via dragging, getRootBlock() still returns the root of that
     // stack.
-    if (draggable instanceof Blockly.BlockSvg && draggable.isShadow()) {
+    if (
+      draggable instanceof Blockly.BlockSvg &&
+      (draggable.isShadow() || draggable.type === 'procedures_prototype')
+    ) {
       return draggable.getParent()
     }
 


### PR DESCRIPTION
### Resolves

- Resolves scratchfoundation/scratch-blocks#3450

### Proposed Changes

Stop using shadows for procedure prototype blocks or their argument reporters.

### Reason for Changes

This allows argument reporters to be draggable in the context of RaspberryPiFoundation/blockly#9538. The remaining changes deal with the fallout from this change: we still want the prototype to use the secondary (shadow-esque) color, we still want the arguments to be non-deletable, etc.
