### PR TITLE
Minor cleanup

### DIFF
--- a/src/blocks/procedures.ts
+++ b/src/blocks/procedures.ts
@@ -570,10 +570,7 @@ function populateArgumentOnDeclaration_(
     oldBlock = saveInfo?.block ?? null
   }
 
-  // TODO: This always returns false, because it checks for argument reporter
-  // blocks instead of argument editor blocks.  Create a new version for argument
-  // editors.
-  const oldTypeMatches = checkOldTypeMatches_(oldBlock, type)
+  const oldTypeMatches = checkOldEditorTypeMatches_(oldBlock, type)
   const displayName = this.displayNames_[index]
 
   // Decide which block to attach.
@@ -591,13 +588,13 @@ function populateArgumentOnDeclaration_(
 }
 
 /**
- * Check whether the type of the old block corresponds to the given argument
- * type.
+ * Check whether the type of the old argument reporter block corresponds to the
+ * given argument type.
  * @param oldBlock The old block to check.
- * @param type The argument type.  One of 'n', 'n', or 's'.
+ * @param type The argument type.  One of 'n', 'b', or 's'.
  * @returns True if the type matches, false otherwise.
  */
-function checkOldTypeMatches_(oldBlock: Blockly.BlockSvg | null, type: string): boolean {
+function checkOldTypeMatches_(oldBlock: Blockly.BlockSvg | null, type: ArgumentType): boolean {
   if (!oldBlock) {
     return false
   }
@@ -608,6 +605,29 @@ function checkOldTypeMatches_(oldBlock: Blockly.BlockSvg | null, type: string): 
     return true
   }
   if (type === ArgumentType.BOOLEAN && oldBlock.type === 'argument_reporter_boolean') {
+    return true
+  }
+  return false
+}
+
+/**
+ * Check whether the type of the old argument editor block corresponds to the
+ * given argument type.
+ * @param oldBlock The old block to check.
+ * @param type The argument type.  One of 'n', 'b', or 's'.
+ * @returns True if the type matches, false otherwise.
+ */
+function checkOldEditorTypeMatches_(oldBlock: Blockly.BlockSvg | null, type: ArgumentType): boolean {
+  if (!oldBlock) {
+    return false
+  }
+  if (
+    (type === ArgumentType.NUMBER || type === ArgumentType.STRING) &&
+    oldBlock.type === 'argument_editor_string_number'
+  ) {
+    return true
+  }
+  if (type === ArgumentType.BOOLEAN && oldBlock.type === 'argument_editor_boolean') {
     return true
   }
   return false

--- a/tests/custom_procedure_playground.html
+++ b/tests/custom_procedure_playground.html
@@ -70,7 +70,7 @@
     <xml id="main_ws_blocks" style="display: none">
       <block id="]){{Y!7N9ezN+j@Vr`8p" type="procedures_definition" x="25" y="25">
         <statement name="custom_block">
-          <shadow type="procedures_prototype" id="caller_internal">
+          <block type="procedures_prototype" id="caller_internal">
             <mutation
               proccode="say %s %n times if %b"
               argumentnames='["something","this many","this is true"]'
@@ -78,7 +78,7 @@
               warp="false"
               argumentids='["a42", "b23", "c99"]'
             />
-          </shadow>
+          </block>
         </statement>
         <next>
           <block id="caller_external" type="procedures_call">
@@ -107,7 +107,7 @@
     <xml id="main_ws_blocks_simpler" style="display: none">
       <block id="]){{Y!7N9ezN+j@Vr`8p" type="procedures_definition" x="25" y="25">
         <statement name="custom_block">
-          <shadow type="procedures_prototype" id="caller_internal">
+          <block type="procedures_prototype" id="caller_internal">
             <mutation
               proccode="say %s %n times if %b"
               argumentnames='["something","this many","this is true"]'
@@ -115,7 +115,7 @@
               warp="false"
               argumentids='["a42", "b23", "c99"]'
             />
-          </shadow>
+          </block>
         </statement>
         <next>
           <block id="caller_external" type="procedures_call"> </block>
@@ -126,7 +126,7 @@
     <xml id="main_ws_blocks_simplest" style="display: none">
       <block id="]){{Y!7N9ezN+j@Vr`8p" type="procedures_definition" x="25" y="25">
         <statement name="custom_block">
-          <shadow type="procedures_prototype" id="caller_internal">
+          <block type="procedures_prototype" id="caller_internal">
             <mutation
               proccode="my first function"
               argumentnames="[]"
@@ -134,7 +134,7 @@
               warp="false"
               argumentids="[]"
             />
-          </shadow>
+          </block>
         </statement>
         <next>
           <block id="caller_external" type="procedures_call">


### PR DESCRIPTION
### Proposed Changes

1. Update the playground HTML to reflect the new non-shadow procedure definition blocks
2. Check for old argument editor blocks, in addition to argument reporter blocks, when updating a procedure declaration

### Reason for Changes

1. Makes the playground align better with the current state of the code it tests
2. Implements a TODO and should allow existing arg editor blocks to be reused instead of re-creating them unnecessarily
