### PR TITLE
Fix issues and risks introduced by recent lint-driven type changes

### DIFF
--- a/src/renderer/render_info.ts
+++ b/src/renderer/render_info.ts
@@ -56,12 +56,12 @@ export class RenderInfo extends Blockly.zelos.RenderInfo {
   }
 
   override getInRowSpacing_(
-    prev: Blockly.blockRendering.Measurable,
-    next: Blockly.blockRendering.Measurable,
+    prev: Blockly.blockRendering.Measurable | null,
+    next: Blockly.blockRendering.Measurable | null,
   ): number {
     if (
       this.isBowlerHatBlock() &&
-      (Blockly.blockRendering.Types.isHat(prev) || Blockly.blockRendering.Types.isHat(next))
+      ((prev && Blockly.blockRendering.Types.isHat(prev)) || (next && Blockly.blockRendering.Types.isHat(next)))
     ) {
       // Bowler hat rows have no spacing/gaps, just the hat.
       return 0

--- a/src/renderer/render_info.ts
+++ b/src/renderer/render_info.ts
@@ -6,6 +6,13 @@ import * as Blockly from 'blockly/core'
 import { BowlerHat } from './bowler_hat'
 import { ConstantProvider } from './constants'
 
+// Blockly's BlockSvg types previousConnection as non-null, but blocks without a
+// previous connector (hat blocks) have it as null at runtime. This type corrects
+// that so null checks are recognized by the type system instead of suppressed.
+type BlockSvgWithNullableConnections = Omit<Blockly.BlockSvg, 'previousConnection'> & {
+  previousConnection: Blockly.RenderedConnection | null
+}
+
 export class RenderInfo extends Blockly.zelos.RenderInfo {
   declare constants_: ConstantProvider
 
@@ -86,7 +93,10 @@ export class RenderInfo extends Blockly.zelos.RenderInfo {
       this.block_.isScratchExtension &&
       Blockly.blockRendering.Types.isField(elem) &&
       elem.field instanceof Blockly.FieldImage &&
-      elem.field === this.block_.inputList[0].fieldRow[0]
+      elem.field === this.block_.inputList[0].fieldRow[0] &&
+      // Hat-style extension blocks have no previousConnection and use their
+      // own centering; only offset stack-style extensions.
+      (this.block_ as BlockSvgWithNullableConnections).previousConnection
     ) {
       // Vertically center the icon on extension blocks.
       return super.getElemCenterline_(row, elem) + this.constants_.GRID_UNIT

--- a/tests/browser/bowler_hat_rendering.test.ts
+++ b/tests/browser/bowler_hat_rendering.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Copyright 2026 Scratch Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+// Regression tests for the null-argument crash in RenderInfo.getInRowSpacing_
+// when rendering a bowler-hat (procedures_definition) block with the scratch
+// renderer.
+//
+// Blockly's addElemSpacing_ iterates over row elements and calls
+//   getInRowSpacing_(prev, elem)
+// where `prev` is null for the very first element of each row.  The override
+// in RenderInfo called Types.isHat(null) without guarding for null, which
+// threw "Cannot read properties of null (reading 'type')".
+import * as Blockly from 'blockly/core'
+import { afterAll, afterEach, assert, beforeAll, describe, expect, it } from 'vitest'
+import { ScratchMsgs } from '../../msg/scratch_msgs'
+import '../../src/blocks/procedures'
+import '../../src/blocks/vertical_extensions'
+// Registering the scratch renderer is the key difference from the other
+// browser/procedures.test.ts — that test uses the default renderer and never
+// exercises our RenderInfo override.
+import '../../src/renderer/renderer'
+
+let container: HTMLElement
+let workspace: Blockly.WorkspaceSvg
+
+beforeAll(() => {
+  ScratchMsgs.setLocale('en')
+  container = document.createElement('div')
+  container.style.width = '800px'
+  container.style.height = '600px'
+  document.body.appendChild(container)
+  // Inject once: ConstantProvider.setTheme mutates the shared Blockly default
+  // theme (adding _selected variants), so re-injecting in each test causes
+  // "Invalid colour" failures on the second and later calls.
+  workspace = Blockly.inject(container, { renderer: 'scratch_classic' })
+})
+
+afterAll(() => {
+  workspace.dispose()
+  container.remove()
+})
+
+afterEach(() => {
+  workspace.clear()
+})
+
+function loadXml(xml: string): void {
+  Blockly.Xml.domToWorkspace(Blockly.utils.xml.textToDom(xml), workspace)
+}
+
+describe('bowler hat block rendering — scratch renderer', () => {
+  it('renders a no-argument procedures_definition without throwing', () => {
+    // Before the fix this threw:
+    // TypeError: Cannot read properties of null (reading 'type')
+    //   at TypesContainer.isHat
+    //   at RenderInfo.getInRowSpacing_
+    expect(() =>
+      loadXml(`
+        <xml>
+          <block type="procedures_definition">
+            <statement name="custom_block">
+              <block type="procedures_prototype">
+                <mutation
+                  proccode="test block"
+                  argumentids='[]'
+                  argumentnames='[]'
+                  argumentdefaults='[]'
+                  warp="false">
+                </mutation>
+              </block>
+            </statement>
+          </block>
+        </xml>
+      `),
+    ).not.toThrow()
+  })
+
+  it('renders a one-argument procedures_definition without throwing', () => {
+    expect(() =>
+      loadXml(`
+        <xml>
+          <block type="procedures_definition">
+            <statement name="custom_block">
+              <block type="procedures_prototype">
+                <mutation
+                  proccode="test %s"
+                  argumentids='["arg1"]'
+                  argumentnames='["x"]'
+                  argumentdefaults='[""]'
+                  warp="false">
+                </mutation>
+                <value name="arg1">
+                  <block type="argument_reporter_string_number">
+                    <field name="VALUE">x</field>
+                  </block>
+                </value>
+              </block>
+            </statement>
+          </block>
+        </xml>
+      `),
+    ).not.toThrow()
+  })
+
+  it('procedures_definition block has positive dimensions after rendering', () => {
+    loadXml(`
+      <xml>
+        <block type="procedures_definition">
+          <statement name="custom_block">
+            <block type="procedures_prototype">
+              <mutation
+                proccode="my block"
+                argumentids='[]'
+                argumentnames='[]'
+                argumentdefaults='[]'
+                warp="false">
+              </mutation>
+            </block>
+          </statement>
+        </block>
+      </xml>
+    `)
+
+    const allBlocks = workspace.getAllBlocks(false)
+    const defBlock = allBlocks.find((b) => b.type === 'procedures_definition')
+    assert(defBlock, 'Expected procedures_definition block')
+    // If rendering succeeds the block must have real, positive dimensions.
+    expect(defBlock.width).toBeGreaterThan(0)
+    expect(defBlock.height).toBeGreaterThan(0)
+  })
+})

--- a/tests/browser/c_block_wrap.test.ts
+++ b/tests/browser/c_block_wrap.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Copyright 2026 Scratch Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Browser-level regression tests for C-block wrapping (issue #3494).
+//
+// When a C-block (e.g. "repeat") is dropped onto a block in the middle of an
+// existing stack, the displaced block(s) should be placed *inside* the C-block's
+// statement input (wrap behavior), not after the C-block's next connection.
+//
+// These tests use rendered BlockSvg blocks (via Blockly.inject) to exercise the
+// full connection path, including the connection checker and drag checks, not
+// just the patched getConnectionForOrphanedConnection in isolation.
+
+import * as Blockly from 'blockly/core'
+import { afterAll, afterEach, assert, beforeAll, describe, expect, it } from 'vitest'
+import { ScratchMsgs } from '../../msg/scratch_msgs'
+import '../../src/blocks/vertical_extensions'
+import '../../src/scratch_c_block_wrap'
+import '../../src/scratch_connection_checker'
+
+const BLOCK_TYPES = ['test_c_block', 'test_stack_a', 'test_stack_b', 'test_stack_c']
+
+let container: HTMLElement
+let workspace: Blockly.WorkspaceSvg
+
+beforeAll(() => {
+  ScratchMsgs.setLocale('en')
+  container = document.createElement('div')
+  container.style.width = '800px'
+  container.style.height = '600px'
+  document.body.appendChild(container)
+  workspace = Blockly.inject(container, {})
+
+  Blockly.defineBlocksWithJsonArray([
+    {
+      type: 'test_c_block',
+      message0: 'repeat %1',
+      args0: [{ type: 'input_statement', name: 'SUBSTACK' }],
+      previousStatement: null,
+      nextStatement: null,
+    },
+    {
+      type: 'test_stack_a',
+      message0: 'block A',
+      previousStatement: null,
+      nextStatement: null,
+    },
+    {
+      type: 'test_stack_b',
+      message0: 'block B',
+      previousStatement: null,
+      nextStatement: null,
+    },
+    {
+      type: 'test_stack_c',
+      message0: 'block C',
+      previousStatement: null,
+      nextStatement: null,
+    },
+  ])
+})
+
+afterAll(() => {
+  for (const type of BLOCK_TYPES) {
+    delete Blockly.Blocks[type]
+  }
+  workspace.dispose()
+  container.remove()
+})
+
+afterEach(() => {
+  workspace.clear()
+})
+
+describe('C-block wrapping in rendered workspace — issue #3494', () => {
+  it('getConnectionForOrphanedConnection sends displaced block to statement input', () => {
+    const cBlock = workspace.newBlock('test_c_block')
+    const blockB = workspace.newBlock('test_stack_b')
+
+    assert(blockB.previousConnection, 'blockB should have previousConnection')
+
+    const result = Blockly.Connection.getConnectionForOrphanedConnection(cBlock, blockB.previousConnection)
+
+    const substackConn = cBlock.getInput('SUBSTACK')?.connection
+    assert(substackConn, 'cBlock should have a SUBSTACK connection')
+
+    expect(result).toBe(substackConn)
+  })
+
+  it('connecting C-block mid-stack wraps displaced blocks into statement input', () => {
+    // Build stack: A → B → C
+    const blockA = workspace.newBlock('test_stack_a')
+    const blockB = workspace.newBlock('test_stack_b')
+    const blockC = workspace.newBlock('test_stack_c')
+
+    assert(blockA.nextConnection, 'blockA should have nextConnection')
+    assert(blockB.previousConnection, 'blockB should have previousConnection')
+    assert(blockB.nextConnection, 'blockB should have nextConnection')
+    assert(blockC.previousConnection, 'blockC should have previousConnection')
+
+    blockA.nextConnection.connect(blockB.previousConnection)
+    blockB.nextConnection.connect(blockC.previousConnection)
+
+    // Verify initial stack: A → B → C
+    expect(blockA.nextConnection.targetBlock()).toBe(blockB)
+    expect(blockB.nextConnection.targetBlock()).toBe(blockC)
+
+    // Now connect C-block's previous to blockA's next, displacing blockB.
+    // This simulates dropping a C-block onto blockB in the middle of the stack.
+    const cBlock = workspace.newBlock('test_c_block')
+    assert(cBlock.previousConnection, 'cBlock should have previousConnection')
+
+    blockA.nextConnection.connect(cBlock.previousConnection)
+
+    // After the connect, the stack should be: A → C-block
+    expect(blockA.nextConnection.targetBlock()).toBe(cBlock)
+
+    // The displaced blockB (and its successor blockC) should have been placed
+    // inside the C-block's statement input, not after the C-block's next connection.
+    const substackConn = cBlock.getInput('SUBSTACK')?.connection
+    assert(substackConn, 'cBlock should have a SUBSTACK connection')
+
+    expect(substackConn.targetBlock()).toBe(blockB)
+    // blockC should still be connected after blockB
+    assert(blockB.nextConnection, 'blockB should have nextConnection')
+    expect(blockB.nextConnection.targetBlock()).toBe(blockC)
+  })
+
+  it('C-block next connection is empty after wrapping (displaced block is not after C-block)', () => {
+    // Build stack: A → B
+    const blockA = workspace.newBlock('test_stack_a')
+    const blockB = workspace.newBlock('test_stack_b')
+
+    assert(blockA.nextConnection, 'blockA should have nextConnection')
+    assert(blockB.previousConnection, 'blockB should have previousConnection')
+
+    blockA.nextConnection.connect(blockB.previousConnection)
+
+    // Drop C-block mid-stack, displacing blockB
+    const cBlock = workspace.newBlock('test_c_block')
+    assert(cBlock.previousConnection, 'cBlock should have previousConnection')
+
+    blockA.nextConnection.connect(cBlock.previousConnection)
+
+    // blockB should NOT be after the C-block's next connection
+    // (that would be the old, incorrect Blockly default behavior)
+    assert(cBlock.nextConnection, 'cBlock should have nextConnection')
+    expect(cBlock.nextConnection.targetBlock()).toBeNull()
+
+    // blockB should be inside the C-block's SUBSTACK
+    const substackConn = cBlock.getInput('SUBSTACK')?.connection
+    assert(substackConn, 'cBlock should have a SUBSTACK connection')
+    expect(substackConn.targetBlock()).toBe(blockB)
+  })
+
+  it('wrapping works with insertion markers (drag preview matches drop result)', () => {
+    // Build stack: A → B
+    const blockA = workspace.newBlock('test_stack_a')
+    const blockB = workspace.newBlock('test_stack_b')
+
+    assert(blockA.nextConnection, 'blockA should have nextConnection')
+    assert(blockB.previousConnection, 'blockB should have previousConnection')
+
+    blockA.nextConnection.connect(blockB.previousConnection)
+
+    // Create a C-block insertion marker (simulating drag preview)
+    const markerBlock = workspace.newBlock('test_c_block')
+    markerBlock.setInsertionMarker(true)
+
+    // The orphan routing should work the same way for markers as for real blocks
+    const result = Blockly.Connection.getConnectionForOrphanedConnection(
+      markerBlock,
+      blockB.previousConnection,
+    )
+
+    const substackConn = markerBlock.getInput('SUBSTACK')?.connection
+    assert(substackConn, 'markerBlock should have a SUBSTACK connection')
+
+    expect(result).toBe(substackConn)
+  })
+})

--- a/tests/browser/c_block_wrap.test.ts
+++ b/tests/browser/c_block_wrap.test.ts
@@ -2,7 +2,6 @@
  * Copyright 2026 Scratch Foundation
  * SPDX-License-Identifier: Apache-2.0
  */
-
 // Browser-level regression tests for C-block wrapping (issue #3494).
 //
 // When a C-block (e.g. "repeat") is dropped onto a block in the middle of an
@@ -12,7 +11,6 @@
 // These tests use rendered BlockSvg blocks (via Blockly.inject) to exercise the
 // full connection path, including the connection checker and drag checks, not
 // just the patched getConnectionForOrphanedConnection in isolation.
-
 import * as Blockly from 'blockly/core'
 import { afterAll, afterEach, assert, beforeAll, describe, expect, it } from 'vitest'
 import { ScratchMsgs } from '../../msg/scratch_msgs'
@@ -170,10 +168,7 @@ describe('C-block wrapping in rendered workspace — issue #3494', () => {
     markerBlock.setInsertionMarker(true)
 
     // The orphan routing should work the same way for markers as for real blocks
-    const result = Blockly.Connection.getConnectionForOrphanedConnection(
-      markerBlock,
-      blockB.previousConnection,
-    )
+    const result = Blockly.Connection.getConnectionForOrphanedConnection(markerBlock, blockB.previousConnection)
 
     const substackConn = markerBlock.getInput('SUBSTACK')?.connection
     assert(substackConn, 'markerBlock should have a SUBSTACK connection')

--- a/tests/browser/extension_icon_centering.test.ts
+++ b/tests/browser/extension_icon_centering.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Copyright 2026 Scratch Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+// Regression test for an accidentally-removed `previousConnection` guard in
+// RenderInfo.getElemCenterline_.
+//
+// Extension blocks render a leading icon (FieldImage) which is vertically
+// offset by GRID_UNIT so that it appears centered in the taller extension-block
+// body.  That offset must only apply to stack-style extension blocks (those with
+// a previousConnection), NOT hat-style extension blocks, which have their own
+// height calculations.  The guard was removed during a style cleanup and needs
+// to be restored.
+import * as Blockly from 'blockly/core'
+import { afterAll, afterEach, assert, beforeAll, describe, expect, it } from 'vitest'
+import { ScratchMsgs } from '../../msg/scratch_msgs'
+import '../../src/blocks/vertical_extensions'
+import '../../src/renderer/renderer'
+
+const ICON_URL =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=='
+const BLOCK_TYPES = ['test_ext_stack', 'test_ext_hat']
+
+let container: HTMLElement
+let workspace: Blockly.WorkspaceSvg
+
+beforeAll(() => {
+  ScratchMsgs.setLocale('en')
+  container = document.createElement('div')
+  container.style.width = '800px'
+  container.style.height = '600px'
+  document.body.appendChild(container)
+  workspace = Blockly.inject(container, { renderer: 'scratch_classic' })
+
+  Blockly.defineBlocksWithJsonArray([
+    {
+      type: 'test_ext_stack',
+      message0: '%1 stack extension',
+      args0: [{ type: 'field_image', src: ICON_URL, width: 40, height: 40 }],
+      previousStatement: null,
+      nextStatement: null,
+      extensions: ['scratch_extension'],
+    },
+    {
+      type: 'test_ext_hat',
+      message0: '%1 hat extension',
+      args0: [{ type: 'field_image', src: ICON_URL, width: 40, height: 40 }],
+      extensions: ['scratch_extension', 'shape_hat'],
+    },
+  ])
+})
+
+afterAll(() => {
+  for (const type of BLOCK_TYPES) {
+    delete Blockly.Blocks[type]
+  }
+  workspace.dispose()
+  container.remove()
+})
+
+afterEach(() => {
+  workspace.clear()
+})
+
+/**
+ * Call getElemCenterline_ for the icon (FieldImage) element of a block and also
+ * compute the "base" centerline via the superclass method.
+ * @param block The rendered block to inspect.
+ * @returns The difference (the offset our override applies).
+ */
+function getIconOffset(block: Blockly.BlockSvg): number {
+  const renderer = workspace.getRenderer()
+  const info = renderer.makeRenderInfo_(block)
+  info.measure()
+
+  for (const row of info.rows) {
+    for (const elem of row.elements) {
+      if (Blockly.blockRendering.Types.isField(elem) && elem.field instanceof Blockly.FieldImage) {
+        const actual = (info as any).getElemCenterline_(row, elem) as number
+        // Call the grandparent (zelos) implementation to get the base value.
+        // Our override adds GRID_UNIT for stack-style extensions.
+        const base: number = Blockly.zelos.RenderInfo.prototype.getElemCenterline_.call(info, row, elem)
+        return actual - base
+      }
+    }
+  }
+  throw new Error('Block has no FieldImage element')
+}
+
+describe('extension block icon centering — getElemCenterline_', () => {
+  it('stack-style extension block icon gets extra GRID_UNIT offset', () => {
+    const block = workspace.newBlock('test_ext_stack')
+    block.initSvg()
+    block.render()
+
+    assert(block.previousConnection, 'stack extension should have previousConnection')
+
+    const constants = workspace.getRenderer().getConstants() as Blockly.zelos.ConstantProvider
+    expect(getIconOffset(block)).toBeCloseTo(constants.GRID_UNIT, 1)
+  })
+
+  it('hat-style extension block icon does NOT get extra offset', () => {
+    const block = workspace.newBlock('test_ext_hat')
+    block.initSvg()
+    block.render()
+
+    expect(block.previousConnection).toBeNull()
+
+    // Without the previousConnection guard, this would be GRID_UNIT instead of 0.
+    expect(getIconOffset(block)).toBe(0)
+  })
+})


### PR DESCRIPTION
### Resolves

- Resolves scratchfoundation/scratch-blocks#3513
- Resolves scratchfoundation/scratch-blocks#3516

### Proposed Changes

1. Admit that the `prev` and `next` args for `getInRowSpacing_` can be null, and check for that
2. Add an explicit test for mid-stack C block wrapping
3. Admit that a block's `previousConnection` can be null, and check for that

### Reason for Changes

The theme here is that scratchfoundation/scratch-blocks#3500 was a bit overly aggressive in its adjustments to null checks and similar logic changes. If a property truly can't be null, then `if (obj.notNullable)` is forbidden as a pointless check. That means the types have to be honest, though: if that property can actually be null, removing the check can introduce an issue. The changes in this PR are intended to fix and/or protect against that sort of mistake.

1. This was breaking "define" blocks as described in scratchfoundation/scratch-blocks#3513
2. Protects against scratchfoundation/scratch-blocks#3494 coming back (I thought it had regressed, but I was wrong... still, testing for it is valuable IMO)
3. Correctly centers extension icons on hat blocks (see scratchfoundation/scratch-blocks#3516)

### Test Coverage

New tests have been added to cover all of these items.
