### PR TITLE
chore: light cleanup for linting and types in tests

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -48,6 +48,15 @@ export default eslintConfigScratch.defineConfig(
       '@typescript-eslint/restrict-template-expressions': 'warn',
     },
   },
+  {
+    // Tests frequently introspect internals and invoke prototype methods directly.
+    files: ['tests/**/*.{ts,tsx,mts,cts}'],
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'off',
+      '@typescript-eslint/no-unsafe-call': 'off',
+      '@typescript-eslint/no-unsafe-member-access': 'off',
+    },
+  },
   globalIgnores([
     '*_compressed*.js',
     '*_uncompressed*.js',

--- a/tests/unit/c_block_wrap.test.ts
+++ b/tests/unit/c_block_wrap.test.ts
@@ -97,7 +97,6 @@ describe('C-block wrapping', () => {
     markerStatementConn.connect(b2.previousConnection)
 
     // The original hideInsertionMarker does not use `this`, so any object works as context.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call -- tested function does not use `this`
     ;(Blockly.InsertionMarkerPreviewer.prototype as any).hideInsertionMarker.call({}, marker.previousConnection)
 
     // After cleanup, the stack should be healed: B1 → B2 (marker was disposed)

--- a/tests/unit/context_menu_items.test.ts
+++ b/tests/unit/context_menu_items.test.ts
@@ -15,6 +15,10 @@ let originalDeleteBlock: string
 let originalDeleteXBlocks: string
 let originalDeleteItem: Blockly.ContextMenuRegistry.RegistryItem | null = null
 
+function asBlockSvg(block: unknown): Blockly.BlockSvg {
+  return block as Blockly.BlockSvg
+}
+
 beforeAll(() => {
   // Save and override messages used by the delete option's displayText.
   // Restored in afterAll to avoid polluting other test files.
@@ -71,7 +75,7 @@ describe('registerDeleteBlock', () => {
     const item = Blockly.ContextMenuRegistry.registry.getItem('blockDelete')
     assert(item, 'Expected blockDelete item to be registered')
     const displayFn = item.displayText as (scope: Blockly.ContextMenuRegistry.Scope) => string
-    const text = displayFn({ block: block as unknown as Blockly.BlockSvg })
+    const text = displayFn({ block: asBlockSvg(block) })
     expect(text).toBe('Delete Block')
   })
 
@@ -106,7 +110,7 @@ describe('registerDeleteBlock', () => {
       const item = Blockly.ContextMenuRegistry.registry.getItem('blockDelete')
       assert(item, 'Expected blockDelete item to be registered')
       const displayFn = item.displayText as (scope: Blockly.ContextMenuRegistry.Scope) => string
-      const text = displayFn({ block: parent as unknown as Blockly.BlockSvg })
+      const text = displayFn({ block: asBlockSvg(parent) })
       expect(text).toBe('Delete Block')
     } finally {
       delete Blockly.Blocks.test_value_block
@@ -128,7 +132,7 @@ describe('registerDeleteBlock', () => {
     const item = Blockly.ContextMenuRegistry.registry.getItem('blockDelete')
     assert(item, 'Expected blockDelete item to be registered')
     const displayFn = item.displayText as (scope: Blockly.ContextMenuRegistry.Scope) => string
-    const text = displayFn({ block: first as unknown as Blockly.BlockSvg })
+    const text = displayFn({ block: asBlockSvg(first) })
     expect(text).toBe('Delete Block')
   })
 
@@ -160,7 +164,7 @@ describe('registerDeleteBlock', () => {
       const item = Blockly.ContextMenuRegistry.registry.getItem('blockDelete')
       assert(item, 'Expected blockDelete item to be registered')
       const displayFn = item.displayText as (scope: Blockly.ContextMenuRegistry.Scope) => string
-      const text = displayFn({ block: parent as unknown as Blockly.BlockSvg })
+      const text = displayFn({ block: asBlockSvg(parent) })
       expect(text).toBe('Delete 2 Blocks')
     } finally {
       delete Blockly.Blocks.test_value_block

--- a/tests/unit/scratch_field_number.test.ts
+++ b/tests/unit/scratch_field_number.test.ts
@@ -22,7 +22,7 @@ function makeField(config: Record<string, unknown> = {}): AnyField {
   // defaults). This is equivalent to the original new FieldClass() pattern.
   const field = Blockly.fieldRegistry.TEST_ONLY.fromJsonInternal({
     type: 'field_number',
-  }) as unknown as AnyField
+  }) as AnyField
   field.configure_(config)
   return field
 }


### PR DESCRIPTION
### Proposed Changes

Turn off some linting rules within `tests/` specifically
Eliminate `as unknown as ...` double-cast pattern

### Reason for Changes

Part of a larger linting cleanup. I broke this off to make the large PR slightly smaller.
