### PR TITLE
fix: allow C-blocks without a next connection (e.g. forever) to wrap around mid-stack blocks

### DIFF
--- a/src/scratch_c_block_wrap.ts
+++ b/src/scratch_c_block_wrap.ts
@@ -81,9 +81,10 @@ Reflect.set(
     // Restore a real block from a statement input to nextConnection so that
     // unplug(true) can heal the stack correctly.  Conditions:
     //   - marker is mid-stack (has a predecessor)
-    //   - marker.nextConnection is empty (displaced block is NOT already there)
+    //   - marker.nextConnection is either empty or absent (cap blocks do not
+    //     have a bottom connector, so the displaced block is NOT already there)
     //   - a non-marker block is sitting in a statement input
-    if (markerPreviousConnection?.isConnected() && markerNextConnection && !markerNextConnection.isConnected()) {
+    if (markerPreviousConnection?.isConnected() && !markerNextConnection?.isConnected()) {
       for (const input of marker.inputList) {
         const conn = input.connection
         const connType = conn?.type as Blockly.ConnectionType | undefined
@@ -97,7 +98,19 @@ Reflect.set(
             continue
           }
           prev.disconnect()
-          markerNextConnection.connect(prev)
+          if (markerNextConnection) {
+            markerNextConnection.connect(prev)
+          } else {
+            // Blocks without a bottom connector (e.g. forever) have no nextConnection. Reconnect
+            // the displaced block directly to the connection the marker's
+            // previousConnection is plugged into, then detach the marker
+            // so unplug() has nothing left to heal.
+            const aboveConn = markerPreviousConnection.targetConnection
+            if (aboveConn) {
+              markerPreviousConnection.disconnect()
+              aboveConn.connect(prev)
+            }
+          }
           break
         }
       }

--- a/src/scratch_connection_checker.ts
+++ b/src/scratch_connection_checker.ts
@@ -44,6 +44,32 @@ class ScratchConnectionChecker extends Blockly.ConnectionChecker {
       return false
     }
 
+    // Blockly's base doDragChecks rejects inserting a block with no
+    // nextConnection into the middle of a stack (NEXT_STATEMENT case) because
+    // it assumes the displaced blocks have nowhere to go. Our
+    // getConnectionForOrphanedConnection patch routes displaced blocks into
+    // statement inputs, so we allow the connection when a suitable statement
+    // input exists on the dragging block.
+    if (
+      (b.type as Blockly.ConnectionType) === Blockly.ConnectionType.NEXT_STATEMENT &&
+      b.isConnected() &&
+      !(a.getSourceBlock() as Blockly.Block).nextConnection
+    ) {
+      const orphan = b.targetBlock()
+      const orphanPrev = (orphan as Blockly.Block | null)?.previousConnection
+      if (orphan && !orphan.isShadow() && orphanPrev) {
+        const canWrap = !!Blockly.Connection.getConnectionForOrphanedConnection(a.getSourceBlock(), orphanPrev)
+        if (canWrap) {
+          // Skip the base class NEXT_STATEMENT check (which would reject
+          // this) but still apply the other generic guards it uses.
+          if ('distanceFrom' in a && a.distanceFrom(b) > distance) return false
+          if (b.getSourceBlock().isInsertionMarker()) return false
+          if (Blockly.common.draggingConnections.includes(b)) return false
+          return true
+        }
+      }
+    }
+
     return super.doDragChecks(a, b, distance)
   }
 }

--- a/tests/unit/c_block_wrap.test.ts
+++ b/tests/unit/c_block_wrap.test.ts
@@ -18,7 +18,7 @@ afterEach(() => {
 })
 
 describe('C-block wrapping', () => {
-  const BLOCK_TYPES = ['test_c_block_wrap', 'test_stmt_wrap_inner', 'test_stmt_wrap_outer']
+  const BLOCK_TYPES = ['test_c_block_wrap', 'test_c_cap_block', 'test_stmt_wrap_inner', 'test_stmt_wrap_outer']
 
   beforeEach(() => {
     Blockly.defineBlocksWithJsonArray([
@@ -28,6 +28,13 @@ describe('C-block wrapping', () => {
         args0: [{ type: 'input_statement', name: 'SUBSTACK' }],
         previousStatement: null,
         nextStatement: null,
+      },
+      {
+        type: 'test_c_cap_block',
+        message0: 'forever %1',
+        args0: [{ type: 'input_statement', name: 'SUBSTACK' }],
+        previousStatement: null,
+        // no nextStatement — like "forever", this block has no bottom connector
       },
       {
         type: 'test_stmt_wrap_inner',
@@ -101,6 +108,62 @@ describe('C-block wrapping', () => {
 
     // After cleanup, the stack should be healed: B1 → B2 (marker was disposed)
     expect(b1.nextConnection.targetBlock()).toBe(b2)
+  })
+
+  it('hideInsertionMarker restores displaced block when block has no bottom connector (e.g. forever)', () => {
+    // A block like "forever" has no nextConnection (no bottom connector).
+    // When its insertion marker is cleaned up, the displaced block must be
+    // reconnected directly to the connection above the marker.
+    const b1 = workspace.newBlock('test_stmt_wrap_outer')
+    const marker = workspace.newBlock('test_c_cap_block')
+    const b2 = workspace.newBlock('test_stmt_wrap_inner')
+
+    marker.setInsertionMarker(true)
+
+    // B1 → marker (marker is mid-stack)
+    assert(b1.nextConnection, 'b1 should have nextConnection')
+    assert(marker.previousConnection, 'marker should have previousConnection')
+    expect(marker.nextConnection).toBeNull()
+    b1.nextConnection.connect(marker.previousConnection)
+
+    // B2 is in the marker's statement input
+    const markerStatementConn = marker.getInput('SUBSTACK')?.connection
+    assert(markerStatementConn, 'marker should have a SUBSTACK statement input')
+    assert(b2.previousConnection, 'b2 should have previousConnection')
+    markerStatementConn.connect(b2.previousConnection)
+    ;(Blockly.InsertionMarkerPreviewer.prototype as any).hideInsertionMarker.call({}, marker.previousConnection)
+
+    // After cleanup, the stack should be healed: B1 → B2
+    expect(b1.nextConnection.targetBlock()).toBe(b2)
+  })
+
+  it('hideInsertionMarker restores displaced block when marker is inside a statement input (not a next-connection chain)', () => {
+    // When a forever marker is inside another C-block's statement input
+    // (rather than chained via nextConnection), targetConnection is the
+    // parent's statement input connection. The fix uses targetConnection
+    // generically, so this should work the same way.
+    const parent = workspace.newBlock('test_c_block_wrap')
+    const marker = workspace.newBlock('test_c_cap_block')
+    const b2 = workspace.newBlock('test_stmt_wrap_inner')
+
+    marker.setInsertionMarker(true)
+
+    // Parent's SUBSTACK → marker (marker is inside a statement input)
+    const parentSubstack = parent.getInput('SUBSTACK')?.connection
+    assert(parentSubstack, 'parent should have a SUBSTACK statement input')
+    assert(marker.previousConnection, 'marker should have previousConnection')
+    expect(marker.nextConnection).toBeNull()
+    parentSubstack.connect(marker.previousConnection)
+
+    // B2 is in the marker's statement input
+    const markerSubstack = marker.getInput('SUBSTACK')?.connection
+    assert(markerSubstack, 'marker should have a SUBSTACK statement input')
+    assert(b2.previousConnection, 'b2 should have previousConnection')
+    markerSubstack.connect(b2.previousConnection)
+    ;(Blockly.InsertionMarkerPreviewer.prototype as any).hideInsertionMarker.call({}, marker.previousConnection)
+
+    // After cleanup, B2 should be reconnected to the parent's SUBSTACK
+    expect(parentSubstack.targetBlock()).toBe(b2)
   })
 
   it('displaced block goes into statement input even when C-block is an insertion marker (preview matches drop)', () => {

--- a/tests/unit/connections.test.ts
+++ b/tests/unit/connections.test.ts
@@ -4,6 +4,7 @@
  */
 import * as Blockly from 'blockly/core'
 import { afterEach, assert, beforeEach, describe, expect, it } from 'vitest'
+import '../../src/scratch_c_block_wrap'
 import '../../src/scratch_connection_checker'
 
 type ScratchCheckerCtor = new () => {
@@ -106,6 +107,103 @@ describe('ScratchConnectionChecker', () => {
       } finally {
         delete Blockly.Blocks.procedures_definition
         delete Blockly.Blocks.test_output_block
+      }
+    })
+  })
+
+  describe('doDragChecks — C-block without nextConnection (e.g. forever)', () => {
+    it('allows mid-stack insertion when the dragging block has a statement input for the orphan', () => {
+      Blockly.defineBlocksWithJsonArray([
+        {
+          type: 'test_forever',
+          message0: 'forever %1',
+          args0: [{ type: 'input_statement', name: 'SUBSTACK' }],
+          previousStatement: null,
+          // no nextStatement
+        },
+        {
+          type: 'test_stack',
+          message0: 'stack',
+          previousStatement: null,
+          nextStatement: null,
+        },
+      ])
+
+      try {
+        const foreverBlock = workspace.newBlock('test_forever')
+        const topBlock = workspace.newBlock('test_stack')
+        const bottomBlock = workspace.newBlock('test_stack')
+
+        assert(topBlock.nextConnection, 'topBlock should have nextConnection')
+        assert(bottomBlock.previousConnection, 'bottomBlock should have previousConnection')
+        topBlock.nextConnection.connect(bottomBlock.previousConnection)
+
+        // Dragging forever's previousConnection toward topBlock's nextConnection
+        // (which is occupied by bottomBlock). Base Blockly would reject this
+        // because forever has no nextConnection, but ScratchConnectionChecker
+        // should allow it because the orphan can go into the statement input.
+        const ScratchChecker = Blockly.registry.getClass(
+          Blockly.registry.Type.CONNECTION_CHECKER,
+          Blockly.registry.DEFAULT,
+        ) as ScratchCheckerCtor | null
+        assert(ScratchChecker, 'Expected ScratchConnectionChecker to be registered')
+        assert(foreverBlock.previousConnection, 'foreverBlock should have previousConnection')
+        assert(topBlock.nextConnection, 'topBlock should have nextConnection')
+        const result = new ScratchChecker().doDragChecks(
+          foreverBlock.previousConnection as unknown as Blockly.RenderedConnection,
+          topBlock.nextConnection as unknown as Blockly.RenderedConnection,
+          Infinity,
+        )
+        expect(result).toBe(true)
+      } finally {
+        delete Blockly.Blocks.test_forever
+        delete Blockly.Blocks.test_stack
+      }
+    })
+
+    it('rejects mid-stack insertion when the target block is an insertion marker', () => {
+      Blockly.defineBlocksWithJsonArray([
+        {
+          type: 'test_forever',
+          message0: 'forever %1',
+          args0: [{ type: 'input_statement', name: 'SUBSTACK' }],
+          previousStatement: null,
+        },
+        {
+          type: 'test_stack',
+          message0: 'stack',
+          previousStatement: null,
+          nextStatement: null,
+        },
+      ])
+
+      try {
+        const foreverBlock = workspace.newBlock('test_forever')
+        const topBlock = workspace.newBlock('test_stack')
+        const bottomBlock = workspace.newBlock('test_stack')
+
+        // Mark topBlock as an insertion marker
+        topBlock.setInsertionMarker(true)
+
+        assert(topBlock.nextConnection, 'topBlock should have nextConnection')
+        assert(bottomBlock.previousConnection, 'bottomBlock should have previousConnection')
+        topBlock.nextConnection.connect(bottomBlock.previousConnection)
+
+        const ScratchChecker = Blockly.registry.getClass(
+          Blockly.registry.Type.CONNECTION_CHECKER,
+          Blockly.registry.DEFAULT,
+        ) as ScratchCheckerCtor | null
+        assert(ScratchChecker, 'Expected ScratchConnectionChecker to be registered')
+        assert(foreverBlock.previousConnection, 'foreverBlock should have previousConnection')
+        const result = new ScratchChecker().doDragChecks(
+          foreverBlock.previousConnection as unknown as Blockly.RenderedConnection,
+          topBlock.nextConnection as unknown as Blockly.RenderedConnection,
+          Infinity,
+        )
+        expect(result).toBe(false)
+      } finally {
+        delete Blockly.Blocks.test_forever
+        delete Blockly.Blocks.test_stack
       }
     })
   })


### PR DESCRIPTION
### Resolves

- Fixes scratchfoundation/scratch-blocks#3494 more correctly :sweat_smile:

### Proposed Changes

Two fixes for wrapping a "forever" block (C-block with no bottom connector) around blocks mid-stack:

#### Enable the wrap insertion preview during drag

Blockly's base `ConnectionChecker.doDragChecks` rejects mid-stack insertion for blocks without a nextConnection, assuming displaced blocks have nowhere to go. This override in ScratchConnectionChecker checks whether `getConnectionForOrphanedConnection` can route the orphan into a statement input instead. Without this, dragging a forever block over the middle of a stack never offered a wrap preview.

#### Prevent data loss during insertion marker cleanup

The `hideInsertionMarker` patch from #3498 assumed the marker always has a `nextConnection`, so it could move the displaced block there for `unplug(true)` to heal. Forever blocks have no `nextConnection`, so the condition short-circuited and the displaced block was disposed with the marker. Now, when the marker has no `nextConnection`, we reconnect the displaced block directly to the connection the marker was plugged into (using `targetConnection`, which handles both next-connection chains and statement inputs).

### Test Coverage

- Connection checker allows mid-stack insertion for C-blocks with statement inputs
- Connection checker rejects insertion when target is an insertion marker
- Insertion marker cleanup restores displaced blocks for blocks with no bottom connector
- Insertion marker cleanup works when the marker is inside a statement input (not just a next-connection chain)
