### PR TITLE
fix: be more cautious about workspace scrolling on block deletion

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -157,3 +157,18 @@ contextMenuItems.registerDuplicateBlock()
 Blockly.ContextMenuRegistry.registry.unregister('workspaceDelete')
 contextMenuItems.registerDeleteAll()
 Blockly.comments.CommentView.defaultCommentSize = new Blockly.utils.Size(200, 200)
+
+// When the focused block is deleted and has no parent or nearby neighbor,
+// Blockly falls back to focusing the first/topmost block in the workspace,
+// which triggers a scroll to that block. In Scratch, focus should fall back
+// to the workspace itself (whose onNodeFocus is a no-op) rather than to a
+// specific block, so deleting a block doesn't reset the scroll position.
+// We may need to re-evaluate this when we explicitly work on keyboard navigation.
+const originalGetRestoredFocusableNode =
+  Blockly.WorkspaceSvg.prototype.getRestoredFocusableNode
+Blockly.WorkspaceSvg.prototype.getRestoredFocusableNode = function (
+  previousNode,
+) {
+  if (!previousNode && !this.isFlyout) return null
+  return originalGetRestoredFocusableNode.call(this, previousNode)
+}


### PR DESCRIPTION
### Resolves

- Resolves scratchfoundation/scratch-blocks#3464

### Proposed Changes

Replace `getRestoredFocusableNode` with a version that defaults to returning `null`, rather than resetting to the first block, if there's no good answer.

### Reason for Changes

This was causing unwanted scrolling; see scratchfoundation/scratch-blocks#3464

@gonfunko, I feel like Blockly might want a more careful version of this, or (maybe more likely) there's something I'm missing about this being intentional or desirable, or (maybe most likely) there's some other set of things conspiring to make this a Scratch-specific issue.