### PR TITLE
Lint src strictly

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,5 +169,6 @@ Review all changes and confirm:
 - **Simplicity**: Implementation is as simple as possible; no unnecessary code remains.
 - **`node_modules/`**: No changes within this directory. In particular, no direct edits to Blockly source files.
 - **Runtime checks**: Any new guards for states that should never happen include diagnostic logging.
+- **Build passes**: `npm run build` completes successfully.
 - **Tests pass**: `npm run test` completes with no failures.
 - **No lint errors**: `npm run test:lint` passes. Iterate with `npm run format` and/or manual changes as needed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,6 +110,24 @@ If data is required (e.g., deserialized event fields), validate and fail with a 
 
 Prefer narrowing once into a local variable over repeating `!` at each use site.
 
+#### Removing non-null assertions
+
+When replacing `!` due to linting, preserve the fail-fast behavior. If code would have crashed on
+`maybeNull.property`, replace with explicit validation that throws, not silent degradation:
+
+```js
+// ❌ BAD: Silently masks an error that would have been loud before
+const badResult = maybeElement?.property ?? fallback
+
+// ✅ GOOD: Turns a generic crash into a specific, actionable error with context
+if (!maybeElement) throw new Error('Missing required element')
+const goodResult = maybeElement.property
+```
+
+Only use graceful degradation (`if (!x) return`) when the situation genuinely warrants it (e.g., optional UI
+updates). For required data (configuration, mutations, required relationships), preserve the crash behavior with an
+explicit error.
+
 ### Type assertions (`as`)
 
 Rely on TypeScript's inference and explicit annotations first. Use `as SomeType` only when necessary (e.g., narrowing

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,26 +92,51 @@ When adding runtime checks for states that should never happen (including guard-
 
 ## TypeScript guidelines
 
-### When using non-null assertions (`!`)
+### Avoid `any`
 
-Use sparingly and only when you genuinely know — in a way the compiler cannot prove — that a value is not null or
-undefined. Prefer type guards (`if (!x) return`), optional chaining (`?.`), or nullish coalescing (`??`) instead. The
-`!` operator silences the compiler without adding any runtime safety, so a misplaced one becomes a runtime crash.
+Do not use `any` as a type annotation. Prefer proper types, `unknown`, or a union. When calling into Blockly APIs
+that have weak types, add a local cast (`as ConcreteType`) with a comment explaining the narrowing rather than
+propagating `any` throughout the caller.
 
-Before adding a new `!`, quickly check these alternatives:
+### Non-null assertions (`!`)
 
-- Can you narrow once and reuse a local (`const x = ...; if (!x) return;`)?
-- Can the type carry the uncertainty directly (`prop?: T`, `T | null`) and be assigned conditionally?
-- Can you use optional chaining for best-effort UI updates (`node?.setAttribute(...)`)?
-- If data is required (e.g., mutation XML attrs), can you validate and fail clearly instead of asserting?
+Do not use `!` unless you genuinely know — in a way the compiler cannot prove — that a value is non-null. Prefer:
 
-Prefer narrowing once and reusing a local variable over repeating assertions at each use site.
+- A type guard with early return: `if (!x) return;`
+- Optional chaining for best-effort reads: `node?.getAttribute(...)`
+- Nullish coalescing for fallbacks: `value ?? default`
 
-### When using type assertions (`as`)
+If data is required (e.g., deserialized event fields), validate and fail with a logged error rather than asserting.
 
-Rely on TypeScript's inference and explicit type annotations first. Use `as SomeType` only when necessary (e.g., when
-narrowing a union that inference can't resolve). Treat `as unknown as Type` as a last resort, and add a comment
-explaining why it is both necessary and safe.
+Prefer narrowing once into a local variable over repeating `!` at each use site.
+
+### Type assertions (`as`)
+
+Rely on TypeScript's inference and explicit annotations first. Use `as SomeType` only when necessary (e.g., narrowing
+a union inference can't resolve). Treat `as unknown as Type` as a last resort; add a comment explaining why it is
+both necessary and safe.
+
+### Nullish coalescing and optional chaining
+
+Prefer `??` over `|| default` for null/undefined fallbacks, and `?.` over `x && x.y` for optional member access.
+Both are safer (they don't coerce falsy values) and trigger lint errors if the left-hand side is provably non-null.
+
+### Promises
+
+Do not leave promises floating. Either `await` the result, return it, or prefix with `void` to explicitly discard it.
+Unhandled promise rejections are silent failures.
+
+### Loop style
+
+Prefer `for...of` over index-based `for` loops when the index is not needed.
+
+### Unused values
+
+Keep `no-unused-vars` enabled. Preferred handling:
+
+- Remove dead locals/imports when possible.
+- For intentionally unused function parameters, prefix with `_` (e.g. `_event`).
+- For required locals in no-op/interface-conformance paths, use `void value` to mark the discard explicitly.
 
 ## Common patterns
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -17,35 +17,19 @@ export default eslintConfigScratch.defineConfig(
     plugins: { '@typescript-eslint': tseslint.plugin },
   },
   {
-    // TypeScript rule overrides (type-checked rules must be scoped to TS files)
-    // Fixing these requires non-trivial adjustments to code that was written before these rules were in place.
-    files: ['src/**/*.{ts,tsx,mts,cts}'],
+    // TODO: upstream to eslint-config-scratch
+    files: ['**/*.{ts,tsx,mts,cts}'],
     rules: {
-      // TODO: improve TypeScript type annotations to remove `any` usage
-      '@typescript-eslint/no-explicit-any': 'warn',
-      '@typescript-eslint/no-unsafe-argument': 'warn',
-      '@typescript-eslint/no-unsafe-assignment': 'warn',
-      '@typescript-eslint/no-unsafe-call': 'warn',
-      '@typescript-eslint/no-unsafe-enum-comparison': 'warn',
-      '@typescript-eslint/no-unsafe-member-access': 'warn',
-      '@typescript-eslint/no-unsafe-return': 'warn',
-      '@typescript-eslint/unbound-method': 'warn',
-
-      // TODO: fix incrementally
-      '@typescript-eslint/no-non-null-assertion': 'warn',
-      '@typescript-eslint/no-unnecessary-condition': 'warn',
-      '@typescript-eslint/prefer-nullish-coalescing': 'warn',
-      '@typescript-eslint/no-base-to-string': 'warn',
-      '@typescript-eslint/no-empty-function': 'warn',
-      '@typescript-eslint/no-floating-promises': 'warn',
-      '@typescript-eslint/no-unnecessary-type-assertion': 'warn',
-      '@typescript-eslint/no-unused-vars': 'warn',
-      '@typescript-eslint/only-throw-error': 'warn',
-      '@typescript-eslint/prefer-optional-chain': 'warn',
-      '@typescript-eslint/require-await': 'warn',
-      '@typescript-eslint/restrict-plus-operands': 'warn',
-      '@typescript-eslint/prefer-for-of': 'warn',
-      '@typescript-eslint/restrict-template-expressions': 'warn',
+      '@typescript-eslint/no-empty-function': 'off',
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          argsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_',
+          destructuredArrayIgnorePattern: '^_',
+          ignoreRestSiblings: true,
+        },
+      ],
     },
   },
   {

--- a/src/block_reporting.ts
+++ b/src/block_reporting.ts
@@ -1,12 +1,24 @@
 import * as Blockly from 'blockly/core'
 import { Colours } from './colours'
 
+function getRequiredMainWorkspaceSvg(): Blockly.WorkspaceSvg {
+  const mainWorkspace = Blockly.getMainWorkspace()
+  if (!(mainWorkspace instanceof Blockly.WorkspaceSvg)) {
+    throw new Error('Expected main workspace to be a WorkspaceSvg')
+  }
+  return mainWorkspace
+}
+
+function getBlockSvgById(workspace: Blockly.WorkspaceSvg, id: string): Blockly.BlockSvg | null {
+  const block = workspace.getBlockById(id)
+  return block instanceof Blockly.BlockSvg ? block : null
+}
+
 export function reportValue(id: string, value: string) {
-  const block = (Blockly.getMainWorkspace().getBlockById(id) ||
-    (Blockly.getMainWorkspace() as Blockly.WorkspaceSvg)
-      .getFlyout()
-      ?.getWorkspace()
-      ?.getBlockById(id)) as Blockly.BlockSvg
+  const mainWorkspace = getRequiredMainWorkspaceSvg()
+  const flyout = mainWorkspace.getFlyout()
+  const flyoutBlock = flyout ? getBlockSvgById(flyout.getWorkspace(), id) : null
+  const block = getBlockSvgById(mainWorkspace, id) ?? flyoutBlock
   if (!block) {
     throw new Error('Tried to report value on block that does not exist.')
   }

--- a/src/block_reporting.ts
+++ b/src/block_reporting.ts
@@ -1,18 +1,6 @@
 import * as Blockly from 'blockly/core'
 import { Colours } from './colours'
-
-function getRequiredMainWorkspaceSvg(): Blockly.WorkspaceSvg {
-  const mainWorkspace = Blockly.getMainWorkspace()
-  if (!(mainWorkspace instanceof Blockly.WorkspaceSvg)) {
-    throw new Error('Expected main workspace to be a WorkspaceSvg')
-  }
-  return mainWorkspace
-}
-
-function getBlockSvgById(workspace: Blockly.WorkspaceSvg, id: string): Blockly.BlockSvg | null {
-  const block = workspace.getBlockById(id)
-  return block instanceof Blockly.BlockSvg ? block : null
-}
+import { getBlockSvgById, getRequiredMainWorkspaceSvg } from './workspace_block_lookup'
 
 export function reportValue(id: string, value: string) {
   const mainWorkspace = getRequiredMainWorkspaceSvg()

--- a/src/blocks/control.ts
+++ b/src/blocks/control.ts
@@ -24,7 +24,7 @@ Blockly.Blocks.control_forever = {
    * https://blockly-demo.appspot.com/static/demos/blockfactory/index.html#5eke39
    */
   init: function (this: Blockly.Block) {
-    const ws = this.workspace.options.parentWorkspace || this.workspace
+    const ws = this.workspace.options.parentWorkspace ?? this.workspace
     this.jsonInit({
       id: 'control_forever',
       message0: Blockly.Msg.CONTROL_FOREVER,
@@ -58,7 +58,7 @@ Blockly.Blocks.control_repeat = {
    * https://blockly-demo.appspot.com/static/demos/blockfactory/index.html#so57n9
    */
   init: function (this: Blockly.Block) {
-    const ws = this.workspace.options.parentWorkspace || this.workspace
+    const ws = this.workspace.options.parentWorkspace ?? this.workspace
     this.jsonInit({
       id: 'control_repeat',
       message0: Blockly.Msg.CONTROL_REPEAT,
@@ -164,7 +164,7 @@ Blockly.Blocks.control_stop = {
     const OTHER_SCRIPTS = 'other scripts in sprite'
     const stopDropdown = new Blockly.FieldDropdown(
       function () {
-        if (this.sourceBlock_ && this.sourceBlock_.nextConnection && this.sourceBlock_.nextConnection.isConnected()) {
+        if (this.sourceBlock_?.nextConnection?.isConnected()) {
           return [[Blockly.Msg.CONTROL_STOP_OTHER, OTHER_SCRIPTS]]
         }
         return [
@@ -232,7 +232,7 @@ Blockly.Blocks.control_repeat_until = {
    * Block to repeat until a condition becomes true.
    */
   init: function (this: Blockly.Block) {
-    const ws = this.workspace.options.parentWorkspace || this.workspace
+    const ws = this.workspace.options.parentWorkspace ?? this.workspace
     this.jsonInit({
       message0: Blockly.Msg.CONTROL_REPEATUNTIL,
       message1: '%1',
@@ -272,7 +272,7 @@ Blockly.Blocks.control_while = {
    * (This is an obsolete "hacked" block, for compatibility with 2.0.)
    */
   init: function (this: Blockly.Block) {
-    const ws = this.workspace.options.parentWorkspace || this.workspace
+    const ws = this.workspace.options.parentWorkspace ?? this.workspace
     this.jsonInit({
       message0: Blockly.Msg.CONTROL_WHILE,
       message1: '%1',

--- a/src/blocks/event.ts
+++ b/src/blocks/event.ts
@@ -64,7 +64,7 @@ Blockly.Blocks.event_whenflagclicked = {
    * Block for when flag clicked.
    */
   init: function (this: Blockly.Block) {
-    const ws = this.workspace.options.parentWorkspace || this.workspace
+    const ws = this.workspace.options.parentWorkspace ?? this.workspace
     this.jsonInit({
       id: 'event_whenflagclicked',
       message0: Blockly.Msg.EVENT_WHENFLAGCLICKED,

--- a/src/blocks/motion.ts
+++ b/src/blocks/motion.ts
@@ -41,7 +41,7 @@ Blockly.Blocks.motion_turnright = {
    * Block to turn right.
    */
   init: function (this: Blockly.Block) {
-    const ws = this.workspace.options.parentWorkspace || this.workspace
+    const ws = this.workspace.options.parentWorkspace ?? this.workspace
     this.jsonInit({
       message0: Blockly.Msg.MOTION_TURNRIGHT,
       args0: [
@@ -66,7 +66,7 @@ Blockly.Blocks.motion_turnleft = {
    * Block to turn left.
    */
   init: function (this: Blockly.Block) {
-    const ws = this.workspace.options.parentWorkspace || this.workspace
+    const ws = this.workspace.options.parentWorkspace ?? this.workspace
     this.jsonInit({
       message0: Blockly.Msg.MOTION_TURNLEFT,
       args0: [

--- a/src/blocks/procedures.ts
+++ b/src/blocks/procedures.ts
@@ -57,7 +57,7 @@ function parseArgumentType(value: string): ArgumentType {
     case 's':
       return ArgumentType.STRING
     default:
-      throw new Error(`Found an custom procedure with an invalid type: ${value}`)
+      throw new Error(`Found a custom procedure with an invalid type: ${value}`)
   }
 }
 

--- a/src/blocks/procedures.ts
+++ b/src/blocks/procedures.ts
@@ -29,8 +29,8 @@ import type { ScratchDragger } from '../scratch_dragger'
 type ConnectionMap = Record<
   string,
   {
-    shadow: Element
-    block: Blockly.BlockSvg
+    shadow: Element | undefined
+    block: Blockly.BlockSvg | null
   } | null
 >
 
@@ -41,6 +41,86 @@ enum ArgumentType {
   STRING = 's',
   NUMBER = 'n',
   BOOLEAN = 'b',
+}
+
+/**
+ * Parse a serialized procedure argument type token.
+ * @param value Serialized token from procCode.
+ * @returns The matching argument type.
+ */
+function parseArgumentType(value: string): ArgumentType {
+  switch (value) {
+    case 'n':
+      return ArgumentType.NUMBER
+    case 'b':
+      return ArgumentType.BOOLEAN
+    case 's':
+      return ArgumentType.STRING
+    default:
+      throw new Error(`Found an custom procedure with an invalid type: ${value}`)
+  }
+}
+
+/**
+ * Read a required mutation attribute or throw if missing.
+ * @param xmlElement The mutation element that should contain required attributes.
+ * @param name The specific mutation attribute to retrieve.
+ * @returns Attribute value.
+ */
+function getRequiredMutationAttribute(xmlElement: Element, name: string): string {
+  const value = xmlElement.getAttribute(name)
+  if (value === null) {
+    throw new Error(`Missing required mutation attribute: ${name}`)
+  }
+  return value
+}
+
+/**
+ * Parse a required mutation attribute as JSON, then validate its type.
+ * @param xmlElement The mutation element that should contain required attributes.
+ * @param name The specific mutation attribute to retrieve and parse.
+ * @param parse Validates and narrows the parsed JSON value.
+ * @returns Parsed and validated mutation attribute value.
+ */
+function parseRequiredMutationJson<T>(
+  xmlElement: Element,
+  name: string,
+  parse: (value: unknown, name: string) => T,
+): T {
+  const rawValue = getRequiredMutationAttribute(xmlElement, name)
+  let parsedValue: unknown
+  try {
+    parsedValue = JSON.parse(rawValue)
+  } catch {
+    throw new Error(`Invalid JSON in mutation attribute: ${name}`)
+  }
+  return parse(parsedValue, name)
+}
+
+/**
+ * Validate a parsed mutation value as a boolean.
+ * @param value Parsed mutation value.
+ * @param name Attribute name used in error messages.
+ * @returns Validated boolean value.
+ */
+function parseBooleanMutationValue(value: unknown, name: string): boolean {
+  if (typeof value !== 'boolean') {
+    throw new Error(`Expected boolean JSON value in mutation attribute: ${name}`)
+  }
+  return value
+}
+
+/**
+ * Validate a parsed mutation value as a string array.
+ * @param value Parsed mutation value.
+ * @param name Attribute name used in error messages.
+ * @returns Validated string array value.
+ */
+function parseStringArrayMutationValue(value: unknown, name: string): string[] {
+  if (!Array.isArray(value) || !value.every((entry) => typeof entry === 'string')) {
+    throw new Error(`Expected string[] JSON value in mutation attribute: ${name}`)
+  }
+  return value
 }
 
 /**
@@ -193,10 +273,10 @@ function callerMutationToDom(this: ProcedureCallBlock): Element {
  * @param xmlElement XML storage element.
  */
 function callerDomToMutation(this: ProcedureCallBlock, xmlElement: Element) {
-  this.procCode_ = xmlElement.getAttribute('proccode')!
-  this.generateShadows_ = JSON.parse(xmlElement.getAttribute('generateshadows')!)
-  this.argumentIds_ = JSON.parse(xmlElement.getAttribute('argumentids')!)
-  this.warp_ = JSON.parse(xmlElement.getAttribute('warp')!)
+  this.procCode_ = getRequiredMutationAttribute(xmlElement, 'proccode')
+  this.generateShadows_ = parseRequiredMutationJson(xmlElement, 'generateshadows', parseBooleanMutationValue)
+  this.argumentIds_ = parseRequiredMutationJson(xmlElement, 'argumentids', parseStringArrayMutationValue)
+  this.warp_ = parseRequiredMutationJson(xmlElement, 'warp', parseBooleanMutationValue)
   this.updateDisplay_()
 }
 
@@ -230,15 +310,15 @@ function definitionMutationToDom(
  * @param xmlElement XML storage element.
  */
 function definitionDomToMutation(this: ProcedurePrototypeBlock | ProcedureDeclarationBlock, xmlElement: Element) {
-  this.procCode_ = xmlElement.getAttribute('proccode')!
-  this.warp_ = JSON.parse(xmlElement.getAttribute('warp')!)
+  this.procCode_ = getRequiredMutationAttribute(xmlElement, 'proccode')
+  this.warp_ = parseRequiredMutationJson(xmlElement, 'warp', parseBooleanMutationValue)
 
   const prevArgIds = this.argumentIds_
   const prevDisplayNames = this.displayNames_
 
-  this.argumentIds_ = JSON.parse(xmlElement.getAttribute('argumentids')!)
-  this.displayNames_ = JSON.parse(xmlElement.getAttribute('argumentnames')!)
-  this.argumentDefaults_ = JSON.parse(xmlElement.getAttribute('argumentdefaults')!)
+  this.argumentIds_ = parseRequiredMutationJson(xmlElement, 'argumentids', parseStringArrayMutationValue)
+  this.displayNames_ = parseRequiredMutationJson(xmlElement, 'argumentnames', parseStringArrayMutationValue)
+  this.argumentDefaults_ = parseRequiredMutationJson(xmlElement, 'argumentdefaults', parseStringArrayMutationValue)
 
   // During full XML deserialization (Blockly.Xml.domToWorkspace), the mutation element
   // is part of the parsed XML tree and its parent element also contains <value> children
@@ -308,13 +388,11 @@ function disconnectOldBlocks_(this: ProcedureBlock): ConnectionMap {
   const connectionMap: ConnectionMap = {}
   for (const input of this.inputList) {
     if (input.connection) {
-      const target = input.connection.targetBlock() as Blockly.BlockSvg
-      const saveInfo = {
-        shadow: input.connection.getShadowDom(true)!,
-        block: target,
+      const target = input.connection.targetBlock()
+      connectionMap[input.name] = {
+        shadow: input.connection.getShadowDom(true) ?? undefined,
+        block: target as Blockly.BlockSvg | null,
       }
-      connectionMap[input.name] = saveInfo
-
       if (target) {
         input.connection.disconnect()
       }
@@ -349,16 +427,7 @@ function createAllInputs_(this: ProcedureBlock, connectionMap: ConnectionMap) {
   for (const component of procComponents) {
     let labelText
     if (component.startsWith('%')) {
-      const argumentType = component.substring(1, 2)
-      if (
-        !(
-          argumentType === ArgumentType.NUMBER ||
-          argumentType === ArgumentType.BOOLEAN ||
-          argumentType === ArgumentType.STRING
-        )
-      ) {
-        throw new Error('Found an custom procedure with an invalid type: ' + argumentType)
-      }
+      const argumentType = parseArgumentType(component.substring(1, 2))
       labelText = component.substring(2).trim()
 
       const id = this.argumentIds_[argumentCount]
@@ -386,19 +455,20 @@ function createAllInputs_(this: ProcedureBlock, connectionMap: ConnectionMap) {
  *     connected to those IDs at the beginning of the mutation.
  */
 function disposeObsoleteBlocks_(this: ProcedureBlock, connectionMap: ConnectionMap) {
-  for (const id in connectionMap) {
-    const saveInfo = connectionMap[id]
-    if (saveInfo) {
-      const block = saveInfo.block
-      const isOrphanedArgumentReporter =
-        this.type === 'procedures_prototype' &&
-        (block.type === 'argument_reporter_string_number' || block.type === 'argument_reporter_boolean')
-      if (block.isShadow() || isOrphanedArgumentReporter) {
-        block.dispose()
-        connectionMap[id] = null
-        // At this point we know which shadow DOMs are about to be orphaned in
-        // the VM.  What do we do with that information?
-      }
+  for (const [id, saveInfo] of Object.entries(connectionMap)) {
+    const block = saveInfo?.block
+    if (!block) {
+      continue
+    }
+
+    const isOrphanedArgumentReporter =
+      this.type === 'procedures_prototype' &&
+      (block.type === 'argument_reporter_string_number' || block.type === 'argument_reporter_boolean')
+    if (block.isShadow() || isOrphanedArgumentReporter) {
+      block.dispose()
+      connectionMap[id] = null
+      // At this point we know which shadow DOMs are about to be orphaned in
+      // the VM.  What do we do with that information?
     }
   }
 }
@@ -458,6 +528,9 @@ function buildShadowDom_(type: ArgumentType): Element {
  */
 function attachShadow_(this: ProcedureCallBlock, input: Blockly.Input, argumentType: ArgumentType) {
   if (argumentType === ArgumentType.NUMBER || argumentType === ArgumentType.STRING) {
+    if (!input.connection) {
+      throw new Error(`Expected input connection for argument ${String(argumentType)}`)
+    }
     const blockType = argumentType === ArgumentType.NUMBER ? 'math_number' : 'text'
     Blockly.Events.disable()
     let newBlock
@@ -479,7 +552,7 @@ function attachShadow_(this: ProcedureCallBlock, input: Blockly.Input, argumentT
     if (Blockly.Events.isEnabled()) {
       Blockly.Events.fire(new (Blockly.Events.get(Blockly.Events.BLOCK_CREATE))(newBlock))
     }
-    newBlock.outputConnection.connect(input.connection!)
+    newBlock.outputConnection.connect(input.connection)
   }
 }
 
@@ -516,7 +589,7 @@ function createArgumentReporter_(
     Blockly.Events.enable()
   }
   if (Blockly.Events.isEnabled()) {
-    Blockly.Events.fire(new (Blockly.Events.get(Blockly.Events.BLOCK_CREATE))(newBlock))
+    void Blockly.Events.fire(new (Blockly.Events.get(Blockly.Events.BLOCK_CREATE))(newBlock))
   }
   return newBlock
 }
@@ -538,21 +611,25 @@ function populateArgumentOnCaller_(
   id: string,
   input: Blockly.Input,
 ) {
-  let oldBlock: Blockly.BlockSvg | undefined
+  let oldBlock: Blockly.BlockSvg | null | undefined
   let oldShadow: Element | undefined
-  if (connectionMap && id in connectionMap) {
+  if (id in connectionMap) {
     const saveInfo = connectionMap[id]
     oldBlock = saveInfo?.block
     oldShadow = saveInfo?.shadow
   }
 
-  if (connectionMap && oldBlock) {
+  const conn = input.connection
+  if (!conn) {
+    throw new Error(`Expected caller input connection for argument id ${id}`)
+  }
+  if (oldBlock) {
     // Reattach the old block and shadow DOM.
     connectionMap[input.name] = null
-    oldBlock.outputConnection.connect(input.connection!)
+    oldBlock.outputConnection.connect(conn)
     if (type !== ArgumentType.BOOLEAN && this.generateShadows_) {
-      const shadowDom = oldShadow || this.buildShadowDom_(type)
-      input.connection!.setShadowDom(shadowDom)
+      const shadowDom = oldShadow ?? this.buildShadowDom_(type)
+      conn.setShadowDom(shadowDom)
     }
   } else if (this.generateShadows_) {
     this.attachShadow_(input, type)
@@ -584,7 +661,12 @@ function populateArgumentOnPrototype_(
   }
 
   let oldBlock: Blockly.BlockSvg | null = null
-  if (connectionMap && id in connectionMap) {
+  const conn = input.connection
+  if (!conn) {
+    throw new Error(`Expected prototype input connection for argument id ${id}`)
+  }
+
+  if (id in connectionMap) {
     const saveInfo = connectionMap[id]
     oldBlock = saveInfo?.block ?? null
   }
@@ -594,7 +676,7 @@ function populateArgumentOnPrototype_(
 
   // Decide which block to attach.
   let argumentReporter: Blockly.BlockSvg
-  if (connectionMap && oldBlock && oldTypeMatches) {
+  if (oldBlock && oldTypeMatches) {
     // Update the text if needed. The old argument reporter is the same type,
     // and on the same input, but the argument's display name may have changed.
     argumentReporter = oldBlock
@@ -605,7 +687,7 @@ function populateArgumentOnPrototype_(
   }
 
   // Attach the block.
-  input.connection!.connect(argumentReporter.outputConnection)
+  conn.connect(argumentReporter.outputConnection)
 }
 
 /**
@@ -627,13 +709,17 @@ function populateArgumentOnDeclaration_(
   input: Blockly.Input,
 ) {
   let oldBlock: Blockly.BlockSvg | null = null
-  if (connectionMap && id in connectionMap) {
+  if (id in connectionMap) {
     const saveInfo = connectionMap[id]
     oldBlock = saveInfo?.block ?? null
   }
 
   const oldTypeMatches = checkOldEditorTypeMatches_(oldBlock, type)
   const displayName = this.displayNames_[index]
+  const conn = input.connection
+  if (!conn) {
+    throw new Error(`Expected declaration input connection for argument id ${id}`)
+  }
 
   // Decide which block to attach.
   let argumentEditor: Blockly.BlockSvg
@@ -646,7 +732,7 @@ function populateArgumentOnDeclaration_(
   }
 
   // Attach the block.
-  input.connection!.connect(argumentEditor.outputConnection)
+  conn.connect(argumentEditor.outputConnection)
 }
 
 /**
@@ -721,13 +807,13 @@ function createArgumentEditor_(
     newBlock.setShadow(true)
     if (!this.isInsertionMarker()) {
       newBlock.initSvg()
-      newBlock.queueRender()
+      void newBlock.queueRender()
     }
   } finally {
     Blockly.Events.enable()
   }
   if (Blockly.Events.isEnabled()) {
-    Blockly.Events.fire(new (Blockly.Events.get(Blockly.Events.BLOCK_CREATE))(newBlock))
+    void Blockly.Events.fire(new (Blockly.Events.get(Blockly.Events.BLOCK_CREATE))(newBlock))
   }
   return newBlock
 }
@@ -749,8 +835,11 @@ function updateDeclarationProcCode_(this: ProcedureDeclarationBlock) {
       this.procCode_ += input.fieldRow[0].getValue()
     } else if (input.type === Blockly.inputs.inputTypes.VALUE) {
       // Inspect the argument editor.
-      const target = input.connection!.targetBlock()!
-      this.displayNames_.push(target.getFieldValue('TEXT'))
+      const target = input.connection?.targetBlock()
+      if (!target) {
+        throw new Error(`Expected argument editor block on input ${input.name}`)
+      }
+      this.displayNames_.push(String(target.getFieldValue('TEXT')))
       this.argumentIds_.push(input.name)
       if (target.type === 'argument_editor_boolean') {
         this.procCode_ += '%b'
@@ -758,7 +847,7 @@ function updateDeclarationProcCode_(this: ProcedureDeclarationBlock) {
         this.procCode_ += '%s'
       }
     } else {
-      throw new Error('Unexpected input type on a procedure mutator root: ' + input.type)
+      throw new Error(`Unexpected input type on a procedure mutator root: ${String(input.type)}`)
     }
   }
 }
@@ -773,8 +862,15 @@ function focusLastEditor_(this: ProcedureDeclarationBlock) {
       newInput.fieldRow[0].showEditor()
     } else if (newInput.type === Blockly.inputs.inputTypes.VALUE) {
       // Inspect the argument editor.
-      const target = newInput.connection!.targetBlock()!
-      target.getField('TEXT')!.showEditor()
+      const target = newInput.connection?.targetBlock()
+      if (!target) {
+        throw new Error(`Expected argument editor block on input ${newInput.name}`)
+      }
+      const field = target.getField('TEXT')
+      if (!field) {
+        throw new Error(`Expected TEXT field on argument editor block ${target.id}`)
+      }
+      field.showEditor()
     }
   }
 }
@@ -843,16 +939,15 @@ function removeFieldCallback(this: ProcedureDeclarationBlock, field: Blockly.Fie
     return
   }
   let inputNameToRemove = null
-  for (let n = 0; n < this.inputList.length; n++) {
-    const input = this.inputList[n]
+  for (const input of this.inputList) {
     if (input.connection) {
-      const target = input.connection.targetBlock()!
-      if (field.name && target.getField(field.name) === field) {
+      const target = input.connection.targetBlock()
+      if (target && field.name && target.getField(field.name) === field) {
         inputNameToRemove = input.name
       }
     } else {
-      for (let j = 0; j < input.fieldRow.length; j++) {
-        if (input.fieldRow[j] === field) {
+      for (const inputField of input.fieldRow) {
+        if (inputField === field) {
           inputNameToRemove = input.name
         }
       }
@@ -875,9 +970,7 @@ function removeArgumentCallback_(
   field: Blockly.Field,
 ) {
   const parent = this.getParent()
-  if (parent && parent.removeFieldCallback) {
-    parent.removeFieldCallback(field)
-  }
+  ;(parent as ProcedureDeclarationBlock | null)?.removeFieldCallback(field)
 }
 
 /**

--- a/src/blocks/sensing.ts
+++ b/src/blocks/sensing.ts
@@ -17,7 +17,6 @@
  * limitations under the License.
  */
 import * as Blockly from 'blockly/core'
-import * as Constants from '../constants'
 
 Blockly.Blocks.sensing_touchingobject = {
   /**

--- a/src/blocks/vertical_extensions.ts
+++ b/src/blocks/vertical_extensions.ts
@@ -163,7 +163,7 @@ const MONITOR_BLOCK = function (this: Blockly.BlockSvg) {
  * Mixin to add a context menu for a procedure definition block.
  * It adds the "edit" option and removes the "duplicate" option.
  */
-const PROCEDURE_DEF_CONTEXTMENU = function (this: Blockly.Block) {
+const PROCEDURE_DEF_CONTEXTMENU = function (this: Blockly.BlockSvg) {
   /**
    * Add the "edit" option and removes the "duplicate" option from the context
    * menu.
@@ -172,7 +172,7 @@ const PROCEDURE_DEF_CONTEXTMENU = function (this: Blockly.Block) {
   this.mixin(
     {
       customContextMenu: function (
-        this: Blockly.Block,
+        this: Blockly.BlockSvg,
         menuOptions: (
           | Blockly.ContextMenuRegistry.ContextMenuOption
           | Blockly.ContextMenuRegistry.LegacyContextMenuOption

--- a/src/blocks/vertical_extensions.ts
+++ b/src/blocks/vertical_extensions.ts
@@ -156,7 +156,7 @@ const OUTPUT_BOOLEAN = function (this: Blockly.Block) {
  */
 const MONITOR_BLOCK = function (this: Blockly.BlockSvg) {
   this.addIcon(new FlyoutCheckboxIcon(this))
-  ;(this as any).checkboxInFlyout = true
+  ;(this as Blockly.BlockSvg & { checkboxInFlyout?: boolean }).checkboxInFlyout = true
 }
 
 /**
@@ -172,6 +172,7 @@ const PROCEDURE_DEF_CONTEXTMENU = function (this: Blockly.Block) {
   this.mixin(
     {
       customContextMenu: function (
+        this: Blockly.Block,
         menuOptions: (
           | Blockly.ContextMenuRegistry.ContextMenuOption
           | Blockly.ContextMenuRegistry.LegacyContextMenuOption
@@ -181,18 +182,20 @@ const PROCEDURE_DEF_CONTEXTMENU = function (this: Blockly.Block) {
         menuOptions.push(ScratchProcedures.makeEditOption(this))
 
         // Find and remove the duplicate option
-        for (let i = 0, option; (option = menuOptions[i]); i++) {
-          if (option.text == Blockly.Msg.DUPLICATE_BLOCK) {
+        for (let i = 0; i < menuOptions.length; i++) {
+          if (menuOptions[i].text == Blockly.Msg.DUPLICATE_BLOCK) {
             menuOptions.splice(i, 1)
             break
           }
         }
       },
-      checkAndDelete: function () {
+      checkAndDelete: function (this: Blockly.BlockSvg) {
         const input = this.getInput('custom_block')
         // this is the root block, not the shadow block.
-        if (input?.connection?.targetBlock()) {
-          const procCode = input.connection.targetBlock().getProcCode()
+        const targetBlock = input?.connection?.targetBlock()
+        const targetWithProcCode = targetBlock as (Blockly.Block & { getProcCode?(): string }) | null
+        if (targetWithProcCode?.getProcCode) {
+          const procCode = targetWithProcCode.getProcCode()
           const didDelete = ScratchProcedures.deleteProcedureDefCallback(procCode, this)
           if (!didDelete) {
             alert(Blockly.Msg.PROCEDURE_USED)
@@ -227,7 +230,7 @@ const PROCEDURE_CALL_CONTEXTMENU = {
 }
 
 const SCRATCH_EXTENSION = function (this: Blockly.Block) {
-  ;(this as any).isScratchExtension = true
+  ;(this as Blockly.Block & { isScratchExtension?: boolean }).isScratchExtension = true
 }
 
 /**

--- a/src/checkable_continuous_flyout.ts
+++ b/src/checkable_continuous_flyout.ts
@@ -8,6 +8,22 @@ import { CheckboxBubble } from './checkbox_bubble'
 import { StatusIndicatorLabel } from './status_indicator_label'
 import { STATUS_INDICATOR_LABEL_TYPE } from './status_indicator_label_flyout_inflater'
 
+interface ReflowElement extends Blockly.BlockSvg {
+  checkboxInFlyout?: boolean
+}
+
+interface ReflowItem {
+  getElement: () => ReflowElement
+}
+
+interface RefreshItem {
+  element: unknown
+}
+
+interface CheckboxIcon {
+  setChecked: (value: boolean) => void
+}
+
 export class CheckableContinuousFlyout extends ContinuousFlyout {
   /**
    * Creates a new CheckableContinuousFlyout.
@@ -42,7 +58,8 @@ export class CheckableContinuousFlyout extends ContinuousFlyout {
    * @param value Value to set the checkbox to.
    */
   setCheckboxState(blockId: string, value: boolean) {
-    this.getWorkspace().getBlockById(blockId)?.getIcon('checkbox')?.setChecked(value)
+    const icon = this.getWorkspace().getBlockById(blockId)?.getIcon('checkbox') as CheckboxIcon | null
+    icon?.setChecked(value)
   }
 
   getFlyoutScale() {
@@ -61,7 +78,8 @@ export class CheckableContinuousFlyout extends ContinuousFlyout {
       // contents, and adjusts blocks in RTL mode accordingly. In Scratch, the
       // flyout width is fixed (and blocks may exceed it), so re-adjust blocks
       // accordingly based on the actual fixed width.
-      for (const item of this.getContents()) {
+      const flyoutItems = this.getContents() as ReflowItem[]
+      for (const item of flyoutItems) {
         const oldX = item.getElement().getBoundingRectangle().left
         let newX =
           this.getWidth() / this.workspace_.scale - item.getElement().getBoundingRectangle().getWidth() - this.MARGIN
@@ -86,7 +104,7 @@ export class CheckableContinuousFlyout extends ContinuousFlyout {
    * Updates the state of status indicators for hardware-based extensions.
    */
   refreshStatusButtons() {
-    for (const item of this.contents) {
+    for (const item of this.contents as RefreshItem[]) {
       if (item.element instanceof StatusIndicatorLabel) {
         item.element.refreshStatus()
       }

--- a/src/checkable_continuous_flyout.ts
+++ b/src/checkable_continuous_flyout.ts
@@ -59,14 +59,15 @@ export class CheckableContinuousFlyout extends ContinuousFlyout {
    */
   setCheckboxState(blockId: string, value: boolean) {
     const icon = this.getWorkspace().getBlockById(blockId)?.getIcon('checkbox')
-    if (icon && !isCheckboxIcon(icon)) {
+    if (!icon) {
+      return
+    }
+    if (!isCheckboxIcon(icon)) {
       throw new Error(
         `[CheckableContinuousFlyout.setCheckboxState] Expected checkbox icon with setChecked for block ${blockId}`,
       )
     }
-    if (isCheckboxIcon(icon)) {
-      icon.setChecked(value)
-    }
+    icon.setChecked(value)
   }
 
   getFlyoutScale() {
@@ -110,7 +111,7 @@ export class CheckableContinuousFlyout extends ContinuousFlyout {
     if (item.getType() === STATUS_INDICATOR_LABEL_TYPE) {
       return true
     }
-    return item.getType() === STATUS_INDICATOR_LABEL_TYPE || super.toolboxItemIsLabel(item)
+    return super.toolboxItemIsLabel(item)
   }
 
   /**

--- a/src/checkable_continuous_flyout.ts
+++ b/src/checkable_continuous_flyout.ts
@@ -2,7 +2,7 @@
  * Copyright 2024 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-import { ContinuousFlyout } from '@blockly/continuous-toolbox'
+import { ContinuousFlyout, type LabelFlyoutItem } from '@blockly/continuous-toolbox'
 import * as Blockly from 'blockly/core'
 import { CheckboxBubble } from './checkbox_bubble'
 import { StatusIndicatorLabel } from './status_indicator_label'
@@ -12,19 +12,19 @@ interface ReflowElement extends Blockly.BlockSvg {
   checkboxInFlyout?: boolean
 }
 
-interface ReflowItem {
-  getElement: () => ReflowElement
-}
-
-interface RefreshItem {
-  element: unknown
-}
-
 interface CheckboxIcon {
   setChecked: (value: boolean) => void
 }
 
+function isCheckboxIcon(icon: Blockly.IIcon | undefined): icon is Blockly.IIcon & CheckboxIcon {
+  return !!icon && typeof (icon as { setChecked?: unknown }).setChecked === 'function'
+}
+
 export class CheckableContinuousFlyout extends ContinuousFlyout {
+  declare protected tabWidth_: number
+  declare MARGIN: number
+  declare GAP_Y: number
+
   /**
    * Creates a new CheckableContinuousFlyout.
    * @param workspaceOptions Configuration options for the flyout workspace.
@@ -58,8 +58,15 @@ export class CheckableContinuousFlyout extends ContinuousFlyout {
    * @param value Value to set the checkbox to.
    */
   setCheckboxState(blockId: string, value: boolean) {
-    const icon = this.getWorkspace().getBlockById(blockId)?.getIcon('checkbox') as CheckboxIcon | null
-    icon?.setChecked(value)
+    const icon = this.getWorkspace().getBlockById(blockId)?.getIcon('checkbox')
+    if (icon && !isCheckboxIcon(icon)) {
+      throw new Error(
+        `[CheckableContinuousFlyout.setCheckboxState] Expected checkbox icon with setChecked for block ${blockId}`,
+      )
+    }
+    if (isCheckboxIcon(icon)) {
+      icon.setChecked(value)
+    }
   }
 
   getFlyoutScale() {
@@ -78,15 +85,18 @@ export class CheckableContinuousFlyout extends ContinuousFlyout {
       // contents, and adjusts blocks in RTL mode accordingly. In Scratch, the
       // flyout width is fixed (and blocks may exceed it), so re-adjust blocks
       // accordingly based on the actual fixed width.
-      const flyoutItems = this.getContents() as ReflowItem[]
+      const flyoutItems = this.getContents()
       for (const item of flyoutItems) {
-        const oldX = item.getElement().getBoundingRectangle().left
-        let newX =
-          this.getWidth() / this.workspace_.scale - item.getElement().getBoundingRectangle().getWidth() - this.MARGIN
-        if ('checkboxInFlyout' in item.getElement() && item.getElement().checkboxInFlyout) {
+        const element = item.getElement()
+        if (!(element instanceof Blockly.BlockSvg)) {
+          continue
+        }
+        const oldX = element.getBoundingRectangle().left
+        let newX = this.getWidth() / this.workspace_.scale - element.getBoundingRectangle().getWidth() - this.MARGIN
+        if ('checkboxInFlyout' in element && (element as ReflowElement).checkboxInFlyout) {
           newX -= CheckboxBubble.CHECKBOX_SIZE + CheckboxBubble.CHECKBOX_MARGIN
         }
-        item.getElement().moveBy(newX - oldX, 0)
+        element.moveBy(newX - oldX, 0)
       }
     }
   }
@@ -96,7 +106,10 @@ export class CheckableContinuousFlyout extends ContinuousFlyout {
    * @param item The toolbox item to check.
    * @returns True if the item represents a label in the flyout.
    */
-  protected toolboxItemIsLabel(item: Blockly.FlyoutItem) {
+  protected toolboxItemIsLabel(item: Blockly.FlyoutItem): item is LabelFlyoutItem {
+    if (item.getType() === STATUS_INDICATOR_LABEL_TYPE) {
+      return true
+    }
     return item.getType() === STATUS_INDICATOR_LABEL_TYPE || super.toolboxItemIsLabel(item)
   }
 
@@ -104,9 +117,10 @@ export class CheckableContinuousFlyout extends ContinuousFlyout {
    * Updates the state of status indicators for hardware-based extensions.
    */
   refreshStatusButtons() {
-    for (const item of this.contents as RefreshItem[]) {
-      if (item.element instanceof StatusIndicatorLabel) {
-        item.element.refreshStatus()
+    for (const item of this.contents) {
+      const element = item.getElement()
+      if (element instanceof StatusIndicatorLabel) {
+        element.refreshStatus()
       }
     }
   }

--- a/src/checkbox_bubble.ts
+++ b/src/checkbox_bubble.ts
@@ -155,10 +155,10 @@ export class CheckboxBubble implements Blockly.IBubble, Blockly.IRenderedElement
    * Returns whether or not the specified block has its checkbox checked.
    *
    * This method is patched by scratch-gui to query the VM state.
-   * @param blockId The ID of the block in question.
+   * @param _blockId The ID of the block in question.
    * @returns True if the block's checkbox should be checked.
    */
-  isChecked(blockId: string): boolean {
+  isChecked(_blockId: string): boolean {
     return false
   }
 
@@ -252,17 +252,17 @@ export class CheckboxBubble implements Blockly.IBubble, Blockly.IRenderedElement
   // to its block and is not draggable by the user.
   showContextMenu() {}
 
-  setDragging(dragging: boolean) {}
+  setDragging(_dragging: boolean) {}
 
-  startDrag(event: PointerEvent) {}
+  startDrag(_event: PointerEvent) {}
 
-  drag(newLocation: Blockly.utils.Coordinate, event: PointerEvent) {}
+  drag(_newLocation: Blockly.utils.Coordinate, _event: PointerEvent) {}
 
-  moveDuringDrag(newLocation: Blockly.utils.Coordinate) {}
+  moveDuringDrag(_newLocation: Blockly.utils.Coordinate) {}
 
   endDrag() {}
 
   revertDrag() {}
 
-  setDeleteStyle(enable: boolean) {}
+  setDeleteStyle(_enable: boolean) {}
 }

--- a/src/colours.ts
+++ b/src/colours.ts
@@ -62,13 +62,15 @@ const Colours = {
  * @param prefix A prefix to prepend to the CSS variables.
  * @returns A string containing CSS variable definitions for the colours.
  */
-function varify(coloursObj: object, prefix = '--colour'): string {
+function varify(coloursObj: Record<string, unknown>, prefix = '--colour'): string {
   return Object.entries(coloursObj)
     .map(([key, colour]) => {
       if (typeof colour === 'string') {
         return `${prefix}-${key}: ${colour};`
+      } else if (typeof colour === 'object' && colour !== null) {
+        return varify(colour as Record<string, unknown>, `${prefix}-${key}`)
       } else {
-        return varify(colour, `${prefix}-${key}`)
+        return ''
       }
     })
     .join('\n')

--- a/src/context_menu_items.ts
+++ b/src/context_menu_items.ts
@@ -10,20 +10,26 @@ import * as Blockly from 'blockly/core'
 export function registerDeleteBlock() {
   const deleteOption = {
     displayText(scope: Blockly.ContextMenuRegistry.Scope) {
-      const descendantCount = getDeletableBlocksInStack(scope.block!).length
+      if (!scope.block) {
+        return Blockly.Msg.DELETE_BLOCK
+      }
+      const descendantCount = getDeletableBlocksInStack(scope.block).length
       return descendantCount === 1
         ? Blockly.Msg.DELETE_BLOCK
         : Blockly.Msg.DELETE_X_BLOCKS.replace('%1', `${descendantCount}`)
     },
     preconditionFn(scope: Blockly.ContextMenuRegistry.Scope) {
-      if (!scope.block!.isInFlyout && scope.block!.isDeletable()) {
+      if (scope.block && !scope.block.isInFlyout && scope.block.isDeletable()) {
         return 'enabled'
       }
       return 'hidden'
     },
     callback(scope: Blockly.ContextMenuRegistry.Scope) {
+      if (!scope.block) {
+        return
+      }
       Blockly.Events.setGroup(true)
-      scope.block!.dispose(true, true)
+      scope.block.dispose(true, true)
       Blockly.Events.setGroup(false)
     },
     scopeType: Blockly.ContextMenuRegistry.ScopeType.BLOCK,
@@ -33,17 +39,18 @@ export function registerDeleteBlock() {
   Blockly.ContextMenuRegistry.registry.register(deleteOption)
 }
 
-function getDeletableBlocksInStack(block: Blockly.BlockSvg): Blockly.BlockSvg[] {
+function getDeletableBlocksInStack(block: Blockly.Block): Blockly.Block[] {
   let descendants = block.getDescendants(false).filter(isDeletable)
-  if (block.getNextBlock()) {
+  const nextBlock = block.getNextBlock()
+  if (nextBlock) {
     // Next blocks are not deleted.
-    const nextDescendants = block.getNextBlock()!.getDescendants(false).filter(isDeletable)
+    const nextDescendants = nextBlock.getDescendants(false).filter(isDeletable)
     descendants = descendants.filter((b) => !nextDescendants.includes(b))
   }
   return descendants
 }
 
-function isDeletable(block: Blockly.BlockSvg): boolean {
+function isDeletable(block: Blockly.Block): boolean {
   return block.isDeletable() && !block.isShadow()
 }
 
@@ -101,8 +108,8 @@ export function registerDeleteAll() {
  * @param workspace to delete all blocks from.
  * @returns list of blocks to delete.
  */
-function getDeletableBlocksInWorkspace(workspace: Blockly.WorkspaceSvg): Blockly.BlockSvg[] {
-  return workspace.getTopBlocks(true).flatMap((b: Blockly.BlockSvg) => b.getDescendants(false).filter(isDeletable))
+function getDeletableBlocksInWorkspace(workspace: Blockly.Workspace): Blockly.Block[] {
+  return workspace.getTopBlocks(true).flatMap((b) => b.getDescendants(false).filter(isDeletable))
 }
 
 /**
@@ -111,7 +118,7 @@ function getDeletableBlocksInWorkspace(workspace: Blockly.WorkspaceSvg): Blockly
  * @param eventGroup Event group ID with which all delete events should be
  *     associated.  If not specified, create a new group.
  */
-function deleteNext(deleteList: Blockly.BlockSvg[], eventGroup?: string) {
+function deleteNext(deleteList: Blockly.Block[], eventGroup?: string) {
   const DELAY = 10
   if (eventGroup) {
     Blockly.Events.setGroup(eventGroup)
@@ -136,10 +143,14 @@ function deleteNext(deleteList: Blockly.BlockSvg[], eventGroup?: string) {
  * all subsequent blocks in the stack.
  */
 export function registerDuplicateBlock() {
-  const original = Blockly.ContextMenuRegistry.registry.getItem('blockDuplicate')!
+  const original = Blockly.ContextMenuRegistry.registry.getItem('blockDuplicate')
+  if (!original) {
+    console.error('[context_menu_items] Missing required blockDuplicate menu item')
+    return
+  }
   const duplicateOption = {
-    displayText: original.displayText!,
-    preconditionFn: original.preconditionFn!,
+    displayText: original.displayText,
+    preconditionFn: original.preconditionFn,
     callback(scope: Blockly.ContextMenuRegistry.Scope) {
       if (!scope.block) return
       const data = scope.block.toCopyData(true)

--- a/src/context_menu_items.ts
+++ b/src/context_menu_items.ts
@@ -4,6 +4,12 @@
  */
 import * as Blockly from 'blockly/core'
 
+type ActionRegistryItem = Extract<Blockly.ContextMenuRegistry.RegistryItem, { callback: unknown }>
+
+function isActionRegistryItem(item: Blockly.ContextMenuRegistry.RegistryItem): item is ActionRegistryItem {
+  return 'callback' in item && 'displayText' in item && 'preconditionFn' in item
+}
+
 /**
  * Registers a block delete option that ignores shadows in the block count.
  */
@@ -129,8 +135,12 @@ function deleteNext(deleteList: Blockly.Block[], eventGroup?: string) {
   const block = deleteList.shift()
   if (block) {
     if (!block.isDeadOrDying()) {
-      block.dispose(false, true)
-      setTimeout(deleteNext, DELAY, deleteList, eventGroup)
+      if (block instanceof Blockly.BlockSvg) {
+        block.dispose(false, true)
+      } else {
+        block.dispose(false)
+      }
+      setTimeout(() => deleteNext(deleteList, eventGroup), DELAY)
     } else {
       deleteNext(deleteList, eventGroup)
     }
@@ -148,7 +158,11 @@ export function registerDuplicateBlock() {
     console.error('[context_menu_items] Missing required blockDuplicate menu item')
     return
   }
-  const duplicateOption = {
+  if (!isActionRegistryItem(original)) {
+    console.error('[context_menu_items] Expected blockDuplicate to be an action item')
+    return
+  }
+  const duplicateOption: ActionRegistryItem = {
     displayText: original.displayText,
     preconditionFn: original.preconditionFn,
     callback(scope: Blockly.ContextMenuRegistry.Scope) {

--- a/src/data_category.ts
+++ b/src/data_category.ts
@@ -440,7 +440,11 @@ function addBlock(
           ${secondValueField}
         </block>
       </xml>`
-    const block = Blockly.utils.xml.textToDom(blockText).firstElementChild!
+    const block = Blockly.utils.xml.textToDom(blockText).firstElementChild
+    if (!block) {
+      console.error(`[data_category/addBlock] Failed to create block XML for type ${blockType}`)
+      return
+    }
     xmlList.push(block)
   }
 }
@@ -456,7 +460,7 @@ function generateVariableFieldXml(
   opt_name?: string,
 ): string {
   const field = document.createElement('field')
-  field.setAttribute('name', opt_name || 'VARIABLE')
+  field.setAttribute('name', opt_name ?? 'VARIABLE')
   field.setAttribute('id', variableModel.getId())
   field.setAttribute('variabletype', variableModel.getType())
   field.textContent = variableModel.getName()
@@ -503,6 +507,10 @@ function createValue(valueName: string, type: string, value: string): string {
  */
 function addSep(xmlList: Element[]) {
   const sepText = `<xml><sep gap="36"/></xml>`
-  const sep = Blockly.utils.xml.textToDom(sepText).firstElementChild!
+  const sep = Blockly.utils.xml.textToDom(sepText).firstElementChild
+  if (!sep) {
+    console.error('[data_category/addSep] Failed to create separator XML')
+    return
+  }
   xmlList.push(sep)
 }

--- a/src/events/events_block_comment_base.ts
+++ b/src/events/events_block_comment_base.ts
@@ -33,7 +33,11 @@ export class BlockCommentBase extends Blockly.Events.Abstract {
     }
   }
 
-  static fromJson(json: BlockCommentBaseJson, workspace: Blockly.Workspace, event?: any): BlockCommentBase {
+  static fromJson(
+    json: BlockCommentBaseJson,
+    workspace: Blockly.Workspace,
+    event?: Blockly.Events.Abstract,
+  ): BlockCommentBase {
     const newEvent = super.fromJson(json, workspace, event ?? new BlockCommentBase()) as BlockCommentBase
     newEvent.commentId = json.commentId
     newEvent.blockId = json.blockId

--- a/src/events/events_block_comment_change.ts
+++ b/src/events/events_block_comment_change.ts
@@ -29,7 +29,11 @@ class BlockCommentChange extends BlockCommentBase {
     }
   }
 
-  static fromJson(json: BlockCommentChangeJson, workspace: Blockly.Workspace, event?: any): BlockCommentChange {
+  static fromJson(
+    json: BlockCommentChangeJson,
+    workspace: Blockly.Workspace,
+    event?: Blockly.Events.Abstract,
+  ): BlockCommentChange {
     const newEvent = super.fromJson(json, workspace, event ?? new BlockCommentChange()) as BlockCommentChange
     newEvent.newContents_ = json.newContents
     newEvent.oldContents_ = json.oldContents

--- a/src/events/events_block_comment_collapse.ts
+++ b/src/events/events_block_comment_collapse.ts
@@ -22,7 +22,11 @@ class BlockCommentCollapse extends BlockCommentBase {
     }
   }
 
-  static fromJson(json: BlockCommentCollapseJson, workspace: Blockly.Workspace, event?: any): BlockCommentCollapse {
+  static fromJson(
+    json: BlockCommentCollapseJson,
+    workspace: Blockly.Workspace,
+    event?: Blockly.Events.Abstract,
+  ): BlockCommentCollapse {
     const newEvent = super.fromJson(json, workspace, event ?? new BlockCommentCollapse()) as BlockCommentCollapse
     newEvent.newCollapsed = json.collapsed
 
@@ -41,7 +45,7 @@ class BlockCommentCollapse extends BlockCommentBase {
       console.warn('BlockCommentCollapse.run: comment icon not found', block.id)
       return
     }
-    comment.setBubbleVisible(forward ? !this.newCollapsed : this.newCollapsed)
+    void comment.setBubbleVisible(forward ? !this.newCollapsed : this.newCollapsed)
   }
 }
 

--- a/src/events/events_block_comment_create.ts
+++ b/src/events/events_block_comment_create.ts
@@ -41,7 +41,11 @@ class BlockCommentCreate extends BlockCommentBase {
     }
   }
 
-  static fromJson(json: BlockCommentCreateJson, workspace: Blockly.Workspace, event?: any): BlockCommentCreate {
+  static fromJson(
+    json: BlockCommentCreateJson,
+    workspace: Blockly.Workspace,
+    event?: Blockly.Events.Abstract,
+  ): BlockCommentCreate {
     const newEvent = super.fromJson(json, workspace, event ?? new BlockCommentCreate()) as BlockCommentCreate
     newEvent.json = {
       x: json.x,

--- a/src/events/events_block_comment_move.ts
+++ b/src/events/events_block_comment_move.ts
@@ -29,7 +29,11 @@ class BlockCommentMove extends BlockCommentBase {
     }
   }
 
-  static fromJson(json: BlockCommentMoveJson, workspace: Blockly.Workspace, event?: any): BlockCommentMove {
+  static fromJson(
+    json: BlockCommentMoveJson,
+    workspace: Blockly.Workspace,
+    event?: Blockly.Events.Abstract,
+  ): BlockCommentMove {
     const newEvent = super.fromJson(json, workspace, event ?? new BlockCommentMove()) as BlockCommentMove
     newEvent.newCoordinate_ = new Blockly.utils.Coordinate(json.newCoordinate.x, json.newCoordinate.y)
     newEvent.oldCoordinate_ = new Blockly.utils.Coordinate(json.oldCoordinate.x, json.oldCoordinate.y)
@@ -39,7 +43,7 @@ class BlockCommentMove extends BlockCommentBase {
 
   run(forward: boolean) {
     const workspace = this.getEventWorkspace_()
-    const block = workspace?.getBlockById(this.blockId)
+    const block = workspace.getBlockById(this.blockId)
     const comment = block?.getIcon(Blockly.icons.IconType.COMMENT)
     comment?.setBubbleLocation(forward ? this.newCoordinate_ : this.oldCoordinate_)
   }

--- a/src/events/events_block_comment_resize.ts
+++ b/src/events/events_block_comment_resize.ts
@@ -31,7 +31,11 @@ class BlockCommentResize extends BlockCommentBase {
     }
   }
 
-  static fromJson(json: BlockCommentResizeJson, workspace: Blockly.Workspace, event?: any): BlockCommentResize {
+  static fromJson(
+    json: BlockCommentResizeJson,
+    workspace: Blockly.Workspace,
+    event?: Blockly.Events.Abstract,
+  ): BlockCommentResize {
     const newEvent = super.fromJson(json, workspace, event ?? new BlockCommentResize()) as BlockCommentResize
     newEvent.newSize = new Blockly.utils.Size(json.newSize.width, json.newSize.height)
     newEvent.oldSize = new Blockly.utils.Size(json.oldSize.width, json.oldSize.height)
@@ -41,7 +45,7 @@ class BlockCommentResize extends BlockCommentBase {
 
   run(forward: boolean) {
     const workspace = this.getEventWorkspace_()
-    const block = workspace?.getBlockById(this.blockId)
+    const block = workspace.getBlockById(this.blockId)
     const comment = block?.getIcon(Blockly.icons.IconType.COMMENT)
     comment?.setBubbleSize(forward ? this.newSize : this.oldSize)
   }

--- a/src/events/events_block_drag_end.ts
+++ b/src/events/events_block_drag_end.ts
@@ -24,7 +24,11 @@ export class BlockDragEnd extends Blockly.Events.BlockBase {
     }
   }
 
-  static fromJson(json: BlockDragEndJson, workspace: Blockly.Workspace, event?: any): BlockDragEnd {
+  static fromJson(
+    json: BlockDragEndJson,
+    workspace: Blockly.Workspace,
+    event?: Blockly.Events.Abstract,
+  ): BlockDragEnd {
     const newEvent = super.fromJson(json, workspace, event ?? new BlockDragEnd()) as BlockDragEnd
     newEvent.isOutside = json.isOutside
     newEvent.xml = Blockly.utils.xml.textToDom(json.xml)

--- a/src/events/events_block_drag_outside.ts
+++ b/src/events/events_block_drag_outside.ts
@@ -21,7 +21,11 @@ export class BlockDragOutside extends Blockly.Events.BlockBase {
     }
   }
 
-  static fromJson(json: BlockDragOutsideJson, workspace: Blockly.Workspace, event?: any): BlockDragOutside {
+  static fromJson(
+    json: BlockDragOutsideJson,
+    workspace: Blockly.Workspace,
+    event?: Blockly.Events.Abstract,
+  ): BlockDragOutside {
     const newEvent = super.fromJson(json, workspace, event ?? new BlockDragOutside()) as BlockDragOutside
     newEvent.isOutside = json.isOutside
 

--- a/src/events/events_scratch_variable_create.ts
+++ b/src/events/events_scratch_variable_create.ts
@@ -25,7 +25,11 @@ class ScratchVariableCreate extends Blockly.Events.VarCreate {
     }
   }
 
-  static fromJson(json: ScratchVariableCreateJson, workspace: Blockly.Workspace, event?: any): ScratchVariableCreate {
+  static fromJson(
+    json: ScratchVariableCreateJson,
+    workspace: Blockly.Workspace,
+    event?: Blockly.Events.Abstract,
+  ): ScratchVariableCreate {
     const newEvent = super.fromJson(json, workspace, event ?? new ScratchVariableCreate()) as ScratchVariableCreate
     newEvent.isLocal = json.isLocal
     newEvent.isCloud = json.isCloud

--- a/src/fields/field_colour_slider.ts
+++ b/src/fields/field_colour_slider.ts
@@ -96,7 +96,7 @@ export class FieldColourSlider extends FieldColour {
           stops.push(Blockly.utils.colour.hsvToHex(this.hue_, this.saturation_, (255 * n) / 360))
           break
         default:
-          throw new Error('Unknown channel for colour sliders: ' + channel)
+          throw new Error(`Unknown channel for colour sliders: ${String(channel)}`)
       }
     }
     return stops
@@ -198,9 +198,7 @@ export class FieldColourSlider extends FieldColour {
           break
       }
       const colour = Blockly.utils.colour.hsvToHex(this.hue_, this.saturation_, this.brightness_)
-      if (colour !== null) {
-        this.setValue(colour, true)
-      }
+      this.setValue(colour, true)
     }
   }
 
@@ -279,7 +277,7 @@ export class FieldColourSlider extends FieldColour {
         button,
         'click',
         this,
-        this.activateEyedropperInternal_,
+        this.activateEyedropperInternal_.bind(this),
       )
     }
 

--- a/src/fields/field_matrix.ts
+++ b/src/fields/field_matrix.ts
@@ -210,7 +210,7 @@ class FieldMatrix extends Blockly.Field<string> {
       this.arrow_.setAttributeNS(
         'http://www.w3.org/1999/xlink',
         'xlink:href',
-        this.getConstants()!.FIELD_DROPDOWN_SVG_ARROW_DATAURI,
+        this.getConstants()?.FIELD_DROPDOWN_SVG_ARROW_DATAURI ?? '',
       )
       this.arrow_.style.cursor = 'default'
     }
@@ -241,7 +241,7 @@ class FieldMatrix extends Blockly.Field<string> {
     } else if (this.borderRect_) {
       this.borderRect_.setAttribute(
         'fill',
-        'colourQuaternary' in style ? `${style.colourQuaternary}` : style.colourTertiary,
+        'colourQuaternary' in style ? String(style.colourQuaternary) : style.colourTertiary,
       )
     }
 
@@ -299,17 +299,22 @@ class FieldMatrix extends Blockly.Field<string> {
 
     Blockly.DropDownDiv.showPositionedByBlock(this, sourceBlock, this.dropdownDispose_.bind(this))
 
-    this.matrixTouchWrapper_ = Blockly.browserEvents.bind(this.matrixStage_, 'mousedown', this, this.onMouseDown)
-    this.clearButtonWrapper_ = Blockly.browserEvents.bind(clearButton, 'click', this, this.clearMatrix_)
-    this.fillButtonWrapper_ = Blockly.browserEvents.bind(fillButton, 'click', this, this.fillMatrix_)
+    this.matrixTouchWrapper_ = Blockly.browserEvents.bind(
+      this.matrixStage_,
+      'mousedown',
+      this,
+      this.onMouseDown.bind(this),
+    )
+    this.clearButtonWrapper_ = Blockly.browserEvents.bind(clearButton, 'click', this, this.clearMatrix_.bind(this))
+    this.fillButtonWrapper_ = Blockly.browserEvents.bind(fillButton, 'click', this, this.fillMatrix_.bind(this))
 
     // Update the matrix for the current value
     this.updateMatrix_()
   }
 
   dropdownDispose_() {
-    const sourceBlock = this.getSourceBlock()!
-    if (sourceBlock.isShadow()) {
+    const sourceBlock = this.getSourceBlock()
+    if (sourceBlock?.isShadow()) {
       sourceBlock.setStyle(this.originalStyle)
     }
     this.updateMatrix_()
@@ -355,10 +360,12 @@ class FieldMatrix extends Blockly.Field<string> {
    * Redraw the matrix with the current value.
    */
   private updateMatrix_() {
-    const matrix = this.getValue()!
-    const sourceBlock = this.getSourceBlock()! as Blockly.BlockSvg
+    const matrix = this.getValue()
+    if (!matrix) return
+    const sourceBlock = this.getSourceBlock() as Blockly.BlockSvg | null
+    if (!sourceBlock) return
     for (let i = 0; i < matrix.length; i++) {
-      if (matrix[i] === LEDState.OFF) {
+      if ((matrix[i] as LEDState) === LEDState.OFF) {
         this.fillMatrixNode_(this.ledButtons_, i, sourceBlock.getColourTertiary())
         this.fillMatrixNode_(this.ledThumbNodes_, i, sourceBlock.getColourSecondary())
       } else {
@@ -393,13 +400,14 @@ class FieldMatrix extends Blockly.Field<string> {
    * @param fill The fill colour in '#rrggbb' format.
    */
   fillMatrixNode_(node: SVGElement[], index: number, fill: string) {
-    if (!node?.[index] || !fill) return
+    if (!node[index] || !fill) return
     node[index].setAttribute('fill', fill)
   }
 
   setLEDNode_(led: number, state: LEDState) {
     if (led < 0 || led > 24) return
-    const oldMatrix = this.getValue()!
+    const oldMatrix = this.getValue()
+    if (!oldMatrix) return
     const newMatrix = oldMatrix.substr(0, led) + state + oldMatrix.substr(led + 1)
     this.setValue(newMatrix)
   }
@@ -416,7 +424,9 @@ class FieldMatrix extends Blockly.Field<string> {
 
   toggleLEDNode_(led: number) {
     if (led < 0 || led > 24) return
-    if (this.getValue()!.charAt(led) === LEDState.OFF) {
+    const value = this.getValue()
+    if (!value) return
+    if ((value.charAt(led) as LEDState) === LEDState.OFF) {
       this.setLEDNode_(led, LEDState.ON)
     } else {
       this.setLEDNode_(led, LEDState.OFF)
@@ -428,11 +438,17 @@ class FieldMatrix extends Blockly.Field<string> {
    * @param e Mouse event.
    */
   onMouseDown(e: PointerEvent) {
-    this.matrixMoveWrapper_ = Blockly.browserEvents.bind(document.body, 'mousemove', this, this.onMouseMove)
-    this.matrixReleaseWrapper_ = Blockly.browserEvents.bind(document.body, 'mouseup', this, this.onMouseUp)
+    this.matrixMoveWrapper_ = Blockly.browserEvents.bind(
+      document.body,
+      'mousemove',
+      this,
+      this.onMouseMove.bind(this),
+    )
+    this.matrixReleaseWrapper_ = Blockly.browserEvents.bind(document.body, 'mouseup', this, this.onMouseUp.bind(this))
     const ledHit = this.checkForLED_(e)
     if (ledHit > -1) {
-      if (this.getValue()!.charAt(ledHit) === LEDState.OFF) {
+      const value = this.getValue()
+      if (value && (value.charAt(ledHit) as LEDState) === LEDState.OFF) {
         this.paintStyle_ = PaintStyle.FILL
       } else {
         this.paintStyle_ = PaintStyle.CLEAR
@@ -470,7 +486,7 @@ class FieldMatrix extends Blockly.Field<string> {
       if (led < 0) return
       if (this.paintStyle_ === PaintStyle.CLEAR) {
         this.clearLEDNode_(led)
-      } else if (this.paintStyle_ === PaintStyle.FILL) {
+      } else {
         this.fillLEDNode_(led)
       }
     }

--- a/src/fields/field_note.ts
+++ b/src/fields/field_note.ts
@@ -284,6 +284,9 @@ export class FieldNote extends Blockly.FieldTextInput {
    */
   showEditor_(event: PointerEvent, quietInput = false) {
     super.showEditor_(event, quietInput, false)
+    const parentBlock = this.getSourceBlock()?.getParent() as Blockly.BlockSvg | undefined
+    const parentTertiary = parentBlock?.getColourTertiary() ?? ''
+    const parentColour = parentBlock?.getColour() ?? ''
 
     // Build the SVG DOM.
     const div = Blockly.DropDownDiv.getContentDiv()
@@ -341,7 +344,7 @@ export class FieldNote extends Blockly.FieldTextInput {
     Blockly.utils.dom.createSvgElement(
       'line',
       {
-        stroke: (this.sourceBlock_!.getParent() as Blockly.BlockSvg).getColourTertiary(),
+        stroke: parentTertiary,
         x1: 0,
         y1: FieldNote.TOP_MENU_HEIGHT,
         x2: this.fieldEditorWidth_,
@@ -379,7 +382,7 @@ export class FieldNote extends Blockly.FieldTextInput {
       this.changeOctaveBy_(1)
     })
     const sourceBlock = this.getSourceBlock() as Blockly.BlockSvg
-    Blockly.DropDownDiv.setColour(sourceBlock.getParent()!.getColour(), sourceBlock.getParent()!.getColourTertiary())
+    Blockly.DropDownDiv.setColour(parentColour, parentTertiary)
     Blockly.DropDownDiv.showPositionedByBlock(this, sourceBlock)
 
     this.updateSelection_()
@@ -398,6 +401,8 @@ export class FieldNote extends Blockly.FieldTextInput {
     blackKeyGroup: SVGElement,
     keySVGarray: SVGElement[] | null,
   ) {
+    const parentTertiary =
+      (this.getSourceBlock()?.getParent() as Blockly.BlockSvg | undefined)?.getColourTertiary() ?? ''
     let xIncrement, width, height, fill, stroke, group
     x += FieldNote.EDGE_PADDING / 2
     const y = FieldNote.TOP_MENU_HEIGHT
@@ -417,7 +422,7 @@ export class FieldNote extends Blockly.FieldTextInput {
         width = FieldNote.WHITE_KEY_WIDTH
         height = FieldNote.WHITE_KEY_HEIGHT
         fill = FieldNote.WHITE_KEY_COLOR
-        stroke = (this.sourceBlock_!.getParent() as Blockly.BlockSvg).getColourTertiary()
+        stroke = parentTertiary
         group = whiteKeyGroup
       }
       const attr = {
@@ -435,8 +440,18 @@ export class FieldNote extends Blockly.FieldTextInput {
         keySVG.setAttribute('data-name', `${FieldNote.KEY_INFO[i].name}`)
         keySVG.setAttribute('data-isBlack', `${FieldNote.KEY_INFO[i].isBlack}`)
 
-        this.mouseDownWrappers_[i] = Blockly.browserEvents.bind(keySVG, 'mousedown', this, this.onMouseDownOnKey_)
-        this.mouseEnterWrappers_[i] = Blockly.browserEvents.bind(keySVG, 'mouseenter', this, this.onMouseEnter_)
+        this.mouseDownWrappers_[i] = Blockly.browserEvents.bind(
+          keySVG,
+          'mousedown',
+          this,
+          this.onMouseDownOnKey_.bind(this),
+        )
+        this.mouseEnterWrappers_[i] = Blockly.browserEvents.bind(
+          keySVG,
+          'mouseenter',
+          this,
+          this.onMouseEnter_.bind(this),
+        )
       }
     }
   }
@@ -505,6 +520,8 @@ export class FieldNote extends Blockly.FieldTextInput {
    * @returns A group containing the button SVG elements.
    */
   private addOctaveButton_(x: number, flipped: boolean, svg: SVGElement): SVGElement {
+    const parentTertiary =
+      (this.getSourceBlock()?.getParent() as Blockly.BlockSvg | undefined)?.getColourTertiary() ?? ''
     const group = Blockly.utils.dom.createSvgElement('g', {}, svg)
     const imageSize = FieldNote.OCTAVE_BUTTON_SIZE
     const arrow = Blockly.utils.dom.createSvgElement(
@@ -525,7 +542,7 @@ export class FieldNote extends Blockly.FieldTextInput {
     Blockly.utils.dom.createSvgElement(
       'line',
       {
-        stroke: (this.sourceBlock_!.getParent() as Blockly.BlockSvg).getColourTertiary(),
+        stroke: parentTertiary,
         x1: x - FieldNote.INSET,
         y1: 0,
         x2: x - FieldNote.INSET,
@@ -588,7 +605,7 @@ export class FieldNote extends Blockly.FieldTextInput {
    */
   private onMouseDownOnKey_(e: PointerEvent) {
     this.mouseIsDown_ = true
-    this.mouseUpWrapper_ = Blockly.browserEvents.bind(document.body, 'mouseup', this, this.onMouseUp_)
+    this.mouseUpWrapper_ = Blockly.browserEvents.bind(document.body, 'mouseup', this, this.onMouseUp_.bind(this))
     this.selectNoteWithMouseEvent_(e)
   }
 
@@ -628,18 +645,19 @@ export class FieldNote extends Blockly.FieldTextInput {
    * Play a note, by calling the externally overriden play note function.
    */
   private playNoteInternal_() {
-    if (FieldNote.playNote_) {
-      FieldNote.playNote_(Number(this.getValue()!), 'Music')
+    const noteNum = this.getValue()
+    if (FieldNote.playNote_ && noteNum !== null) {
+      FieldNote.playNote_(Number(noteNum), 'Music')
     }
   }
 
   /**
    * Function to play a musical note corresponding to the key selected.
    * Overridden externally.
-   * @param noteNum the MIDI note number to play.
-   * @param id An id to select a scratch extension to play the note.
+   * @param _noteNum the MIDI note number to play.
+   * @param _id An id to select a scratch extension to play the note.
    */
-  static playNote_ = function (noteNum: number, id: string) {
+  static playNote_: ((noteNum: number, id: string) => void) | null = function (_noteNum: number, _id: string) {
     return
   }
 
@@ -739,7 +757,7 @@ export class FieldNote extends Blockly.FieldTextInput {
         this.noteNameText_.textContent = noteName + ' (' + Math.floor(noteNum) + ')'
       }
       // Update the low and high C note names
-      const lowCNum = (this.displayedOctave_ ?? 0) * 12
+      const lowCNum = this.displayedOctave_ * 12
       if (this.lowCText_) this.lowCText_.textContent = 'C(' + lowCNum + ')'
       if (this.highCText_) this.highCText_.textContent = 'C(' + (lowCNum + 12) + ')'
     }
@@ -750,7 +768,7 @@ export class FieldNote extends Blockly.FieldTextInput {
    * @param text The user's text.
    * @returns A string representing a valid note number, or null if invalid.
    */
-  doClassValidation_(text: string): string | null {
+  doClassValidation_(text: string | null): string | null {
     if (text === null) {
       return null
     }

--- a/src/fields/field_note.ts
+++ b/src/fields/field_note.ts
@@ -382,8 +382,9 @@ export class FieldNote extends Blockly.FieldTextInput {
       this.changeOctaveBy_(1)
     })
     const sourceBlock = this.getSourceBlock() as Blockly.BlockSvg
+    const dropdownAnchor = this as unknown as Blockly.Field<string | null>
     Blockly.DropDownDiv.setColour(parentColour, parentTertiary)
-    Blockly.DropDownDiv.showPositionedByBlock(this, sourceBlock)
+    Blockly.DropDownDiv.showPositionedByBlock(dropdownAnchor, sourceBlock)
 
     this.updateSelection_()
   }

--- a/src/fields/field_note.ts
+++ b/src/fields/field_note.ts
@@ -285,8 +285,11 @@ export class FieldNote extends Blockly.FieldTextInput {
   showEditor_(event: PointerEvent, quietInput = false) {
     super.showEditor_(event, quietInput, false)
     const parentBlock = this.getSourceBlock()?.getParent() as Blockly.BlockSvg | undefined
-    const parentTertiary = parentBlock?.getColourTertiary() ?? ''
-    const parentColour = parentBlock?.getColour() ?? ''
+    if (!parentBlock) {
+      throw new Error('[field_note] Missing parent block for note field editor')
+    }
+    const parentColour = parentBlock.getColour()
+    const parentTertiary = parentBlock.getColourTertiary()
 
     // Build the SVG DOM.
     const div = Blockly.DropDownDiv.getContentDiv()
@@ -317,9 +320,21 @@ export class FieldNote extends Blockly.FieldTextInput {
     // Add three piano octaves, so we can animate moving up or down an octave.
     // Only the middle octave gets bound to events.
     this.keySVGs_ = []
-    this.addPianoOctave_(-this.fieldEditorWidth_ + FieldNote.EDGE_PADDING, whiteKeyGroup, blackKeyGroup, null)
-    this.addPianoOctave_(0, whiteKeyGroup, blackKeyGroup, this.keySVGs_)
-    this.addPianoOctave_(this.fieldEditorWidth_ - FieldNote.EDGE_PADDING, whiteKeyGroup, blackKeyGroup, null)
+    this.addPianoOctave_(
+      -this.fieldEditorWidth_ + FieldNote.EDGE_PADDING,
+      whiteKeyGroup,
+      blackKeyGroup,
+      null,
+      parentBlock,
+    )
+    this.addPianoOctave_(0, whiteKeyGroup, blackKeyGroup, this.keySVGs_, parentBlock)
+    this.addPianoOctave_(
+      this.fieldEditorWidth_ - FieldNote.EDGE_PADDING,
+      whiteKeyGroup,
+      blackKeyGroup,
+      null,
+      parentBlock,
+    )
 
     // Note name indicator at the top of the field
     this.noteNameText_ = Blockly.utils.dom.createSvgElement(
@@ -368,11 +383,12 @@ export class FieldNote extends Blockly.FieldTextInput {
     )
 
     // Octave buttons
-    const octaveDownButton = this.addOctaveButton_(0, true, svg)
+    const octaveDownButton = this.addOctaveButton_(0, true, svg, parentBlock)
     const octaveUpButton = this.addOctaveButton_(
       this.fieldEditorWidth_ + FieldNote.INSET * 2 - FieldNote.OCTAVE_BUTTON_SIZE,
       false,
       svg,
+      parentBlock,
     )
 
     this.octaveDownMouseDownWrapper_ = Blockly.browserEvents.bind(octaveDownButton, 'mousedown', this, () => {
@@ -395,16 +411,17 @@ export class FieldNote extends Blockly.FieldTextInput {
    * @param whiteKeyGroup The group for all white piano keys.
    * @param blackKeyGroup The group for all black piano keys.
    * @param keySVGarray An array containing all the key SVGs.
+   * @param parentBlock The validated parent block providing styling.
    */
   private addPianoOctave_(
     x: number,
     whiteKeyGroup: SVGElement,
     blackKeyGroup: SVGElement,
     keySVGarray: SVGElement[] | null,
+    parentBlock: Blockly.BlockSvg,
   ) {
-    const parentTertiary =
-      (this.getSourceBlock()?.getParent() as Blockly.BlockSvg | undefined)?.getColourTertiary() ?? ''
     let xIncrement, width, height, fill, stroke, group
+    const parentTertiary = parentBlock.getColourTertiary()
     x += FieldNote.EDGE_PADDING / 2
     const y = FieldNote.TOP_MENU_HEIGHT
     for (let i = 0; i < FieldNote.KEY_INFO.length; i++) {
@@ -518,12 +535,12 @@ export class FieldNote extends Blockly.FieldTextInput {
    * @param x The x position of the button.
    * @param flipped If true, the icon should be flipped.
    * @param svg The svg element to add the buttons to.
+   * @param parentBlock The validated parent block providing styling.
    * @returns A group containing the button SVG elements.
    */
-  private addOctaveButton_(x: number, flipped: boolean, svg: SVGElement): SVGElement {
-    const parentTertiary =
-      (this.getSourceBlock()?.getParent() as Blockly.BlockSvg | undefined)?.getColourTertiary() ?? ''
+  private addOctaveButton_(x: number, flipped: boolean, svg: SVGElement, parentBlock: Blockly.BlockSvg): SVGElement {
     const group = Blockly.utils.dom.createSvgElement('g', {}, svg)
+    const parentTertiary = parentBlock.getColourTertiary()
     const imageSize = FieldNote.OCTAVE_BUTTON_SIZE
     const arrow = Blockly.utils.dom.createSvgElement(
       'image',

--- a/src/fields/field_textinput_removable.ts
+++ b/src/fields/field_textinput_removable.ts
@@ -35,19 +35,28 @@ export class FieldTextInputRemovable extends Blockly.FieldTextInput {
   showEditor_() {
     // Wait for our parent block to render so we can examine its metrics to
     // calculate rounded corners on the editor as needed.
-    Blockly.renderManagement.finishQueuedRenders().then(() => {
+    void Blockly.renderManagement.finishQueuedRenders().then(() => {
       super.showEditor_()
 
-      const div = Blockly.WidgetDiv.getDiv()!
+      const div = Blockly.WidgetDiv.getDiv()
+      if (!div) {
+        console.error('[field_textinput_removable] Missing WidgetDiv for removable text input')
+        return
+      }
+      if (!this.sourceBlock_) {
+        console.error('[field_textinput_removable] Missing source block for removable text input')
+        return
+      }
+
       div.className += ' removableTextInput'
       const removeButton = document.createElement('img')
       removeButton.className = 'blocklyTextRemoveIcon'
-      removeButton.setAttribute('src', this.sourceBlock_!.workspace.options.pathToMedia + 'icons/remove.svg')
+      removeButton.setAttribute('src', this.sourceBlock_.workspace.options.pathToMedia + 'icons/remove.svg')
       this.removeButtonMouseWrapper_ = Blockly.browserEvents.bind(
         removeButton,
         'mousedown',
         this,
-        this.removeCallback_,
+        this.removeCallback_.bind(this),
       )
       div.appendChild(removeButton)
     })

--- a/src/fields/field_variable_getter.ts
+++ b/src/fields/field_variable_getter.ts
@@ -70,8 +70,13 @@ class FieldVariableGetter extends Blockly.FieldLabel {
    */
   doValueUpdate_(newVariableId: string) {
     super.doValueUpdate_(newVariableId)
-    const workspace = this.getSourceBlock()!.workspace
-    this.variable = Blockly.Variables.getVariable(workspace, newVariableId)
+    const sourceBlock = this.getSourceBlock()
+    if (!sourceBlock) {
+      console.error('[field_variable_getter] Missing source block in doValueUpdate_')
+      this.variable = null
+      return
+    }
+    this.variable = Blockly.Variables.getVariable(sourceBlock.workspace, newVariableId)
   }
 
   /**
@@ -92,13 +97,22 @@ class FieldVariableGetter extends Blockly.FieldLabel {
   }
 
   fromXml(element: Element) {
-    this.setValue(element.getAttribute('id')!)
+    const id = element.getAttribute('id')
+    if (!id) {
+      console.error('[field_variable_getter] Missing variable id in XML')
+      return
+    }
+    this.setValue(id)
   }
 
   toXml(element: Element): Element {
-    element.setAttribute('id', this.variable!.getId())
-    element.setAttribute('variabletype', this.variable!.getType())
-    element.textContent = this.variable!.getName()
+    if (!this.variable) {
+      console.error('[field_variable_getter] Missing variable in toXml')
+      return element
+    }
+    element.setAttribute('id', this.variable.getId())
+    element.setAttribute('variabletype', this.variable.getType())
+    element.textContent = this.variable.getName()
     return element
   }
 }

--- a/src/fields/field_vertical_separator.ts
+++ b/src/fields/field_vertical_separator.ts
@@ -73,7 +73,11 @@ class FieldVerticalSeparator extends Blockly.Field {
    * @package
    */
   setLineHeight(newHeight: number) {
-    this.lineElement!.setAttribute('y2', `${newHeight}`)
+    if (!this.lineElement) {
+      console.error('[field_vertical_separator] Missing lineElement in setLineHeight')
+      return
+    }
+    this.lineElement.setAttribute('y2', `${newHeight}`)
   }
 
   /**

--- a/src/fields/scratch_field_angle.ts
+++ b/src/fields/scratch_field_angle.ts
@@ -47,17 +47,17 @@ class ScratchFieldAngle extends Blockly.FieldNumber {
   /**
    * Opaque identifier used to unbind event listener in dispose().
    */
-  private mouseDownWrapper_!: Blockly.browserEvents.Data
+  private mouseDownWrapper_?: Blockly.browserEvents.Data
 
   /**
    * Opaque identifier used to unbind event listener in dispose().
    */
-  private mouseMoveWrapper!: Blockly.browserEvents.Data
+  private mouseMoveWrapper?: Blockly.browserEvents.Data
 
   /**
    * Opaque identifier used to unbind event listener in dispose().
    */
-  private mouseUpWrapper!: Blockly.browserEvents.Data
+  private mouseUpWrapper?: Blockly.browserEvents.Data
 
   /**
    * Round angles to the nearest 15 degrees when using mouse.
@@ -164,6 +164,14 @@ class ScratchFieldAngle extends Blockly.FieldNumber {
     Blockly.DropDownDiv.hideWithoutAnimation()
     Blockly.DropDownDiv.clearContent()
     const div = Blockly.DropDownDiv.getContentDiv()
+    const sourceBlock = this.getSourceBlock()
+    if (!(sourceBlock instanceof Blockly.BlockSvg)) {
+      throw new Error('[scratch_field_angle] Missing source BlockSvg for showEditor_')
+    }
+    const parentBlock = sourceBlock.getParent()
+    if (!parentBlock) {
+      throw new Error('[scratch_field_angle] Missing parent block for showEditor_')
+    }
     // Build the SVG DOM.
     const svg = Blockly.utils.dom.createSvgElement(
       'svg',
@@ -183,8 +191,8 @@ class ScratchFieldAngle extends Blockly.FieldNumber {
         cx: this.HALF,
         cy: this.HALF,
         r: this.RADIUS,
-        fill: (this.getSourceBlock()!.getParent() as Blockly.BlockSvg).getColourSecondary(),
-        stroke: (this.getSourceBlock()!.getParent() as Blockly.BlockSvg).getColourTertiary(),
+        fill: parentBlock.getColourSecondary(),
+        stroke: parentBlock.getColourTertiary(),
         class: 'blocklyAngleCircle',
       },
       svg,
@@ -268,13 +276,10 @@ class ScratchFieldAngle extends Blockly.FieldNumber {
       Blockly.getMainWorkspace().options.pathToMedia + this.ARROW_SVG_PATH,
     )
 
-    Blockly.DropDownDiv.setColour(
-      (this.getSourceBlock()!.getParent() as Blockly.BlockSvg).getColour(),
-      (this.getSourceBlock()!.getParent() as Blockly.BlockSvg).getColourTertiary(),
-    )
-    Blockly.DropDownDiv.showPositionedByBlock(this, this.getSourceBlock() as Blockly.BlockSvg)
+    Blockly.DropDownDiv.setColour(parentBlock.getColour(), parentBlock.getColourTertiary())
+    Blockly.DropDownDiv.showPositionedByBlock(this as Blockly.Field<string | number | null>, sourceBlock)
 
-    this.mouseDownWrapper_ = Blockly.browserEvents.bind(this.handle, 'mousedown', this, this.onMouseDown)
+    this.mouseDownWrapper_ = Blockly.browserEvents.bind(this.handle, 'mousedown', this, this.onMouseDown.bind(this))
 
     this.updateGraph()
   }
@@ -283,16 +288,20 @@ class ScratchFieldAngle extends Blockly.FieldNumber {
    * Set the angle to match the mouse's position.
    */
   onMouseDown() {
-    this.mouseMoveWrapper = Blockly.browserEvents.bind(document.body, 'mousemove', this, this.onMouseMove)
-    this.mouseUpWrapper = Blockly.browserEvents.bind(document.body, 'mouseup', this, this.onMouseUp)
+    this.mouseMoveWrapper = Blockly.browserEvents.bind(document.body, 'mousemove', this, this.onMouseMove.bind(this))
+    this.mouseUpWrapper = Blockly.browserEvents.bind(document.body, 'mouseup', this, this.onMouseUp.bind(this))
   }
 
   /**
    * Set the angle to match the mouse's position.
    */
   onMouseUp() {
-    Blockly.browserEvents.unbind(this.mouseMoveWrapper)
-    Blockly.browserEvents.unbind(this.mouseUpWrapper)
+    if (this.mouseMoveWrapper) {
+      Blockly.browserEvents.unbind(this.mouseMoveWrapper)
+    }
+    if (this.mouseUpWrapper) {
+      Blockly.browserEvents.unbind(this.mouseUpWrapper)
+    }
   }
 
   /**
@@ -301,7 +310,9 @@ class ScratchFieldAngle extends Blockly.FieldNumber {
    */
   onMouseMove(e: PointerEvent) {
     e.preventDefault()
-    const bBox = this.gauge!.ownerSVGElement!.getBoundingClientRect()
+    const ownerSvg = this.gauge?.ownerSVGElement
+    if (!ownerSvg) return
+    const bBox = ownerSvg.getBoundingClientRect()
     const dx = e.clientX - bBox.left - this.HALF
     const dy = e.clientY - bBox.top - this.HALF
     let angle = Math.atan(-dy / dx)
@@ -383,12 +394,12 @@ class ScratchFieldAngle extends Blockly.FieldNumber {
       } else {
         imageRotation = -angleDegrees
       }
-      this.arrow!.setAttribute('transform', 'rotate(' + imageRotation + ')')
+      this.arrow?.setAttribute('transform', 'rotate(' + imageRotation + ')')
     }
     this.gauge.setAttribute('d', path.join(''))
-    this.line!.setAttribute('x2', `${x2}`)
-    this.line!.setAttribute('y2', `${y2}`)
-    this.handle!.setAttribute('transform', 'translate(' + x2 + ',' + y2 + ')')
+    this.line?.setAttribute('x2', `${x2}`)
+    this.line?.setAttribute('y2', `${y2}`)
+    this.handle?.setAttribute('transform', 'translate(' + x2 + ',' + y2 + ')')
   }
 
   /**
@@ -396,7 +407,7 @@ class ScratchFieldAngle extends Blockly.FieldNumber {
    * @param text The user's text.
    * @returns A string representing a valid angle, or null if invalid.
    */
-  doClassValidation_(text: string): number | null {
+  doClassValidation_(text: string | null): number | null {
     if (text === null) {
       return null
     }

--- a/src/fields/scratch_field_dropdown.ts
+++ b/src/fields/scratch_field_dropdown.ts
@@ -17,14 +17,18 @@ class ScratchFieldDropdown extends Blockly.FieldDropdown {
     } else if (this.borderRect_) {
       this.borderRect_.setAttribute(
         'fill',
-        'colourQuaternary' in style ? `${style.colourQuaternary}` : style.colourTertiary,
+        'colourQuaternary' in style ? String(style.colourQuaternary) : style.colourTertiary,
       )
     }
   }
 
   dropdownDispose_() {
     super.dropdownDispose_()
-    const sourceBlock = this.getSourceBlock()!
+    const sourceBlock = this.getSourceBlock()
+    if (!sourceBlock) {
+      console.error('[scratch_field_dropdown] Missing source block in dropdownDispose_')
+      return
+    }
     if (sourceBlock.isShadow()) {
       sourceBlock.setStyle(this.originalStyle)
     }

--- a/src/fields/scratch_field_number.ts
+++ b/src/fields/scratch_field_number.ts
@@ -112,12 +112,12 @@ class ScratchFieldNumber extends Blockly.FieldTextInput {
    */
   showEditor_(e: PointerEvent) {
     // Do not focus on mobile devices so we can show the num-pad
-    const showNumPad = e?.pointerType === 'touch'
+    const showNumPad = e.pointerType === 'touch'
     super.showEditor_(e, showNumPad)
 
     // Show a numeric keypad in the drop-down on touch
     if (showNumPad) {
-      this.htmlInput_!.select()
+      this.htmlInput_?.select()
       this.showNumPad_()
     }
   }
@@ -148,7 +148,10 @@ class ScratchFieldNumber extends Blockly.FieldTextInput {
 
     // Set colour and size of drop-down
     const sourceBlock = this.getSourceBlock() as Blockly.BlockSvg
-    Blockly.DropDownDiv.setColour(sourceBlock.getParent()!.getColour(), sourceBlock.getColourTertiary())
+    const parentBlock = sourceBlock.getParent()
+    if (parentBlock) {
+      Blockly.DropDownDiv.setColour(parentBlock.getColour(), sourceBlock.getColourTertiary())
+    }
     contentDiv.style.width = ScratchFieldNumber.DROPDOWN_WIDTH + 'px'
 
     this.position_()
@@ -176,7 +179,7 @@ class ScratchFieldNumber extends Blockly.FieldTextInput {
     Blockly.DropDownDiv.setBoundsElement(sourceBlock.workspace.getParentSvg().parentElement)
     Blockly.DropDownDiv.show(
       this,
-      this.getSourceBlock()!.RTL,
+      sourceBlock.RTL,
       primaryX,
       primaryY,
       secondaryX,
@@ -193,8 +196,9 @@ class ScratchFieldNumber extends Blockly.FieldTextInput {
    */
   private addButtons_(contentDiv: Element) {
     const sourceBlock = this.getSourceBlock() as Blockly.BlockSvg
-    const buttonColour = sourceBlock.getParent()!.getColour()
-    const buttonBorderColour = sourceBlock.getParent()!.getColourTertiary()
+    const parent = sourceBlock.getParent()
+    const buttonColour = parent?.getColour() ?? sourceBlock.getColour()
+    const buttonBorderColour = parent?.getColourTertiary() ?? sourceBlock.getColourTertiary()
 
     // Add numeric keypad buttons
     const buttons = ScratchFieldNumber.NUMPAD_BUTTONS
@@ -248,10 +252,12 @@ class ScratchFieldNumber extends Blockly.FieldTextInput {
     // String of the button (e.g., '7')
     const spliceValue = (e.target as HTMLElement).innerText
     // Old value of the text field
-    const oldValue = this.htmlInput_!.value
+    const htmlInput = this.htmlInput_
+    if (!htmlInput) return
+    const oldValue = htmlInput.value
     // Determine the selected portion of the text field
-    const selectionStart = this.htmlInput_!.selectionStart ?? 0
-    const selectionEnd = this.htmlInput_!.selectionEnd ?? 0
+    const selectionStart = htmlInput.selectionStart ?? 0
+    const selectionEnd = htmlInput.selectionEnd ?? 0
 
     // Splice in the new value
     const newValue = oldValue.slice(0, selectionStart) + spliceValue + oldValue.slice(selectionEnd)
@@ -273,10 +279,12 @@ class ScratchFieldNumber extends Blockly.FieldTextInput {
    */
   numPadEraseButtonTouch(e: PointerEvent) {
     // Old value of the text field
-    const oldValue = this.htmlInput_!.value
+    const htmlInput = this.htmlInput_
+    if (!htmlInput) return
+    const oldValue = htmlInput.value
     // Determine what is selected to erase (if anything)
-    let selectionStart = this.htmlInput_!.selectionStart ?? 0
-    const selectionEnd = this.htmlInput_!.selectionEnd ?? 0
+    let selectionStart = htmlInput.selectionStart ?? 0
+    const selectionEnd = htmlInput.selectionEnd ?? 0
 
     // If selection is zero-length, shift start to the left 1 character
     if (selectionStart == selectionEnd) {
@@ -303,7 +311,8 @@ class ScratchFieldNumber extends Blockly.FieldTextInput {
   private updateDisplay_(newValue: string, newSelection: number) {
     this.setEditorValue_(newValue)
     // Resize and scroll the text field appropriately
-    const htmlInput = this.htmlInput_!
+    const htmlInput = this.htmlInput_
+    if (!htmlInput) return
     htmlInput.setSelectionRange(newSelection, newSelection)
     htmlInput.scrollLeft = htmlInput.scrollWidth
   }

--- a/src/fields/scratch_field_number.ts
+++ b/src/fields/scratch_field_number.ts
@@ -110,9 +110,9 @@ class ScratchFieldNumber extends Blockly.FieldTextInput {
    * appropriate.
    * @param e The triggering pointer event.
    */
-  showEditor_(e: PointerEvent) {
+  showEditor_(e?: PointerEvent) {
     // Do not focus on mobile devices so we can show the num-pad
-    const showNumPad = e.pointerType === 'touch'
+    const showNumPad = e?.pointerType === 'touch'
     super.showEditor_(e, showNumPad)
 
     // Show a numeric keypad in the drop-down on touch

--- a/src/fields/scratch_field_variable.ts
+++ b/src/fields/scratch_field_variable.ts
@@ -29,6 +29,13 @@ import { createVariable, renameVariable } from '../variables'
 export class ScratchFieldVariable extends Blockly.FieldVariable {
   private originalStyle!: string
 
+  private getSourceWorkspaceSvg_(sourceBlock: Blockly.Block): Blockly.WorkspaceSvg {
+    if (!(sourceBlock.workspace instanceof Blockly.WorkspaceSvg)) {
+      throw new Error('[scratch_field_variable] Expected source block workspace to be a WorkspaceSvg')
+    }
+    return sourceBlock.workspace
+  }
+
   constructor(
     varName: string | null | typeof Blockly.Field.SKIP_SETUP,
     validator?: Blockly.FieldVariableValidator,
@@ -40,14 +47,15 @@ export class ScratchFieldVariable extends Blockly.FieldVariable {
     // dropdownCreate returns MenuOption[] rather than Blockly.MenuGenerator's
     // MenuOption[][] variant; the cast is needed to satisfy FieldVariable's
     // menuGenerator_ type while the actual runtime shape is compatible.
-    this.menuGenerator_ = ScratchFieldVariable.dropdownCreate as unknown as Blockly.MenuGenerator
+    this.menuGenerator_ = ScratchFieldVariable.dropdownCreate.bind(this) as unknown as Blockly.MenuGenerator
   }
 
   initModel() {
     if (!this.getVariable()) {
       const sourceBlock = this.getSourceBlock()
       if (sourceBlock) {
-        const broadcastVariable = this.initFlyoutBroadcast(sourceBlock.workspace as Blockly.WorkspaceSvg)
+        const sourceWorkspace = this.getSourceWorkspaceSvg_(sourceBlock)
+        const broadcastVariable = this.initFlyoutBroadcast(sourceWorkspace)
         if (broadcastVariable) {
           this.doValueUpdate_(broadcastVariable.getId())
           return
@@ -96,7 +104,8 @@ export class ScratchFieldVariable extends Blockly.FieldVariable {
         if (option[1] === Blockly.RENAME_VARIABLE_ID) {
           return [ScratchMsgs.translate('RENAME_LIST'), option[1]]
         } else if (option[1] === Blockly.DELETE_VARIABLE_ID) {
-          return [ScratchMsgs.translate('DELETE_LIST').replace('%1', this.getText()), option[1]]
+          const fieldText = (this as Blockly.FieldVariable).getText()
+          return [String(ScratchMsgs.translate('DELETE_LIST')).replace('%1', fieldText), option[1]]
         }
         return option
       })
@@ -118,8 +127,9 @@ export class ScratchFieldVariable extends Blockly.FieldVariable {
     if (sourceBlock && !sourceBlock.isDeadOrDying()) {
       const selectedItem = menuItem.getValue()
       if (selectedItem === Constants.NEW_BROADCAST_MESSAGE_ID) {
+        const sourceWorkspace = this.getSourceWorkspaceSvg_(sourceBlock)
         createVariable(
-          sourceBlock.workspace as Blockly.WorkspaceSvg,
+          sourceWorkspace,
           (varId) => {
             if (varId) {
               this.setValue(varId)
@@ -129,7 +139,7 @@ export class ScratchFieldVariable extends Blockly.FieldVariable {
         )
         return
       } else if (selectedItem === Blockly.RENAME_VARIABLE_ID) {
-        renameVariable(sourceBlock.workspace as Blockly.WorkspaceSvg, this.getVariable() as ScratchVariableModel)
+        renameVariable(sourceBlock.workspace, this.getVariable() as ScratchVariableModel)
         return
       }
     }
@@ -138,26 +148,30 @@ export class ScratchFieldVariable extends Blockly.FieldVariable {
 
   showEditor_(event: PointerEvent) {
     super.showEditor_(event)
-    const sourceBlock = this.getSourceBlock()!
+    const sourceBlock = this.getSourceBlock()
+    if (!sourceBlock) {
+      throw new Error('[scratch_field_variable] Missing source block in showEditor_')
+    }
+    const sourceWorkspace = this.getSourceWorkspaceSvg_(sourceBlock)
     const styleName = sourceBlock.getStyleName()
-    const style = (sourceBlock.workspace as Blockly.WorkspaceSvg)
-      .getRenderer()
-      .getConstants()
-      .getBlockStyle(styleName)
+    const style = sourceWorkspace.getRenderer().getConstants().getBlockStyle(styleName)
     if (sourceBlock.isShadow()) {
       this.originalStyle = styleName
       sourceBlock.setStyle(`${this.originalStyle}_selected`)
     } else if (this.borderRect_) {
       this.borderRect_.setAttribute(
         'fill',
-        'colourQuaternary' in style ? `${style.colourQuaternary}` : style.colourTertiary,
+        'colourQuaternary' in style ? String(style.colourQuaternary) : style.colourTertiary,
       )
     }
   }
 
   dropdownDispose_() {
     super.dropdownDispose_()
-    const sourceBlock = this.getSourceBlock()!
+    const sourceBlock = this.getSourceBlock()
+    if (!sourceBlock) {
+      throw new Error('[scratch_field_variable] Missing source block in dropdownDispose_')
+    }
     if (sourceBlock.isShadow()) {
       sourceBlock.setStyle(this.originalStyle)
     }

--- a/src/flyout_checkbox_icon.ts
+++ b/src/flyout_checkbox_icon.ts
@@ -36,25 +36,29 @@ export class FlyoutCheckboxIcon extends Blockly.icons.Icon implements Blockly.IH
     return this.sourceBlock.workspace.isFlyout
   }
 
-  onLocationChange(blockOrigin: Blockly.utils.Coordinate) {
-    this.checkboxBubble?.updateLocation()
+  onLocationChange(_blockOrigin: Blockly.utils.Coordinate) {
+    this.checkboxBubble.updateLocation()
   }
 
   setChecked(checked: boolean) {
-    this.checkboxBubble?.setChecked(checked)
+    this.checkboxBubble.setChecked(checked)
   }
 
   dispose() {
-    this.checkboxBubble?.dispose()
+    this.checkboxBubble.dispose()
     super.dispose()
   }
 
   // These methods are required by the interfaces, but intentionally have no
   // implementation, largely because this icon has no visual representation.
 
-  async setBubbleVisible(visible: boolean) {}
+  setBubbleVisible(_visible: boolean): Promise<void> {
+    return Promise.resolve()
+  }
 
-  initView(pointerDownListener: (e: PointerEvent) => void) {}
+  initView(_pointerDownListener: (e: PointerEvent) => void) {
+    return
+  }
 
   canBeFocused() {
     return false

--- a/src/flyout_checkbox_icon.ts
+++ b/src/flyout_checkbox_icon.ts
@@ -9,7 +9,7 @@ import { CheckboxBubble } from './checkbox_bubble'
  * Invisible icon that exists solely to host the corresponding checkbox bubble.
  */
 export class FlyoutCheckboxIcon extends Blockly.icons.Icon implements Blockly.IHasBubble {
-  private checkboxBubble!: CheckboxBubble
+  private checkboxBubble?: CheckboxBubble
   private type = new Blockly.icons.IconType('checkbox')
 
   constructor(protected override sourceBlock: Blockly.BlockSvg) {
@@ -37,15 +37,15 @@ export class FlyoutCheckboxIcon extends Blockly.icons.Icon implements Blockly.IH
   }
 
   onLocationChange(_blockOrigin: Blockly.utils.Coordinate) {
-    this.checkboxBubble.updateLocation()
+    this.checkboxBubble?.updateLocation()
   }
 
   setChecked(checked: boolean) {
-    this.checkboxBubble.setChecked(checked)
+    this.checkboxBubble?.setChecked(checked)
   }
 
   dispose() {
-    this.checkboxBubble.dispose()
+    this.checkboxBubble?.dispose()
     super.dispose()
   }
 
@@ -65,7 +65,7 @@ export class FlyoutCheckboxIcon extends Blockly.icons.Icon implements Blockly.IH
   }
 
   getBubble() {
-    return this.checkboxBubble
+    return this.checkboxBubble ?? null
   }
 }
 

--- a/src/glows.ts
+++ b/src/glows.ts
@@ -5,17 +5,29 @@
 import * as Blockly from 'blockly/core'
 import { Colours } from './colours'
 
+function getRequiredMainWorkspaceSvg(): Blockly.WorkspaceSvg {
+  const mainWorkspace = Blockly.getMainWorkspace()
+  if (!(mainWorkspace instanceof Blockly.WorkspaceSvg)) {
+    throw new Error('Expected main workspace to be a WorkspaceSvg')
+  }
+  return mainWorkspace
+}
+
+function getBlockSvgById(workspace: Blockly.WorkspaceSvg, id: string): Blockly.BlockSvg | null {
+  const block = workspace.getBlockById(id)
+  return block instanceof Blockly.BlockSvg ? block : null
+}
+
 /**
  * Glow/unglow a stack in the workspace.
  * @param id ID of block which starts the stack.
  * @param isGlowingStack Whether to glow the stack.
  */
 export function glowStack(id: string, isGlowingStack: boolean) {
-  const block = (Blockly.getMainWorkspace().getBlockById(id) ||
-    (Blockly.getMainWorkspace() as Blockly.WorkspaceSvg)
-      .getFlyout()
-      ?.getWorkspace()
-      ?.getBlockById(id)) as Blockly.BlockSvg
+  const mainWorkspace = getRequiredMainWorkspaceSvg()
+  const flyout = mainWorkspace.getFlyout()
+  const flyoutBlock = flyout ? getBlockSvgById(flyout.getWorkspace(), id) : null
+  const block = getBlockSvgById(mainWorkspace, id) ?? flyoutBlock
   if (!block) {
     throw new Error('Tried to glow block that does not exist.')
   }

--- a/src/glows.ts
+++ b/src/glows.ts
@@ -4,19 +4,7 @@
  */
 import * as Blockly from 'blockly/core'
 import { Colours } from './colours'
-
-function getRequiredMainWorkspaceSvg(): Blockly.WorkspaceSvg {
-  const mainWorkspace = Blockly.getMainWorkspace()
-  if (!(mainWorkspace instanceof Blockly.WorkspaceSvg)) {
-    throw new Error('Expected main workspace to be a WorkspaceSvg')
-  }
-  return mainWorkspace
-}
-
-function getBlockSvgById(workspace: Blockly.WorkspaceSvg, id: string): Blockly.BlockSvg | null {
-  const block = workspace.getBlockById(id)
-  return block instanceof Blockly.BlockSvg ? block : null
-}
+import { getBlockSvgById, getRequiredMainWorkspaceSvg } from './workspace_block_lookup'
 
 /**
  * Glow/unglow a stack in the workspace.

--- a/src/index.ts
+++ b/src/index.ts
@@ -206,5 +206,5 @@ Blockly.comments.CommentView.defaultCommentSize = new Blockly.utils.Size(200, 20
 const originalGetRestoredFocusableNode = Blockly.WorkspaceSvg.prototype.getRestoredFocusableNode
 Blockly.WorkspaceSvg.prototype.getRestoredFocusableNode = function (previousNode) {
   if (!previousNode && !this.isFlyout) return null
-  return originalGetRestoredFocusableNode.bind(this)(previousNode)
+  return originalGetRestoredFocusableNode.call(this, previousNode)
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -159,7 +159,7 @@ export function isContentNodeFocused(): boolean {
   return Blockly.getFocusManager().getFocusedNode() !== null
 }
 
-registerContinuousToolbox()
+;(registerContinuousToolbox as () => void)()
 Blockly.Scrollbar.scrollbarThickness = Blockly.Touch.TOUCH_ENABLED ? 14 : 11
 Blockly.FlyoutButton.TEXT_MARGIN_X = 40
 Blockly.FlyoutButton.TEXT_MARGIN_Y = 10
@@ -169,12 +169,23 @@ Blockly.ContextMenuItems.registerCommentOptions()
 // Blockly hides "Add Comment" for simple reporters because comments can't be
 // read in the default renderer. In Scratch they're shown differently, so
 // remove that restriction by dropping the isFullBlockField check.
-Blockly.ContextMenuRegistry.registry.getItem('blockComment')!.preconditionFn = (scope) => {
-  const block = scope.block
-  if (block && !block.isInFlyout && block.workspace.options.comments && !block.isCollapsed() && block.isEditable()) {
-    return 'enabled'
+const blockCommentMenuItem = Blockly.ContextMenuRegistry.registry.getItem('blockComment')
+if (!blockCommentMenuItem) {
+  console.error('[index] Missing context menu item: blockComment')
+} else {
+  blockCommentMenuItem.preconditionFn = (scope) => {
+    const block = scope.block
+    if (
+      block &&
+      !block.isInFlyout &&
+      block.workspace.options.comments &&
+      !block.isCollapsed() &&
+      block.isEditable()
+    ) {
+      return 'enabled'
+    }
+    return 'hidden'
   }
-  return 'hidden'
 }
 Blockly.ContextMenuRegistry.registry.unregister('blockDelete')
 contextMenuItems.registerDeleteBlock()
@@ -191,8 +202,9 @@ Blockly.comments.CommentView.defaultCommentSize = new Blockly.utils.Size(200, 20
 // to the workspace itself (whose onNodeFocus is a no-op) rather than to a
 // specific block, so deleting a block doesn't reset the scroll position.
 // We may need to re-evaluate this when we explicitly work on keyboard navigation.
+// eslint-disable-next-line @typescript-eslint/unbound-method -- preserve original prototype method for patched wrapper
 const originalGetRestoredFocusableNode = Blockly.WorkspaceSvg.prototype.getRestoredFocusableNode
 Blockly.WorkspaceSvg.prototype.getRestoredFocusableNode = function (previousNode) {
   if (!previousNode && !this.isFlyout) return null
-  return originalGetRestoredFocusableNode.call(this, previousNode)
+  return originalGetRestoredFocusableNode.bind(this)(previousNode)
 }

--- a/src/procedures.ts
+++ b/src/procedures.ts
@@ -33,7 +33,12 @@ function allProcedureMutations(root: Blockly.WorkspaceSvg): Element[] {
   const blocks = root.getAllBlocks()
   return blocks
     .filter((b) => b.type === Constants.PROCEDURES_PROTOTYPE_BLOCK_TYPE)
-    .map((b) => b.mutationToDom!(/* opt_generateShadows */ true))
+    .map((b) => {
+      if (!b.mutationToDom) {
+        throw new Error(`Expected mutationToDom on procedure prototype block ${b.id}`)
+      }
+      return b.mutationToDom(/* opt_generateShadows */ true)
+    })
 }
 
 /**
@@ -44,8 +49,8 @@ function allProcedureMutations(root: Blockly.WorkspaceSvg): Element[] {
  */
 function sortProcedureMutations(mutations: Element[]): Element[] {
   return mutations.slice().sort((a, b) => {
-    const procCodeA = a.getAttribute('proccode')!
-    const procCodeB = b.getAttribute('proccode')!
+    const procCodeA = a.getAttribute('proccode') ?? ''
+    const procCodeB = b.getAttribute('proccode') ?? ''
 
     return scratchBlocksUtils.compareStrings(procCodeA, procCodeB)
   })
@@ -114,23 +119,19 @@ function addCreateButton(workspace: Blockly.WorkspaceSvg, xmlList: Element[]) {
  */
 export function getCallers(
   name: string,
-  workspace: Blockly.WorkspaceSvg,
-  definitionRoot: Blockly.BlockSvg,
+  workspace: Blockly.Workspace,
+  definitionRoot: Pick<Blockly.Block, 'id'>,
   allowRecursive: boolean,
-): Blockly.BlockSvg[] {
+): ProcedureBlock[] {
   return workspace.getTopBlocks().flatMap((block) => {
     if (block.id === definitionRoot.id && !allowRecursive) {
       return []
     }
 
-    return block
-      .getDescendants(false)
-      .filter(
-        (descendant) =>
-          isProcedureBlock(descendant) &&
-          descendant.type === Constants.PROCEDURES_CALL_BLOCK_TYPE &&
-          descendant.getProcCode() === name,
-      )
+    const procedureDescendants = block.getDescendants(false).filter(isProcedureBlock)
+    return procedureDescendants.filter(
+      (descendant) => descendant.type === Constants.PROCEDURES_CALL_BLOCK_TYPE && descendant.getProcCode() === name,
+    )
   })
 }
 
@@ -147,16 +148,22 @@ function mutateCallersAndPrototype(name: string, workspace: Blockly.WorkspaceSvg
     alert('No define block on workspace') // TODO decide what to do about this.
     return
   }
+  if (!isProcedureBlock(prototypeBlock)) {
+    throw new Error(`Expected procedure prototype block for procCode ${name}`)
+  }
 
   const callers = getCallers(name, defineBlock.workspace, defineBlock, true /* allowRecursive */)
   callers.push(prototypeBlock)
   Blockly.Events.setGroup(true)
   callers.forEach((caller) => {
-    const oldMutationDom = caller.mutationToDom!()
-    const oldMutation = oldMutationDom && Blockly.Xml.domToText(oldMutationDom)
-    caller.domToMutation!(mutation)
-    const newMutationDom = caller.mutationToDom!()
-    const newMutation = newMutationDom && Blockly.Xml.domToText(newMutationDom)
+    if (!caller.mutationToDom || !caller.domToMutation) {
+      throw new Error(`Expected mutation APIs on block ${caller.id} (${caller.type})`)
+    }
+    const oldMutationDom = caller.mutationToDom()
+    const oldMutation = Blockly.Xml.domToText(oldMutationDom)
+    caller.domToMutation(mutation)
+    const newMutationDom = caller.mutationToDom()
+    const newMutation = Blockly.Xml.domToText(newMutationDom)
     if (oldMutation !== newMutation) {
       Blockly.Events.fire(
         new (Blockly.Events.get(Blockly.Events.BLOCK_CHANGE))(caller, 'mutation', null, oldMutation, newMutation),
@@ -172,16 +179,31 @@ function mutateCallersAndPrototype(name: string, workspace: Blockly.WorkspaceSvg
  * @param workspace The workspace to search.
  * @returns The procedure definition block, or undefined if not found.
  */
-function getDefineBlock(procCode: string, workspace: Blockly.WorkspaceSvg): Blockly.BlockSvg | undefined {
+function getDefineBlock(procCode: string, workspace: Blockly.Workspace): Blockly.BlockSvg | undefined {
   // Assume that a procedure definition is a top block.
-  return workspace.getTopBlocks(false).find((block) => {
+  for (const block of workspace.getTopBlocks(false)) {
     if (block.type === Constants.PROCEDURES_DEFINITION_BLOCK_TYPE) {
-      const prototypeBlock = block.getInput('custom_block')!.connection!.targetBlock() as Blockly.BlockSvg
-      return isProcedureBlock(prototypeBlock) && prototypeBlock.getProcCode() === procCode
+      const input = block.getInput('custom_block')
+      if (!input?.connection) {
+        throw new Error(`Expected custom_block input connection on block ${block.id}`)
+      }
+      const raw = input.connection.targetBlock()
+      if (!raw) {
+        throw new Error(`Expected custom_block target block on block ${block.id}`)
+      }
+      if (!(raw instanceof Blockly.BlockSvg)) {
+        throw new Error(`Expected custom_block target BlockSvg on block ${block.id}`)
+      }
+      const prototypeBlock = raw
+      if (isProcedureBlock(prototypeBlock) && prototypeBlock.getProcCode() === procCode) {
+        if (!(block instanceof Blockly.BlockSvg)) {
+          throw new Error(`Expected procedure definition BlockSvg for block ${block.id}`)
+        }
+        return block
+      }
     }
-
-    return false
-  })
+  }
+  return undefined
 }
 
 /**
@@ -190,10 +212,21 @@ function getDefineBlock(procCode: string, workspace: Blockly.WorkspaceSvg): Bloc
  * @param workspace The workspace to search.
  * @returns The procedure prototype block, or undefined if not found.
  */
-function getPrototypeBlock(procCode: string, workspace: Blockly.WorkspaceSvg): Blockly.BlockSvg | undefined {
+function getPrototypeBlock(procCode: string, workspace: Blockly.Workspace): Blockly.BlockSvg | undefined {
   const defineBlock = getDefineBlock(procCode, workspace)
   if (defineBlock) {
-    return defineBlock.getInput('custom_block')!.connection!.targetBlock() as Blockly.BlockSvg
+    const input = defineBlock.getInput('custom_block')
+    if (!input?.connection) {
+      throw new Error(`Expected custom_block input connection on block ${defineBlock.id}`)
+    }
+    const target = input.connection.targetBlock()
+    if (!target) {
+      throw new Error(`Expected custom_block target block on block ${defineBlock.id}`)
+    }
+    if (!(target instanceof Blockly.BlockSvg)) {
+      throw new Error(`Expected custom_block target BlockSvg on block ${defineBlock.id}`)
+    }
+    return target
   }
   return undefined
 }
@@ -213,7 +246,9 @@ function newProcedureMutation(): Element {
         warp="false">
       </mutation>
     </xml>`
-  return Blockly.utils.xml.textToDom(mutationText).firstElementChild!
+  const el = Blockly.utils.xml.textToDom(mutationText).firstElementChild
+  if (!el) throw new Error('Failed to parse mutation XML')
+  return el
 }
 
 /**
@@ -221,7 +256,11 @@ function newProcedureMutation(): Element {
  * @param workspace The workspace to create the new procedure on.
  */
 function createProcedureDefCallback(workspace: Blockly.WorkspaceSvg) {
-  ScratchProcedures.externalProcedureDefCallback!(newProcedureMutation(), createProcedureCallbackFactory(workspace))
+  const callback = ScratchProcedures.externalProcedureDefCallback
+  if (!callback) {
+    throw new Error('ScratchProcedures.externalProcedureDefCallback is not set')
+  }
+  callback(newProcedureMutation(), createProcedureCallbackFactory(workspace))
 }
 
 /**
@@ -243,10 +282,13 @@ function createProcedureCallbackFactory(workspace: Blockly.WorkspaceSvg): (mutat
           </statement>
         </block>
       </xml>`
-    const blockDom = Blockly.utils.xml.textToDom(blockText).firstElementChild!
+    const blockDom = Blockly.utils.xml.textToDom(blockText).firstElementChild
+    if (!blockDom) {
+      throw new Error('Failed to parse procedure definition XML')
+    }
     Blockly.Events.setGroup(true)
     const block = Blockly.Xml.domToBlock(blockDom, workspace) as Blockly.BlockSvg
-    Blockly.renderManagement.finishQueuedRenders().then(() => {
+    void Blockly.renderManagement.finishQueuedRenders().then(() => {
       // To convert from pixel units to workspace units
       const scale = workspace.scale
       // Position the block so that it is at the top left of the visible
@@ -293,7 +335,9 @@ function editProcedureCallback(block: Blockly.BlockSvg) {
   } else if (block.type === Constants.PROCEDURES_CALL_BLOCK_TYPE && isProcedureBlock(block)) {
     // This is a call block, find the prototype corresponding to the procCode.
     // Make sure to search the correct workspace, call block can be in flyout.
-    const workspaceToSearch = block.workspace.isFlyout ? block.workspace.targetWorkspace! : block.workspace
+    const workspaceToSearch = block.workspace.isFlyout
+      ? (block.workspace.targetWorkspace ?? block.workspace)
+      : block.workspace
     const foundBlock = getPrototypeBlock(block.getProcCode(), workspaceToSearch)
     if (!foundBlock) {
       console.warn('editProcedureCallback: could not find prototype for', block.getProcCode())
@@ -304,10 +348,14 @@ function editProcedureCallback(block: Blockly.BlockSvg) {
     prototypeBlock = block
   }
   // Block now refers to the procedure prototype block, it is safe to proceed.
-  ScratchProcedures.externalProcedureDefCallback!(
-    prototypeBlock.mutationToDom!(),
-    editProcedureCallbackFactory(prototypeBlock),
-  )
+  const callback = ScratchProcedures.externalProcedureDefCallback
+  if (!callback) {
+    throw new Error('ScratchProcedures.externalProcedureDefCallback is not set')
+  }
+  if (!prototypeBlock.mutationToDom) {
+    throw new Error(`Expected mutationToDom on block ${prototypeBlock.id} (${prototypeBlock.type})`)
+  }
+  callback(prototypeBlock.mutationToDom(), editProcedureCallbackFactory(prototypeBlock))
 }
 
 /**
@@ -349,15 +397,14 @@ function makeEditOption(block: Blockly.BlockSvg): Blockly.ContextMenuRegistry.Co
  *     procedure.
  * @returns True if the custom procedure was deleted, false otherwise.
  */
-function deleteProcedureDefCallback(procCode: string, definitionRoot: Blockly.BlockSvg): boolean {
+function deleteProcedureDefCallback(procCode: string, definitionRoot: Blockly.Block): boolean {
   const callers = getCallers(procCode, definitionRoot.workspace, definitionRoot, false /* allowRecursive */)
   if (callers.length > 0) {
     return false
   }
 
-  const workspace = definitionRoot.workspace
   // Bypass the checkAndDelete provided by the procedure block mixin
-  Blockly.BlockSvg.prototype.checkAndDelete.call(definitionRoot)
+  Blockly.BlockSvg.prototype.checkAndDelete.call(definitionRoot as Blockly.BlockSvg)
   return true
 }
 
@@ -366,7 +413,7 @@ function deleteProcedureDefCallback(procCode: string, definitionRoot: Blockly.Bl
  * @param block The block to check.
  * @returns True if the block is a procedure block, otherwise false.
  */
-export function isProcedureBlock(block: Blockly.BlockSvg): block is ProcedureBlock {
+export function isProcedureBlock(block: Blockly.Block): block is ProcedureBlock {
   return (
     block.type === Constants.PROCEDURES_CALL_BLOCK_TYPE ||
     block.type === Constants.PROCEDURES_DECLARATION_BLOCK_TYPE ||
@@ -378,7 +425,7 @@ export function isProcedureBlock(block: Blockly.BlockSvg): block is ProcedureBlo
  * Interface for procedure blocks, which have the getProcCode method added
  * through an extension.
  */
-interface ProcedureBlock extends Blockly.BlockSvg {
+interface ProcedureBlock extends Blockly.Block {
   getProcCode(): string
 }
 

--- a/src/procedures.ts
+++ b/src/procedures.ts
@@ -49,8 +49,11 @@ function allProcedureMutations(root: Blockly.WorkspaceSvg): Element[] {
  */
 function sortProcedureMutations(mutations: Element[]): Element[] {
   return mutations.slice().sort((a, b) => {
-    const procCodeA = a.getAttribute('proccode') ?? ''
-    const procCodeB = b.getAttribute('proccode') ?? ''
+    const procCodeA = a.getAttribute('proccode')
+    const procCodeB = b.getAttribute('proccode')
+    if (!procCodeA || !procCodeB) {
+      throw new Error('Expected proccode attribute in procedure mutation element')
+    }
 
     return scratchBlocksUtils.compareStrings(procCodeA, procCodeB)
   })

--- a/src/recyclable_block_flyout_inflater.ts
+++ b/src/recyclable_block_flyout_inflater.ts
@@ -13,13 +13,14 @@ export class RecyclableBlockFlyoutInflater extends BlocklyRecyclableBlockFlyoutI
   /**
    * Creates a block on the flyout workspace from the given block definition.
    * @param state A JSON representation of a block to load.
-   * @param flyoutWorkspace The workspace on which the block will be inflated.
+   * @param flyout The flyout on which the block will be inflated.
    * @returns The newly created block.
    */
-  load(state: Blockly.utils.toolbox.BlockInfo, flyoutWorkspace: Blockly.WorkspaceSvg): Blockly.FlyoutItem {
-    const flyoutItem = super.load(state, flyoutWorkspace)
+  load(state: object, flyout: Blockly.IFlyout): Blockly.FlyoutItem {
+    const flyoutItem = super.load(state, flyout)
     const block = flyoutItem.getElement()
-    if ('checkboxInFlyout' in block && block.checkboxInFlyout) {
+    const flyoutWorkspace = flyout.getWorkspace()
+    if (block instanceof Blockly.BlockSvg && 'checkboxInFlyout' in block && block.checkboxInFlyout === true) {
       block.moveBy(
         (flyoutWorkspace.RTL ? -1 : 1) * (CheckboxBubble.CHECKBOX_SIZE + CheckboxBubble.CHECKBOX_MARGIN),
         0,

--- a/src/renderer/cat/cat_face.ts
+++ b/src/renderer/cat/cat_face.ts
@@ -33,7 +33,7 @@ const setVisibility = (element: SVGElement, visible: boolean) => {
  * Owned by the PathObject with similar lifetime.
  */
 export class CatFace {
-  faceGroup_!: SVGElement
+  faceGroup_: SVGElement | null = null
   parts_ = {} as Record<FacePart, SVGElement>
   pathEarState: CatPathState
   constants_: ConstantProvider

--- a/src/renderer/cat/drawer.ts
+++ b/src/renderer/cat/drawer.ts
@@ -53,8 +53,7 @@ export class Drawer extends ClassicDrawer {
     }
     const pathObject = this.block_.pathObject as PathObject
     if (!pathObject.catFace) {
-      console.error('[renderer/cat/drawer] Missing catFace while drawing hat block')
-      return super.makeReplacementTop_()
+      throw new Error('[renderer/cat/drawer] Missing catFace while drawing hat block')
     }
     return this.constants_.makeCatPath(this.info_.width, pathObject.catFace.pathEarState)
   }

--- a/src/renderer/cat/drawer.ts
+++ b/src/renderer/cat/drawer.ts
@@ -52,6 +52,10 @@ export class Drawer extends ClassicDrawer {
       return super.makeReplacementTop_()
     }
     const pathObject = this.block_.pathObject as PathObject
-    return this.constants_.makeCatPath(this.info_.width, pathObject.catFace!.pathEarState)
+    if (!pathObject.catFace) {
+      console.error('[renderer/cat/drawer] Missing catFace while drawing hat block')
+      return super.makeReplacementTop_()
+    }
+    return this.constants_.makeCatPath(this.info_.width, pathObject.catFace.pathEarState)
   }
 }

--- a/src/renderer/constants.ts
+++ b/src/renderer/constants.ts
@@ -27,10 +27,10 @@ export class ConstantProvider extends Blockly.zelos.ConstantProvider {
         root.style.setProperty(varKey, colour)
       } else {
         const style = {
-          colourPrimary: 'colourQuaternary' in colour ? `${colour.colourQuaternary}` : colour.colourTertiary,
-          colourSecondary: 'colourQuaternary' in colour ? `${colour.colourQuaternary}` : colour.colourTertiary,
-          colourTertiary: 'colourQuaternary' in colour ? `${colour.colourQuaternary}` : colour.colourTertiary,
-          colourQuaternary: 'colourQuaternary' in colour ? `${colour.colourQuaternary}` : colour.colourTertiary,
+          colourPrimary: 'colourQuaternary' in colour ? String(colour.colourQuaternary) : colour.colourTertiary,
+          colourSecondary: 'colourQuaternary' in colour ? String(colour.colourQuaternary) : colour.colourTertiary,
+          colourTertiary: 'colourQuaternary' in colour ? String(colour.colourQuaternary) : colour.colourTertiary,
+          colourQuaternary: 'colourQuaternary' in colour ? String(colour.colourQuaternary) : colour.colourTertiary,
           hat: '',
         }
         theme.setBlockStyle(`${key}_selected`, style)
@@ -52,38 +52,43 @@ export class ConstantProvider extends Blockly.zelos.ConstantProvider {
    * @returns The shape object for the given connection.
    */
   override shapeFor(connection: Blockly.RenderedConnection): ReturnType<Blockly.zelos.ConstantProvider['shapeFor']> {
+    const connectionType = connection.type as Blockly.ConnectionType
     let checks = connection.getCheck()
+    const hexagonal = this.HEXAGONAL
+    const rounded = this.ROUNDED
+    const squared = this.SQUARED
+    if (!hexagonal || !rounded || !squared) return super.shapeFor(connection)
     if (!checks && connection.targetConnection) {
       checks = connection.targetConnection.getCheck()
     }
 
-    if (connection.type === Blockly.ConnectionType.OUTPUT_VALUE) {
+    if (connectionType === Blockly.ConnectionType.OUTPUT_VALUE) {
       const outputShape = connection.getSourceBlock().getOutputShape()
       if (outputShape !== null) {
         switch (outputShape) {
           case this.SHAPES.HEXAGONAL:
-            return this.HEXAGONAL!
+            return hexagonal
           case this.SHAPES.ROUND:
-            return this.ROUNDED!
+            return rounded
           case this.SHAPES.SQUARE:
-            return this.SQUARED!
+            return squared
         }
       }
     }
 
     // For INPUT_VALUE (and OUTPUT_VALUE fallthrough), use connection checks.
-    if (checks?.includes('Boolean')) return this.HEXAGONAL!
-    if (checks?.includes('Number')) return this.ROUNDED!
-    if (checks?.includes('String')) return this.ROUNDED!
+    if (checks?.includes('Boolean')) return hexagonal
+    if (checks?.includes('Number')) return rounded
+    if (checks?.includes('String')) return rounded
     // For INPUT_VALUE or OUTPUT_VALUE with unrecognized checks, default to
     // ROUNDED. Don't call super.shapeFor() here: the base implementation
     // uses getSourceBlock().getOutputShape(), which would incorrectly return
     // HEXAGONAL for inputs inside Boolean reporters (e.g. `<a = b>`).
     if (
-      connection.type === Blockly.ConnectionType.INPUT_VALUE ||
-      connection.type === Blockly.ConnectionType.OUTPUT_VALUE
+      connectionType === Blockly.ConnectionType.INPUT_VALUE ||
+      connectionType === Blockly.ConnectionType.OUTPUT_VALUE
     ) {
-      return this.ROUNDED!
+      return rounded
     }
     return super.shapeFor(connection)
   }

--- a/src/renderer/drawer.ts
+++ b/src/renderer/drawer.ts
@@ -64,7 +64,8 @@ export class Drawer extends Blockly.zelos.Drawer {
    */
   override drawConnectionHighlightPath(measurable: Blockly.blockRendering.Connection) {
     const conn = measurable.connectionModel
-    if (conn.type === Blockly.ConnectionType.INPUT_VALUE && measurable.isDynamicShape) {
+    const connectionType = conn.type as Blockly.ConnectionType
+    if (connectionType === Blockly.ConnectionType.INPUT_VALUE && measurable.isDynamicShape) {
       const input = measurable as Blockly.blockRendering.InlineInput
       const EXPAND_X = 0.5
       const EXPAND_Y = 2

--- a/src/renderer/render_info.ts
+++ b/src/renderer/render_info.ts
@@ -39,8 +39,7 @@ export class RenderInfo extends Blockly.zelos.RenderInfo {
       const statementRow = this.rows.find((r) => r.hasStatement)
       const input = statementRow?.elements.find((e) => Blockly.blockRendering.Types.isInput(e))
       if (!statementRow || !input) {
-        console.error('[renderer/render_info] Missing statement row or input for bowler hat block')
-        return
+        throw new Error('[renderer/render_info] Missing statement row or input for bowler hat block')
       }
       this.width = statementRow.widthWithConnectedBlocks - input.width + this.constants_.MEDIUM_PADDING
 
@@ -49,8 +48,7 @@ export class RenderInfo extends Blockly.zelos.RenderInfo {
       // populateTopRow_ always adds a hat element for bowler hat blocks.
       const hat = this.topRow.elements.find((e) => Blockly.blockRendering.Types.isHat(e))
       if (!hat) {
-        console.error('[renderer/render_info] Missing hat measurable for bowler hat block')
-        return
+        throw new Error('[renderer/render_info] Missing hat measurable for bowler hat block')
       }
       hat.width = this.width
       this.topRow.measure()

--- a/src/renderer/render_info.ts
+++ b/src/renderer/render_info.ts
@@ -36,16 +36,22 @@ export class RenderInfo extends Blockly.zelos.RenderInfo {
       // bowler hat block.
       // Bowler hat blocks always have exactly one statement row and one input
       // element, so these find() calls are guaranteed to succeed.
-      const statementRow = this.rows.find((r) => r.hasStatement)!
-      this.width =
-        statementRow.widthWithConnectedBlocks -
-        statementRow.elements.find((e) => Blockly.blockRendering.Types.isInput(e))!.width +
-        this.constants_.MEDIUM_PADDING
+      const statementRow = this.rows.find((r) => r.hasStatement)
+      const input = statementRow?.elements.find((e) => Blockly.blockRendering.Types.isInput(e))
+      if (!statementRow || !input) {
+        console.error('[renderer/render_info] Missing statement row or input for bowler hat block')
+        return
+      }
+      this.width = statementRow.widthWithConnectedBlocks - input.width + this.constants_.MEDIUM_PADDING
 
       // The bowler hat's width is the same as the block's width, so it can't
       // be derived from the constants like a normal hat and has to be set here.
       // populateTopRow_ always adds a hat element for bowler hat blocks.
-      const hat = this.topRow.elements.find((e) => Blockly.blockRendering.Types.isHat(e))!
+      const hat = this.topRow.elements.find((e) => Blockly.blockRendering.Types.isHat(e))
+      if (!hat) {
+        console.error('[renderer/render_info] Missing hat measurable for bowler hat block')
+        return
+      }
       hat.width = this.width
       this.topRow.measure()
     }
@@ -57,7 +63,7 @@ export class RenderInfo extends Blockly.zelos.RenderInfo {
   ): number {
     if (
       this.isBowlerHatBlock() &&
-      ((prev && Blockly.blockRendering.Types.isHat(prev)) || (next && Blockly.blockRendering.Types.isHat(next)))
+      (Blockly.blockRendering.Types.isHat(prev) || Blockly.blockRendering.Types.isHat(next))
     ) {
       // Bowler hat rows have no spacing/gaps, just the hat.
       return 0
@@ -82,8 +88,7 @@ export class RenderInfo extends Blockly.zelos.RenderInfo {
       this.block_.isScratchExtension &&
       Blockly.blockRendering.Types.isField(elem) &&
       elem.field instanceof Blockly.FieldImage &&
-      elem.field === this.block_.inputList[0].fieldRow[0] &&
-      this.block_.previousConnection
+      elem.field === this.block_.inputList[0].fieldRow[0]
     ) {
       // Vertically center the icon on extension blocks.
       return super.getElemCenterline_(row, elem) + this.constants_.GRID_UNIT

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -65,7 +65,7 @@ export class ScratchRenderer extends Blockly.zelos.Renderer {
    * @returns True if we should highlight the connection.
    */
   override shouldHighlightConnection(connection: Blockly.RenderedConnection): boolean {
-    return connection.type === Blockly.ConnectionType.INPUT_VALUE
+    return (connection.type as Blockly.ConnectionType) === Blockly.ConnectionType.INPUT_VALUE
   }
 }
 

--- a/src/scratch_blocks_utils.ts
+++ b/src/scratch_blocks_utils.ts
@@ -20,8 +20,6 @@
  * @file Utility methods for Scratch Blocks but not Blockly.
  * @author fenichel@google.com (Rachel Fenichel)
  */
-import * as Blockly from 'blockly/core'
-
 /**
  * Compare strings with natural number sorting.
  * @param str1 First input.

--- a/src/scratch_c_block_wrap.ts
+++ b/src/scratch_c_block_wrap.ts
@@ -74,27 +74,30 @@ Reflect.set(
   previewerProto,
   'hideInsertionMarker',
   function (this: Blockly.InsertionMarkerPreviewer, markerConn: Blockly.Connection) {
-    const marker = markerConn.getSourceBlock() as Blockly.BlockSvg
+    const marker = markerConn.getSourceBlock()
+    const markerPreviousConnection = marker.previousConnection
+    const markerNextConnection = marker.nextConnection
 
     // Restore a real block from a statement input to nextConnection so that
     // unplug(true) can heal the stack correctly.  Conditions:
     //   - marker is mid-stack (has a predecessor)
     //   - marker.nextConnection is empty (displaced block is NOT already there)
     //   - a non-marker block is sitting in a statement input
-    if (marker.previousConnection.isConnected() && !marker.nextConnection.isConnected()) {
+    if (markerPreviousConnection?.isConnected() && markerNextConnection && !markerNextConnection.isConnected()) {
       for (const input of marker.inputList) {
         const conn = input.connection
-        if (
-          (conn?.type as Blockly.ConnectionType | undefined) !== Blockly.ConnectionType.NEXT_STATEMENT ||
-          !conn?.isConnected()
-        ) {
+        const connType = conn?.type as Blockly.ConnectionType | undefined
+        if (connType !== Blockly.ConnectionType.NEXT_STATEMENT || !conn?.isConnected()) {
           continue
         }
-        const blockInInput = conn.targetBlock() as Blockly.BlockSvg | null
+        const blockInInput = conn.targetBlock()
         if (blockInInput && !blockInInput.isInsertionMarker()) {
           const prev = blockInInput.previousConnection
+          if (!prev) {
+            continue
+          }
           prev.disconnect()
-          marker.nextConnection.connect(prev)
+          markerNextConnection.connect(prev)
           break
         }
       }

--- a/src/scratch_c_block_wrap.ts
+++ b/src/scratch_c_block_wrap.ts
@@ -28,7 +28,7 @@ Blockly.Connection.getConnectionForOrphanedConnection = function (
   // Apply the wrapping logic when the orphaned connection is a statement
   // connection (PREVIOUS_STATEMENT).  Value connections (OUTPUT_VALUE) are
   // already handled by the original implementation.
-  if (orphanConnection.type === Blockly.ConnectionType.PREVIOUS_STATEMENT) {
+  if ((orphanConnection.type as Blockly.ConnectionType) === Blockly.ConnectionType.PREVIOUS_STATEMENT) {
     const checker = orphanConnection.getConnectionChecker()
     for (const input of startBlock.inputList) {
       const conn = input.connection
@@ -61,32 +61,45 @@ Blockly.Connection.getConnectionForOrphanedConnection = function (
  * marker's statement input back to `marker.nextConnection` before the original
  * cleanup runs, so the standard healing logic reconnects B1.next → B2.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- InsertionMarkerPreviewer does not publicly expose hideInsertionMarker
-const proto = Blockly.InsertionMarkerPreviewer.prototype as any
-const originalHideInsertionMarker = proto.hideInsertionMarker as (markerConn: Blockly.Connection) => void
-proto.hideInsertionMarker = function (this: Blockly.InsertionMarkerPreviewer, markerConn: Blockly.Connection) {
-  const marker = markerConn.getSourceBlock() as Blockly.BlockSvg
+const previewerProto = Blockly.InsertionMarkerPreviewer.prototype
+const hideInsertionMarker: unknown = Reflect.get(previewerProto, 'hideInsertionMarker')
+if (typeof hideInsertionMarker !== 'function') {
+  throw new Error('Expected InsertionMarkerPreviewer.hideInsertionMarker to be a function')
+}
+const originalHideInsertionMarker = hideInsertionMarker as (
+  this: Blockly.InsertionMarkerPreviewer,
+  markerConn: Blockly.Connection,
+) => void
+Reflect.set(
+  previewerProto,
+  'hideInsertionMarker',
+  function (this: Blockly.InsertionMarkerPreviewer, markerConn: Blockly.Connection) {
+    const marker = markerConn.getSourceBlock() as Blockly.BlockSvg
 
-  // Restore a real block from a statement input to nextConnection so that
-  // unplug(true) can heal the stack correctly.  Conditions:
-  //   - marker is mid-stack (has a predecessor)
-  //   - marker.nextConnection is empty (displaced block is NOT already there)
-  //   - a non-marker block is sitting in a statement input
-  if (marker.previousConnection?.isConnected() && marker.nextConnection && !marker.nextConnection.isConnected()) {
-    for (const input of marker.inputList) {
-      const conn = input.connection
-      if (conn?.type === Blockly.ConnectionType.NEXT_STATEMENT && conn.isConnected()) {
+    // Restore a real block from a statement input to nextConnection so that
+    // unplug(true) can heal the stack correctly.  Conditions:
+    //   - marker is mid-stack (has a predecessor)
+    //   - marker.nextConnection is empty (displaced block is NOT already there)
+    //   - a non-marker block is sitting in a statement input
+    if (marker.previousConnection.isConnected() && !marker.nextConnection.isConnected()) {
+      for (const input of marker.inputList) {
+        const conn = input.connection
+        if (
+          (conn?.type as Blockly.ConnectionType | undefined) !== Blockly.ConnectionType.NEXT_STATEMENT ||
+          !conn?.isConnected()
+        ) {
+          continue
+        }
         const blockInInput = conn.targetBlock() as Blockly.BlockSvg | null
         if (blockInInput && !blockInInput.isInsertionMarker()) {
           const prev = blockInInput.previousConnection
-          if (!prev) continue
           prev.disconnect()
           marker.nextConnection.connect(prev)
           break
         }
       }
     }
-  }
 
-  originalHideInsertionMarker.call(this, markerConn)
-}
+    originalHideInsertionMarker.call(this, markerConn)
+  },
+)

--- a/src/scratch_comment_bubble.ts
+++ b/src/scratch_comment_bubble.ts
@@ -27,16 +27,16 @@ export class ScratchCommentBubble
     this.getSvgRoot().setAttribute('style', `--colour-commentBorder: ${sourceBlock.getColourTertiary()};`)
     this.getSvgRoot().setAttribute('id', this.id)
 
-    Blockly.browserEvents.conditionalBind(this.getSvgRoot(), 'pointerdown', this, this.startGesture)
+    Blockly.browserEvents.conditionalBind(this.getSvgRoot(), 'pointerdown', this, this.startGesture.bind(this))
     // Don't zoom with mousewheel; let it scroll instead.
     Blockly.browserEvents.conditionalBind(this.getSvgRoot(), 'wheel', this, (e: WheelEvent) => {
       e.stopPropagation()
     })
   }
 
-  setDeleteStyle(enable: boolean) {}
+  setDeleteStyle(_enable: boolean) {}
   showContextMenu() {}
-  setDragging(start: boolean) {}
+  setDragging(_start: boolean) {}
   select() {}
   unselect() {}
 
@@ -51,10 +51,16 @@ export class ScratchCommentBubble
   moveTo(xOrCoordinate: number, y: number): void
   moveTo(xOrCoordinate: Blockly.utils.Coordinate): void
   moveTo(xOrCoordinate: Blockly.utils.Coordinate | number, y?: number) {
-    const destination =
-      xOrCoordinate instanceof Blockly.utils.Coordinate
-        ? xOrCoordinate
-        : new Blockly.utils.Coordinate(xOrCoordinate, y!)
+    let destination: Blockly.utils.Coordinate
+    if (xOrCoordinate instanceof Blockly.utils.Coordinate) {
+      destination = xOrCoordinate
+    } else {
+      if (y === undefined) {
+        console.error('ScratchCommentBubble.moveTo: missing y coordinate')
+        return
+      }
+      destination = new Blockly.utils.Coordinate(xOrCoordinate, y)
+    }
     super.moveTo(destination)
     this.redrawAnchorChain()
   }
@@ -69,14 +75,14 @@ export class ScratchCommentBubble
     }
   }
 
-  startDrag(event: PointerEvent) {
+  startDrag(_event: PointerEvent) {
     this.dragStartLocation = this.getRelativeToSurfaceXY()
     this.workspace.setResizesEnabled(false)
     this.workspace.getLayerManager()?.moveToDragLayer(this)
     Blockly.utils.dom.addClass(this.getSvgRoot(), 'blocklyDragging')
   }
 
-  drag(newLocation: Blockly.utils.Coordinate, event?: PointerEvent) {
+  drag(newLocation: Blockly.utils.Coordinate, _event?: PointerEvent) {
     this.moveTo(newLocation)
   }
 
@@ -90,35 +96,43 @@ export class ScratchCommentBubble
   }
 
   revertDrag() {
-    this.moveTo(this.dragStartLocation!)
+    if (!this.dragStartLocation) {
+      console.warn('ScratchCommentBubble.revertDrag: missing drag start location')
+      return
+    }
+    this.moveTo(this.dragStartLocation)
   }
 
   setAnchorLocation(newAnchor: Blockly.utils.Coordinate) {
     const oldAnchor = this.anchor
-    const alreadyAnchored = !!this.anchor
+    const alreadyAnchored = oldAnchor !== undefined
     this.anchor = newAnchor
     if (!alreadyAnchored) {
       this.dropAnchor()
     } else {
       const oldLocation = this.getRelativeToSurfaceXY()
-      const delta = Blockly.utils.Coordinate.difference(this.anchor, oldAnchor!)
+      const delta = Blockly.utils.Coordinate.difference(this.anchor, oldAnchor)
       const newLocation = Blockly.utils.Coordinate.sum(oldLocation, delta)
       this.moveTo(newLocation)
     }
   }
 
   dropAnchor() {
+    if (!this.anchor || !this.sourceBlock) {
+      console.warn('ScratchCommentBubble.dropAnchor: missing anchor or source block')
+      return
+    }
     const verticalOffset = 16
-    this.moveTo(this.anchor!.x + 40 * (this.workspace.RTL ? -1 : 1), this.anchor!.y - verticalOffset)
+    this.moveTo(this.anchor.x + 40 * (this.workspace.RTL ? -1 : 1), this.anchor.y - verticalOffset)
     const location = this.getRelativeToSurfaceXY()
     this.anchorChain = Blockly.utils.dom.createSvgElement(
       Blockly.utils.Svg.LINE,
       {
-        x1: this.anchor!.x - location.x,
-        y1: this.anchor!.y - location.y,
+        x1: this.anchor.x - location.x,
+        y1: this.anchor.y - location.y,
         x2: (this.getSize().width / 2) * (this.workspace.RTL ? -1 : 1),
         y2: verticalOffset,
-        style: `stroke: ${this.sourceBlock!.getColourTertiary()}; stroke-width: 1`,
+        style: `stroke: ${this.sourceBlock.getColourTertiary()}; stroke-width: 1`,
       },
       this.getSvgRoot(),
     )
@@ -126,11 +140,11 @@ export class ScratchCommentBubble
   }
 
   redrawAnchorChain() {
-    if (!this.anchorChain) return
+    if (!this.anchorChain || !this.anchor) return
 
     const location = this.getRelativeToSurfaceXY()
-    this.anchorChain.setAttribute('x1', `${this.anchor!.x - location.x}`)
-    this.anchorChain.setAttribute('y1', `${this.anchor!.y - location.y}`)
+    this.anchorChain.setAttribute('x1', `${this.anchor.x - location.x}`)
+    this.anchorChain.setAttribute('y1', `${this.anchor.y - location.y}`)
   }
 
   getId() {

--- a/src/scratch_comment_bubble.ts
+++ b/src/scratch_comment_bubble.ts
@@ -56,8 +56,7 @@ export class ScratchCommentBubble
       destination = xOrCoordinate
     } else {
       if (y === undefined) {
-        console.error('ScratchCommentBubble.moveTo: missing y coordinate')
-        return
+        throw new Error('ScratchCommentBubble.moveTo: missing y coordinate')
       }
       destination = new Blockly.utils.Coordinate(xOrCoordinate, y)
     }
@@ -97,8 +96,7 @@ export class ScratchCommentBubble
 
   revertDrag() {
     if (!this.dragStartLocation) {
-      console.warn('ScratchCommentBubble.revertDrag: missing drag start location')
-      return
+      throw new Error('ScratchCommentBubble.revertDrag: missing drag start location')
     }
     this.moveTo(this.dragStartLocation)
   }
@@ -119,8 +117,7 @@ export class ScratchCommentBubble
 
   dropAnchor() {
     if (!this.anchor || !this.sourceBlock) {
-      console.warn('ScratchCommentBubble.dropAnchor: missing anchor or source block')
-      return
+      throw new Error('ScratchCommentBubble.dropAnchor: missing anchor or source block')
     }
     const verticalOffset = 16
     this.moveTo(this.anchor.x + 40 * (this.workspace.RTL ? -1 : 1), this.anchor.y - verticalOffset)

--- a/src/scratch_comment_icon.ts
+++ b/src/scratch_comment_icon.ts
@@ -39,7 +39,7 @@ export class ScratchCommentIcon extends Blockly.icons.Icon implements Blockly.IS
     return Blockly.icons.IconType.COMMENT
   }
 
-  initView(pointerDownListener: (e: PointerEvent) => void) {
+  initView(_pointerDownListener: (e: PointerEvent) => void) {
     // Scratch comments have no indicator icon on the block.
     return
   }
@@ -57,8 +57,6 @@ export class ScratchCommentIcon extends Blockly.icons.Icon implements Blockly.IS
   }
 
   onLocationChange(blockOrigin: Blockly.utils.Coordinate) {
-    if (!this.sourceBlock || !this.commentBubble) return
-
     if (this.sourceBlock.isInsertionMarker()) {
       this.commentBubble.dispose()
       return
@@ -74,11 +72,11 @@ export class ScratchCommentIcon extends Blockly.icons.Icon implements Blockly.IS
   }
 
   setText(text: string) {
-    this.commentBubble?.setText(text)
+    this.commentBubble.setText(text)
   }
 
   getText(): string {
-    return this.commentBubble?.getText() ?? ''
+    return this.commentBubble.getText()
   }
 
   onTextChanged(oldText: string, newText: string) {
@@ -97,26 +95,24 @@ export class ScratchCommentIcon extends Blockly.icons.Icon implements Blockly.IS
   }
 
   setBubbleSize(size: Blockly.utils.Size) {
-    this.commentBubble?.setSize(size)
+    this.commentBubble.setSize(size)
   }
 
   getBubbleSize(): Blockly.utils.Size {
-    return this.commentBubble?.getSize() ?? new Blockly.utils.Size(0, 0)
+    return this.commentBubble.getSize()
   }
 
   setBubbleLocation(newLocation: Blockly.utils.Coordinate) {
     const oldLocation = this.getBubbleLocation()
-    this.commentBubble?.moveTo(newLocation)
+    this.commentBubble.moveTo(newLocation)
     Blockly.Events.fire(new (Blockly.Events.get('block_comment_move'))(this.commentBubble, oldLocation, newLocation))
   }
 
   getBubbleLocation(): Blockly.utils.Coordinate {
-    return this.commentBubble?.getRelativeToSurfaceXY()
+    return this.commentBubble.getRelativeToSurfaceXY()
   }
 
   saveState(): CommentState | null {
-    if (!this.commentBubble) return null
-
     const size = this.getBubbleSize()
     const bubbleLocation = this.commentBubble.getRelativeToSurfaceXY()
     const delta = Blockly.utils.Coordinate.difference(bubbleLocation, this.workspaceLocation)
@@ -145,8 +141,9 @@ export class ScratchCommentIcon extends Blockly.icons.Icon implements Blockly.IS
     return true
   }
 
-  async setBubbleVisible(visible: boolean) {
+  setBubbleVisible(visible: boolean) {
     this.commentBubble.setCollapsed(!visible)
+    return Promise.resolve()
   }
 
   getBubble(): ScratchCommentBubble | null {

--- a/src/scratch_continuous_category.ts
+++ b/src/scratch_continuous_category.ts
@@ -54,7 +54,9 @@ export class ScratchContinuousCategory extends ContinuousCategory {
     } else {
       const icon = super.createIconDom_()
       if (icon instanceof HTMLElement) {
-        icon.style.border = `1px solid ${this.secondaryColour ?? ''}`
+        if (this.secondaryColour) {
+          icon.style.border = `1px solid ${this.secondaryColour}`
+        }
       }
       return icon
     }

--- a/src/scratch_continuous_category.ts
+++ b/src/scratch_continuous_category.ts
@@ -19,6 +19,8 @@ export class ScratchContinuousCategory extends ContinuousCategory {
    * devices.
    */
   private showStatusButton = false
+  private iconURI?: string
+  private secondaryColour?: string
 
   /**
    * Creates a new ScratchContinuousCategory.
@@ -33,21 +35,27 @@ export class ScratchContinuousCategory extends ContinuousCategory {
   ) {
     super(toolboxItemDef, parentToolbox, opt_parent)
     this.showStatusButton = toolboxItemDef.showStatusButton === 'true'
+    const iconURI = 'iconURI' in toolboxItemDef ? toolboxItemDef.iconURI : undefined
+    const secondaryColour = 'secondaryColour' in toolboxItemDef ? toolboxItemDef.secondaryColour : undefined
+    this.iconURI = typeof iconURI === 'string' ? iconURI : undefined
+    this.secondaryColour = typeof secondaryColour === 'string' ? secondaryColour : undefined
   }
 
   /**
    * Creates a DOM element for this category's icon.
    * @returns A DOM element for this category's icon.
    */
-  createIconDom_(): HTMLElement {
-    if (this.toolboxItemDef_.iconURI) {
+  createIconDom_(): Element {
+    if (this.iconURI) {
       const icon = document.createElement('img')
-      icon.src = this.toolboxItemDef_.iconURI
+      icon.src = this.iconURI
       icon.className = 'categoryIconBubble'
       return icon
     } else {
       const icon = super.createIconDom_()
-      icon.style.border = `1px solid ${this.toolboxItemDef_.secondaryColour}`
+      if (icon instanceof HTMLElement) {
+        icon.style.border = `1px solid ${this.secondaryColour ?? ''}`
+      }
       return icon
     }
   }
@@ -59,7 +67,9 @@ export class ScratchContinuousCategory extends ContinuousCategory {
   setSelected(isSelected: boolean) {
     super.setSelected(isSelected)
     // Prevent hardcoding the background color to grey.
-    this.rowDiv_.style.backgroundColor = ''
+    if (this.rowDiv_) {
+      this.rowDiv_.style.backgroundColor = ''
+    }
   }
 
   /**
@@ -74,10 +84,7 @@ export class ScratchContinuousCategory extends ContinuousCategory {
 
 /** Registers this toolbox category and unregisters the default one. */
 export function registerScratchContinuousCategory() {
-  Blockly.registry.unregister(Blockly.registry.Type.TOOLBOX_ITEM, ScratchContinuousCategory.registrationName)
-  Blockly.registry.register(
-    Blockly.registry.Type.TOOLBOX_ITEM,
-    ScratchContinuousCategory.registrationName,
-    ScratchContinuousCategory,
-  )
+  const registrationName = ScratchContinuousCategory.registrationName
+  Blockly.registry.unregister(Blockly.registry.Type.TOOLBOX_ITEM, registrationName)
+  Blockly.registry.register(Blockly.registry.Type.TOOLBOX_ITEM, registrationName, ScratchContinuousCategory)
 }

--- a/src/scratch_continuous_toolbox.ts
+++ b/src/scratch_continuous_toolbox.ts
@@ -16,6 +16,10 @@ export class ScratchContinuousToolbox extends ContinuousToolbox {
    */
   private postRenderCallbacks: (() => void)[] = []
 
+  private getInitialFlyoutContents_(): Blockly.utils.toolbox.FlyoutItemInfoArray {
+    return this.getToolboxItems().flatMap((item) => this.convertToolboxItemToFlyoutItems(item))
+  }
+
   refreshSelection() {
     // Intentionally a no-op, Scratch manually manages refreshing the toolbox
     // via forceRerender().
@@ -45,9 +49,14 @@ export class ScratchContinuousToolbox extends ContinuousToolbox {
    * Forcibly rerenders the toolbox, preserving selection when possible.
    */
   forceRerender() {
-    const selectedCategoryName = this.selectedItem_?.getName()
-    this.getFlyout().show(this.getInitialFlyoutContents())
-    this.selectCategoryByName(selectedCategoryName)
+    const selectedCategoryName = this.getSelectedItem()?.getName()
+    if (selectedCategoryName === '') {
+      throw new Error('Expected selected category name to be non-empty')
+    }
+    this.getFlyout().show(this.getInitialFlyoutContents_())
+    if (selectedCategoryName) {
+      this.selectCategoryByName(selectedCategoryName)
+    }
     let callback
     while ((callback = this.postRenderCallbacks.shift())) {
       callback()

--- a/src/scratch_dragger.ts
+++ b/src/scratch_dragger.ts
@@ -93,7 +93,7 @@ export class ScratchDragger extends Blockly.dragging.Dragger {
       dragRoot.type === 'procedures_definition' &&
       this.wouldDeleteDraggable(event, dragRoot.getRootBlock())
     ) {
-      const prototype = dragRoot.getInput('custom_block')!.connection!.targetBlock()
+      const prototype = dragRoot.getInput('custom_block')?.connection?.targetBlock()
       const hasCaller =
         prototype instanceof Blockly.BlockSvg &&
         isProcedureBlock(prototype) &&
@@ -118,7 +118,7 @@ export class ScratchDragger extends Blockly.dragging.Dragger {
       // on the workspace in order to depict the block mid-drag needs to be
       // deleted.
       if (this.originatedFromFlyout && this.draggedOutOfBounds) {
-        Blockly.renderManagement.finishQueuedRenders().then(() => {
+        void Blockly.renderManagement.finishQueuedRenders().then(() => {
           const rootBlock = this.getDragRoot(this.draggable)
           if (rootBlock instanceof Blockly.BlockSvg) {
             rootBlock.dispose()

--- a/src/scratch_variable_map.ts
+++ b/src/scratch_variable_map.ts
@@ -12,7 +12,7 @@ class ScratchVariableMap extends Blockly.VariableMap {
     // Variable names in Blockly are case-insensitive, but case sensitive in
     // Scratch. Override the implementation to only return a variable whose name
     // is identical to the one requested.
-    const variables = this.getVariablesOfType(type ?? '')
+    const variables = this.getVariablesOfType(type)
     if (!variables.length) return null
     return variables.find((v) => v.getName() === name) ?? null
   }

--- a/src/status_indicator_label.ts
+++ b/src/status_indicator_label.ts
@@ -60,7 +60,10 @@ export class StatusIndicatorLabel extends Blockly.FlyoutButton {
     json: Blockly.utils.toolbox.LabelInfo,
   ) {
     super(workspace, targetWorkspace, json, true)
-    this.extensionId = json.id ?? ''
+    if (!json.id) {
+      throw new Error('StatusIndicatorLabel: missing required extension id in toolbox JSON')
+    }
+    this.extensionId = json.id
 
     const heightDelta = 40 - this.height
     this.height = 40

--- a/src/status_indicator_label.ts
+++ b/src/status_indicator_label.ts
@@ -46,7 +46,7 @@ export class StatusIndicatorLabel extends Blockly.FlyoutButton {
   /**
    * Function to be invoked when the status indicator is clicked.
    */
-  static statusButtonCallback: (extensionId: string) => void
+  static statusButtonCallback: ((extensionId: string) => void) | null = null
 
   /**
    * Creates a new StatusIndicatorLabel.
@@ -60,11 +60,14 @@ export class StatusIndicatorLabel extends Blockly.FlyoutButton {
     json: Blockly.utils.toolbox.LabelInfo,
   ) {
     super(workspace, targetWorkspace, json, true)
-    this.extensionId = json.id!
+    this.extensionId = json.id ?? ''
 
     const heightDelta = 40 - this.height
     this.height = 40
-    const text = this.getSvgRoot().querySelector('text')!
+    const text = this.getSvgRoot().querySelector('text')
+    if (!text) {
+      throw new Error('StatusIndicatorLabel: missing flyout text element')
+    }
     const previousY = Number(text.getAttribute('y'))
 
     text.setAttribute('y', `${previousY + heightDelta / 2}`)
@@ -73,7 +76,7 @@ export class StatusIndicatorLabel extends Blockly.FlyoutButton {
     const marginX = 20
     const marginY = 5
     const touchPadding = 16
-    const flyoutWidth = targetWorkspace.getFlyout()!.getWidth()
+    const flyoutWidth = targetWorkspace.getFlyout()?.getWidth() ?? 0
 
     const statusButtonX = workspace.RTL
       ? marginX - flyoutWidth + statusButtonWidth
@@ -129,17 +132,15 @@ export class StatusIndicatorLabel extends Blockly.FlyoutButton {
    * @package
    */
   setImageSrc(src: string) {
-    if (this.imageElement) {
-      this.imageElement.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href', src)
-    }
+    this.imageElement.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href', src)
   }
 
   /**
    * Gets the extension state. Overridden externally.
-   * @param extensionId A string identifying which extension's state to retrieve.
+   * @param _extensionId A string identifying which extension's state to retrieve.
    * @returns Whether the extension is ready to be used.
    */
-  getExtensionState(extensionId: string): StatusButtonState {
+  getExtensionState(_extensionId: string): StatusButtonState {
     return StatusButtonState.NOT_READY
   }
 

--- a/src/status_indicator_label_flyout_inflater.ts
+++ b/src/status_indicator_label_flyout_inflater.ts
@@ -18,7 +18,8 @@ class StatusIndicatorLabelFlyoutInflater extends Blockly.LabelFlyoutInflater {
    * @returns The newly created status indicator label.
    */
   load(state: Blockly.utils.toolbox.LabelInfo, flyout: Blockly.IFlyout): Blockly.FlyoutItem {
-    const label = new StatusIndicatorLabel(flyout.getWorkspace(), flyout.targetWorkspace!, state)
+    const targetWorkspace = flyout.targetWorkspace ?? flyout.getWorkspace()
+    const label = new StatusIndicatorLabel(flyout.getWorkspace(), targetWorkspace, state)
     label.show()
     return new Blockly.FlyoutItem(label, STATUS_INDICATOR_LABEL_TYPE)
   }

--- a/src/variables.ts
+++ b/src/variables.ts
@@ -84,23 +84,27 @@ export function createVariable(
     // opt_type -- turns a falsey opt_type into ''
     // TODO (#1251) Warn developers that they didn't provide an opt_type/
     // provided a falsey opt_type
-    opt_type = opt_type ? opt_type : ''
+    opt_type = opt_type ?? ''
     newMsg = Blockly.Msg.NEW_VARIABLE_TITLE
     modalTitle = Blockly.Msg.VARIABLE_MODAL_TITLE
   }
   const validate = nameValidator.bind(null, opt_type)
+  if (!prompt) {
+    console.warn('createVariable: prompt handler is not set')
+    return
+  }
 
   // Prompt the user to enter a name for the variable
-  prompt!(
+  prompt(
     newMsg,
     '',
-    (text: string, additionalVars: string[], variableOptions?: { scope?: string; isCloud?: boolean }) => {
-      variableOptions = variableOptions || {}
+    (text: string, additionalVars?: string[], variableOptions?: { scope?: string; isCloud?: boolean }) => {
+      variableOptions = variableOptions ?? {}
       const scope = variableOptions.scope
-      const isLocal = scope === 'local' || false
-      const isCloud = variableOptions.isCloud || false
+      const isLocal = scope === 'local'
+      const isCloud = variableOptions.isCloud ?? false
       // Default to [] if additionalVars is not provided
-      additionalVars = additionalVars || []
+      additionalVars = additionalVars ?? []
       // Only use additionalVars for global variable creation.
       const additionalVarNames = isLocal ? [] : additionalVars
 
@@ -159,7 +163,7 @@ export function createVariable(
 function nameValidator(
   type: string,
   text: string,
-  workspace: Blockly.WorkspaceSvg,
+  workspace: Blockly.Workspace,
   additionalVars: string[],
   isCloud: boolean,
   opt_callback?: (id?: string) => void,
@@ -200,7 +204,7 @@ function nameValidator(
  */
 function validateBroadcastMessageName(
   name: string,
-  workspace: Blockly.WorkspaceSvg,
+  workspace: Blockly.Workspace,
   opt_callback?: (id?: string) => void,
 ): string | null {
   if (!name) {
@@ -242,7 +246,7 @@ function validateBroadcastMessageName(
  */
 function validateScalarVarOrListName(
   name: string,
-  workspace: Blockly.WorkspaceSvg,
+  workspace: Blockly.Workspace,
   additionalVars: string[],
   isCloud: boolean,
   type: string,
@@ -275,7 +279,7 @@ function validateScalarVarOrListName(
  *     an existing variable was chosen.
  */
 export function renameVariable(
-  workspace: Blockly.WorkspaceSvg,
+  workspace: Blockly.Workspace,
   variable: ScratchVariableModel,
   opt_callback?: (id?: string) => void,
 ) {
@@ -305,15 +309,20 @@ export function renameVariable(
     promptDefaultText = promptDefaultText.substring(CLOUD_PREFIX.length)
   }
 
-  prompt!(
+  if (!prompt) {
+    console.warn('renameVariable: prompt handler is not set')
+    return
+  }
+
+  prompt(
     promptText,
     promptDefaultText,
-    (newName: string, additionalVars: string[]) => {
+    (newName: string, additionalVars?: string[]) => {
       if (variable.isCloud && newName.length > 0 && newName.startsWith(CLOUD_PREFIX)) {
         newName = newName.substring(CLOUD_PREFIX.length)
         // The name validator will add the prefix back
       }
-      additionalVars = additionalVars || []
+      additionalVars = additionalVars ?? []
       const additionalVarNames = variable.isLocal ? [] : additionalVars
       const validatedText = validate(newName, workspace, additionalVarNames, variable.isCloud)
       if (validatedText) {

--- a/src/variables.ts
+++ b/src/variables.ts
@@ -90,8 +90,7 @@ export function createVariable(
   }
   const validate = nameValidator.bind(null, opt_type)
   if (!prompt) {
-    console.warn('createVariable: prompt handler is not set')
-    return
+    throw new Error('createVariable: prompt handler is not set')
   }
 
   // Prompt the user to enter a name for the variable
@@ -310,8 +309,7 @@ export function renameVariable(
   }
 
   if (!prompt) {
-    console.warn('renameVariable: prompt handler is not set')
-    return
+    throw new Error('renameVariable: prompt handler is not set')
   }
 
   prompt(

--- a/src/workspace_block_lookup.ts
+++ b/src/workspace_block_lookup.ts
@@ -1,0 +1,14 @@
+import * as Blockly from 'blockly/core'
+
+export function getRequiredMainWorkspaceSvg(): Blockly.WorkspaceSvg {
+  const mainWorkspace = Blockly.getMainWorkspace()
+  if (!(mainWorkspace instanceof Blockly.WorkspaceSvg)) {
+    throw new Error('Expected main workspace to be a WorkspaceSvg')
+  }
+  return mainWorkspace
+}
+
+export function getBlockSvgById(workspace: Blockly.WorkspaceSvg, id: string): Blockly.BlockSvg | null {
+  const block = workspace.getBlockById(id)
+  return block instanceof Blockly.BlockSvg ? block : null
+}

--- a/src/xml.ts
+++ b/src/xml.ts
@@ -22,7 +22,7 @@ export function clearWorkspaceAndLoadFromXml(xml: Element, workspace: Blockly.Wo
     const id = variable.getAttribute('id')
     if (!id) continue
     const type = variable.getAttribute('type') ?? ''
-    const name = variable.textContent ?? ''
+    const name = variable.textContent
     const isLocal = variable.getAttribute('islocal') === 'true'
     const isCloud = variable.getAttribute('iscloud') === 'true'
 

--- a/types/continuous-toolbox.d.ts
+++ b/types/continuous-toolbox.d.ts
@@ -1,1 +1,0 @@
-declare module '@blockly/continuous-toolbox'


### PR DESCRIPTION
### Proposed Changes

Remove lint exemptions for TS files in `src/`, as well as the placeholder `types/continuous-toolbox.d.ts`, then fix issues exposed by the new, stricter lint rules and more detailed types.

### Reason for Changes

I intended those exemptions to be temporary from the beginning, and I decided now is the time. The `types/continuous-toolbox.d.ts` stub was a useful stopgap when that plugin didn't export types, but it now has real types, so the stub was actually in the way of proper type checking. Removing that stub, combined with making the lint rules more strict, exposed quite a few places where types needed to be narrowed or widened to ensure correctness. I tried to make sure that runtime behavior is identical before and after this change, with the exception that some cases throw more descriptive errors now when they used to throw more generic errors. I've also updated the agent instructions to reflect these changes.

### Test Coverage

Tests updated accordingly