### PR TITLE
fix: preserve dropdown values that are not in the current options list

### DIFF
--- a/src/fields/scratch_field_dropdown.ts
+++ b/src/fields/scratch_field_dropdown.ts
@@ -7,6 +7,50 @@ import * as Blockly from 'blockly/core'
 class ScratchFieldDropdown extends Blockly.FieldDropdown {
   private originalStyle!: string
 
+  /**
+   * Accept string values even when they are not in the current options list.
+   * Scratch populates some dropdowns from dynamic data (e.g. the sprite list
+   * for motion_goto_menu, motion_pointtowards_menu, sensing_touchingobject_menu)
+   * and deliberately excludes the currently-editing sprite. A block moved into
+   * the sprite it now targets carries a stored value that is therefore absent
+   * from the option list for this editing context, but is still valid — the
+   * runtime reads the stored value directly. Preserve that value so the UI
+   * shows what the block actually does, rather than silently reverting to the
+   * first option.
+   * @param newValue The value to validate.
+   * @returns The value unchanged if it is a string; otherwise null to reject
+   *     the update.
+   */
+  protected override doClassValidation_(newValue?: string): string | null {
+    if (typeof newValue !== 'string') {
+      return null
+    }
+    return newValue
+  }
+
+  /**
+   * When the stored value is not in the current options list, display the raw
+   * value. Blockly's base implementation reads from the last-matched option,
+   * which stays stale when the incoming value does not appear in the list, so
+   * the default would otherwise render as the first option's text.
+   * @returns Text to display for the currently-selected value.
+   */
+  protected override getText_(): string | null {
+    const value = this.getValue()
+    if (value === null) {
+      return super.getText_()
+    }
+    for (const option of this.getOptions(true)) {
+      if (option === 'separator') continue
+      if (option[1] === value) {
+        // Delegate to the base for the matched case so image/HTMLElement
+        // option types render correctly.
+        return super.getText_()
+      }
+    }
+    return value
+  }
+
   showEditor_(event: PointerEvent) {
     super.showEditor_(event)
     const sourceBlock = this.getSourceBlock() as Blockly.BlockSvg

--- a/tests/browser/scratch_field_dropdown.test.ts
+++ b/tests/browser/scratch_field_dropdown.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Copyright 2026 Scratch Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import * as Blockly from 'blockly/core'
+import { afterAll, afterEach, assert, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import '../../src/css'
+// The scratch field registrations fire inside the scratch-specific inject();
+// this test drives Blockly directly, so register the scratch dropdown
+// explicitly so its overrides are the ones under test.
+import { registerScratchFieldDropdown } from '../../src/fields/scratch_field_dropdown'
+
+// Scratch lists for "target sprite" dropdowns (e.g. motion_goto_menu,
+// motion_pointtowards_menu, sensing_touchingobject_menu) are populated by
+// scratch-gui at runtime and deliberately exclude the currently editing
+// sprite. When a block is copied from another sprite into the sprite it now
+// references, the stored field value is no longer in the option list for the
+// current editing context. The dropdown must still display and preserve that
+// value so the block visually matches what scratch-vm runs.
+//
+// Regression: https://scratch.mit.edu/discuss/topic/878311/
+
+// Capture the default FieldDropdown class before mutating the global registry
+// so we can restore it in afterAll, preventing state leakage into other suites.
+let originalFieldDropdown: (new (...args: unknown[]) => Blockly.Field) | null = null
+
+beforeAll(() => {
+  originalFieldDropdown = Blockly.registry.getClass(Blockly.registry.Type.FIELD, 'field_dropdown') as
+    | (new (...args: unknown[]) => Blockly.Field)
+    | null
+  registerScratchFieldDropdown()
+  Blockly.Blocks.test_target_menu = {
+    init(this: Blockly.Block) {
+      this.jsonInit({
+        message0: '%1',
+        args0: [
+          {
+            type: 'field_dropdown',
+            name: 'TARGET',
+            options: [
+              ['random position', '_random_'],
+              ['mouse-pointer', '_mouse_'],
+              ['Sprite2', 'Sprite2'],
+            ],
+          },
+        ],
+        output: 'String',
+        outputShape: 2, // OUTPUT_SHAPE_ROUND
+      })
+    },
+  }
+})
+
+afterAll(() => {
+  Blockly.fieldRegistry.unregister('field_dropdown')
+  if (originalFieldDropdown) {
+    // `register` expects a RegistrableField; the captured class satisfies that
+    // contract by construction (it was registered originally).
+    Blockly.fieldRegistry.register(
+      'field_dropdown',
+      originalFieldDropdown as unknown as Parameters<typeof Blockly.fieldRegistry.register>[1],
+    )
+  }
+  delete Blockly.Blocks.test_target_menu
+})
+
+let container: HTMLElement
+let workspace: Blockly.WorkspaceSvg
+
+beforeEach(() => {
+  container = document.createElement('div')
+  container.style.width = '800px'
+  container.style.height = '600px'
+  document.body.appendChild(container)
+  workspace = Blockly.inject(container, {})
+})
+
+afterEach(() => {
+  workspace.dispose()
+  container.remove()
+  vi.restoreAllMocks()
+})
+
+function loadXml(xml: string): void {
+  Blockly.Xml.domToWorkspace(Blockly.utils.xml.textToDom(xml), workspace)
+}
+
+describe('ScratchFieldDropdown — value outside current options', () => {
+  it('preserves a stored value that is not in the current options list', () => {
+    // "Sprite1" is not among the test_target_menu options — mirroring the case
+    // where the editing sprite is excluded from the dropdown.
+    loadXml(`
+      <xml>
+        <block type="test_target_menu">
+          <field name="TARGET">Sprite1</field>
+        </block>
+      </xml>
+    `)
+
+    const block = workspace.getAllBlocks(false).find((b) => b.type === 'test_target_menu')
+    assert(block, 'Expected test_target_menu block')
+    expect(block.getFieldValue('TARGET')).toBe('Sprite1')
+  })
+
+  it('displays the stored value even when it is not in the current options list', () => {
+    loadXml(`
+      <xml>
+        <block type="test_target_menu">
+          <field name="TARGET">Sprite1</field>
+        </block>
+      </xml>
+    `)
+
+    const block = workspace.getAllBlocks(false).find((b) => b.type === 'test_target_menu')
+    assert(block, 'Expected test_target_menu block')
+    const field = block.getField('TARGET')
+    assert(field, 'Expected TARGET field')
+    // Before the fix, the field reverts to the first option's display text
+    // ('random position') because Blockly.FieldDropdown rejects values that
+    // are not in the current option list. The displayed text must reflect
+    // the stored value so the user sees what the block actually targets.
+    expect(field.getText()).not.toBe('random position')
+    expect(field.getText()).toBe('Sprite1')
+  })
+
+  it('setValue directly with an out-of-options value keeps that value', () => {
+    const block = workspace.newBlock('test_target_menu')
+    block.initSvg()
+    block.render()
+    const field = block.getField('TARGET')
+    assert(field, 'Expected TARGET field')
+    field.setValue('Sprite1')
+    expect(field.getValue()).toBe('Sprite1')
+  })
+})
+
+describe('ScratchFieldDropdown — value inside current options', () => {
+  // Guard the happy path: when the value IS in the options list, the overrides
+  // must still route to the base implementation so display text uses the
+  // option's human-readable label rather than the language-neutral value.
+  it('stores the selected value and renders its human-readable label', () => {
+    loadXml(`
+      <xml>
+        <block type="test_target_menu">
+          <field name="TARGET">_random_</field>
+        </block>
+      </xml>
+    `)
+
+    const block = workspace.getAllBlocks(false).find((b) => b.type === 'test_target_menu')
+    assert(block, 'Expected test_target_menu block')
+    const field = block.getField('TARGET')
+    assert(field, 'Expected TARGET field')
+    expect(field.getValue()).toBe('_random_')
+    expect(field.getText()).toBe('random position')
+  })
+})


### PR DESCRIPTION
### Resolves

- Fixes https://scratch.mit.edu/discuss/topic/878311/

### Proposed Changes

Scratch's sprite-targeting menus (`motion_goto_menu`, `motion_pointtowards_menu`, `sensing_touchingobject_menu`, and similar) are populated at runtime from the project's sprite list, with the currently editing sprite deliberately excluded. When a block is copied from another sprite into the sprite it now targets, the stored field value is absent from the option list for that editing context. Blockly's default `FieldDropdown` validator rejects such values, so the field silently reverts to the first option — the displayed text shows the default even though `scratch-vm` runs the block against the real stored value.

Override `doClassValidation_` so `ScratchFieldDropdown` accepts any string, and override `getText_` so the display falls back to the raw value when no option matches. Matched-option cases still delegate to the base, so image and `HTMLElement` option types render correctly.

### Test Coverage

Tests added