### PR TITLE
Fix procedure context menus

### DIFF
--- a/src/blocks/procedures.ts
+++ b/src/blocks/procedures.ts
@@ -876,6 +876,26 @@ function updateArgumentReporterNames_(
   }
 }
 
+/**
+ * Override showContextMenu on an argument reporter block so that right-clicks
+ * while the block is seated inside a procedures_prototype delegate up to the
+ * prototype (which in turn delegates to the parent procedures_definition).
+ * When the reporter has been dragged out and lives elsewhere, it keeps its
+ * normal context menu.
+ * @param block The argument reporter block to configure.
+ */
+function delegateContextMenuToPrototypeParent(block: Blockly.BlockSvg) {
+  const origShowContextMenu = block.showContextMenu.bind(block)
+  block.showContextMenu = function (this: Blockly.BlockSvg, e: Event) {
+    const parent = this.getParent()
+    if (parent?.type === 'procedures_prototype') {
+      parent.showContextMenu(e)
+    } else {
+      origShowContextMenu(e)
+    }
+  }
+}
+
 Blockly.Blocks.procedures_definition = {
   /**
    * Block for defining a procedure with no return value.
@@ -942,6 +962,18 @@ Blockly.Blocks.procedures_prototype = {
     // drag operations to the parent (procedures_definition) block.
     this.setDeletable(false)
     this.setDragStrategy(new DelegateToParentDraggable(this))
+
+    // Delegate right-clicks to the parent define block so that "Add Comment",
+    // "Edit", etc. act on the definition rather than the prototype itself.
+    const protoOrigShowContextMenu = this.showContextMenu.bind(this)
+    this.showContextMenu = function (this: Blockly.BlockSvg, e: Event) {
+      const parent = this.getParent()
+      if (parent) {
+        parent.showContextMenu(e)
+      } else {
+        protoOrigShowContextMenu(e)
+      }
+    }
 
     /* Data known about the procedure. */
     this.procCode_ = ''
@@ -1038,6 +1070,7 @@ Blockly.Blocks.argument_reporter_boolean = {
       extensions: ['colours_more', 'output_boolean'],
     })
     this.setDragStrategy(new DuplicateOnDragDraggable(this))
+    delegateContextMenuToPrototypeParent(this)
   },
 }
 
@@ -1055,6 +1088,7 @@ Blockly.Blocks.argument_reporter_string_number = {
       extensions: ['colours_more', 'output_number', 'output_string'],
     })
     this.setDragStrategy(new DuplicateOnDragDraggable(this))
+    delegateContextMenuToPrototypeParent(this)
   },
 }
 

--- a/src/blocks/vertical_extensions.ts
+++ b/src/blocks/vertical_extensions.ts
@@ -182,7 +182,7 @@ const PROCEDURE_DEF_CONTEXTMENU = function (this: Blockly.Block) {
 
         // Find and remove the duplicate option
         for (let i = 0, option; (option = menuOptions[i]); i++) {
-          if (option.text == Blockly.Msg.DUPLICATE) {
+          if (option.text == Blockly.Msg.DUPLICATE_BLOCK) {
             menuOptions.splice(i, 1)
             break
           }


### PR DESCRIPTION
### Resolves

Somewhat related to scratchfoundation/scratch-blocks#3484 and scratchfoundation/scratch-blocks#3485

### Proposed Changes

- Remove "Duplicate" from the context menu for "define" blocks. (Actually, this was already the intended behavior, but the code to suppress the menu item wasn't working.)
- Make the procedure prototype and its argument reporters "transparent" for the purposes of the context menu: they delegate context menu handling to the "define" block.

### Reason for Changes

These were places where procedure context menu behavior differed from `scratch-blocks@^1`.
