### PR TITLE
fix: recover shadow inputs dropped by Blockly's blockToDom

### DIFF
--- a/src/checkable_continuous_flyout.ts
+++ b/src/checkable_continuous_flyout.ts
@@ -20,6 +20,27 @@ function isCheckboxIcon(icon: Blockly.IIcon | undefined): icon is Blockly.IIcon 
   return !!icon && typeof (icon as { setChecked?: unknown }).setChecked === 'function'
 }
 
+/**
+ * Recursively strip `id` properties from a serialized block state tree
+ * so that every block (including shadows and nested inputs) gets a fresh
+ * ID when deserialized onto the workspace.
+ * @param state A serialized block state object.
+ */
+function stripIds(state: Blockly.serialization.blocks.State): void {
+  delete state.id
+  if (state.inputs) {
+    for (const inputName in state.inputs) {
+      const conn = state.inputs[inputName]
+      if (conn.shadow) stripIds(conn.shadow)
+      if (conn.block) stripIds(conn.block)
+    }
+  }
+  if (state.next) {
+    if (state.next.shadow) stripIds(state.next.shadow)
+    if (state.next.block) stripIds(state.next.block)
+  }
+}
+
 export class CheckableContinuousFlyout extends ContinuousFlyout {
   declare protected tabWidth_: number
   declare MARGIN: number
@@ -44,11 +65,12 @@ export class CheckableContinuousFlyout extends ContinuousFlyout {
    */
   protected serializeBlock(block: Blockly.BlockSvg) {
     const json = super.serializeBlock(block)
-    // Delete the serialized block's ID so that a new one is generated when it is
-    // placed on the workspace. Otherwise, the block on the workspace may be
-    // indistinguishable from the one in the flyout, which can cause reporter blocks
-    // to have their value dropdown shown in the wrong place.
-    delete json.id
+    // Strip all IDs so every block in the tree (including shadows) gets a
+    // fresh ID when placed on the workspace. Without this, disposed shadows
+    // from a previous copy can reuse the flyout's IDs, causing two workspace
+    // blocks to share the same shadow in the VM. Deleting one then destroys
+    // the other's shadow (bug 878291).
+    stripIds(json)
     return json
   }
 

--- a/src/xml.ts
+++ b/src/xml.ts
@@ -5,6 +5,68 @@
 import * as Blockly from 'blockly/core'
 import { ScratchVariableModel } from './scratch_variable_model'
 
+// Blockly's blockToDom has a bug where the `empty` flag for an input's
+// container element is only set to false when a non-shadow target block
+// exists. If a connection has shadow DOM but no target block (which can
+// happen transiently during connect/disconnect operations or if shadow
+// respawn fails), the shadow clone IS appended to the <value> container
+// but the container is never appended to the output because `empty`
+// stays true. This causes the input to silently disappear from the XML,
+// which corrupts the VM's block representation on the next save/load.
+//
+// We fix this by wrapping blockToDom: after the original runs, we check
+// each value/statement input. If the connection has shadow state but the
+// output XML is missing the corresponding <value>/<statement> element,
+// we serialize the shadow ourselves and inject it.
+const originalBlockToDom = Blockly.Xml.blockToDom.bind(Blockly.Xml)
+
+Blockly.Xml.blockToDom = function blockToDomFixed(
+  block: Blockly.Block,
+  opt_noId?: boolean,
+): Element | DocumentFragment {
+  const result = originalBlockToDom(block, opt_noId)
+  if (!(result instanceof Element)) return result
+
+  for (const input of block.inputList) {
+    if (!input.connection) continue
+
+    const name = input.name
+    // Check if this input already appears in the serialized XML.
+    // Use localName for case-insensitive comparison across DOM implementations.
+    const alreadySerialized = Array.from(result.children).some((child) => {
+      const tag = child.localName
+      return (tag === 'value' || tag === 'statement') && child.getAttribute('name') === name
+    })
+    if (alreadySerialized) continue
+
+    // The input is missing from the XML. Check if there's shadow state
+    // that should have been included.
+    if (!input.connection.getShadowState()) continue
+
+    // If shadow DOM is still available on the connection, clone that DOM
+    // into a new container and append it to the serialized output.
+    const existingShadowDom = input.connection.getShadowDom()
+    if (existingShadowDom) {
+      const tagName = input.type === Blockly.inputs.inputTypes.VALUE ? 'value' : 'statement'
+      const doc = result.ownerDocument
+      const container = doc.createElementNS(result.namespaceURI, tagName)
+      container.setAttribute('name', name)
+      container.appendChild(doc.importNode(existingShadowDom, true))
+      if (opt_noId) {
+        for (const shadowEl of container.querySelectorAll('shadow')) {
+          shadowEl.removeAttribute('id')
+        }
+      }
+      result.appendChild(container)
+      console.warn(
+        `[scratch-blocks] blockToDom fix: recovered missing input "${name}" on ${block.type} (${block.id})`,
+      )
+    }
+  }
+
+  return result
+}
+
 /**
  * Clears the workspace and loads the given serialized state.
  * @param xml XML representation of a Blockly workspace.

--- a/src/xml.ts
+++ b/src/xml.ts
@@ -51,15 +51,22 @@ Blockly.Xml.blockToDom = function blockToDomFixed(
       const doc = result.ownerDocument
       const container = doc.createElementNS(result.namespaceURI, tagName)
       container.setAttribute('name', name)
-      container.appendChild(doc.importNode(existingShadowDom, true))
+      const importedShadow = doc.importNode(existingShadowDom, true)
       if (opt_noId) {
-        for (const shadowEl of container.querySelectorAll('shadow')) {
-          shadowEl.removeAttribute('id')
+        importedShadow.removeAttribute('id')
+        for (const el of importedShadow.querySelectorAll('[id]')) {
+          el.removeAttribute('id')
         }
       }
+      container.appendChild(importedShadow)
       result.appendChild(container)
       console.warn(
         `[scratch-blocks] blockToDom fix: recovered missing input "${name}" on ${block.type} (${block.id})`,
+      )
+    } else {
+      console.warn(
+        `[scratch-blocks] blockToDom fix: input "${name}" on ${block.type} (${block.id}) has shadow state` +
+          ` but no shadow DOM — cannot recover`,
       )
     }
   }

--- a/tests/unit/block_input_serialization.test.ts
+++ b/tests/unit/block_input_serialization.test.ts
@@ -20,7 +20,7 @@ import '../../src/xml'
  * with `inputs: {}` in the saved project.
  */
 
-const BLOCK_TYPES = ['test_set_variable', 'test_text_shadow', 'test_reporter']
+const BLOCK_TYPES = ['test_set_variable', 'test_text_shadow', 'test_reporter', 'test_math_shadow', 'test_add']
 
 /**
  * Returns a block's named input, asserting that it exists.
@@ -66,11 +66,27 @@ beforeEach(() => {
       message0: 'answer',
       output: 'String',
     },
+    {
+      type: 'test_math_shadow',
+      message0: '%1',
+      args0: [{ type: 'field_number', name: 'NUM' }],
+      output: 'Number',
+    },
+    {
+      type: 'test_add',
+      message0: '%1 + %2',
+      args0: [
+        { type: 'input_value', name: 'NUM1' },
+        { type: 'input_value', name: 'NUM2' },
+      ],
+      output: 'Number',
+    },
   ])
   workspace = new Blockly.Workspace()
 })
 
 afterEach(() => {
+  vi.restoreAllMocks()
   workspace.dispose()
   for (const t of BLOCK_TYPES) {
     delete Blockly.Blocks[t]
@@ -144,35 +160,96 @@ describe('block input serialization round-trip', () => {
     block.dispose()
   })
 
-  it('flyout copy path: JSON save -> delete id -> append preserves shadow', () => {
-    const flyoutBlock = createTestBlock({
-      ...SHADOW_INPUT_STATE,
-      id: 'flyout-template',
-    })
+  it('flyout copy path: JSON save -> strip ids -> append preserves nested shadows', () => {
+    // Create a block tree with nested inputs and shadows, mirroring what
+    // the palette would produce for "set variable to ((0) + (0))":
+    //   test_set_variable
+    //     VALUE: test_add (non-shadow)
+    //       NUM1: test_math_shadow (shadow)
+    //       NUM2: test_math_shadow (shadow)
+    const nestedState: Blockly.serialization.blocks.State = {
+      type: 'test_set_variable',
+      id: 'flyout-root',
+      inputs: {
+        VALUE: {
+          block: {
+            type: 'test_add',
+            id: 'flyout-add',
+            inputs: {
+              NUM1: {
+                shadow: {
+                  type: 'test_math_shadow',
+                  id: 'flyout-num1-shadow',
+                  fields: { NUM: 1 },
+                },
+              },
+              NUM2: {
+                shadow: {
+                  type: 'test_math_shadow',
+                  id: 'flyout-num2-shadow',
+                  fields: { NUM: 2 },
+                },
+              },
+            },
+          },
+          shadow: {
+            type: 'test_text_shadow',
+            id: 'flyout-value-shadow',
+            fields: { TEXT: '0' },
+          },
+        },
+      },
+    }
+
+    const flyoutBlock = createTestBlock(nestedState)
 
     const json = Blockly.serialization.blocks.save(flyoutBlock)
     assert(json, 'Expected save to return state')
     delete json.id // CheckableContinuousFlyout deletes the root id
 
+    // Verify that nested IDs are present before stripping
+    assert(json.inputs, 'Expected inputs on saved state')
+    assert(json.inputs.VALUE, 'Expected VALUE in saved inputs')
+    const addState = json.inputs.VALUE.block
+    assert(addState, 'Expected add block in saved state')
+    expect(addState.id).toBeDefined()
+    assert(addState.inputs, 'Expected inputs on add block')
+    assert(addState.inputs.NUM1, 'Expected NUM1 in add block inputs')
+    assert(addState.inputs.NUM2, 'Expected NUM2 in add block inputs')
+    expect(addState.inputs.NUM1.shadow?.id).toBeDefined()
+    expect(addState.inputs.NUM2.shadow?.id).toBeDefined()
+
     const newBlock = Blockly.serialization.blocks.append(json, workspace, {
       recordUndo: true,
     })
 
-    const conn = getConnection(getInput(newBlock, 'VALUE'))
-    const target = conn.targetBlock()
-    assert(target, 'Expected shadow on copied block')
-    expect(target.isShadow()).toBe(true)
-    expect(conn.getShadowDom()).not.toBeNull()
-    expect(conn.getShadowState()).not.toBeNull()
+    // The root VALUE input should have its shadow state
+    const valueConn = getConnection(getInput(newBlock, 'VALUE'))
+    expect(valueConn.getShadowDom()).not.toBeNull()
+    expect(valueConn.getShadowState()).not.toBeNull()
 
+    // The nested add block should have shadows on both NUM inputs
+    const addBlock = valueConn.targetBlock()
+    assert(addBlock, 'Expected add block on VALUE')
+    expect(addBlock.type).toBe('test_add')
+
+    const num1Conn = getConnection(getInput(addBlock, 'NUM1'))
+    const num1Shadow = num1Conn.targetBlock()
+    assert(num1Shadow, 'Expected shadow on NUM1')
+    expect(num1Shadow.isShadow()).toBe(true)
+    expect(num1Shadow.type).toBe('test_math_shadow')
+
+    const num2Conn = getConnection(getInput(addBlock, 'NUM2'))
+    const num2Shadow = num2Conn.targetBlock()
+    assert(num2Shadow, 'Expected shadow on NUM2')
+    expect(num2Shadow.isShadow()).toBe(true)
+
+    // blockToDom should include all nested shadows
     const dom = Blockly.Xml.blockToDom(newBlock)
     const xmlStr = new XMLSerializer().serializeToString(dom)
     expect(xmlStr).toContain('name="VALUE"')
-    expect(xmlStr).toContain('<shadow')
-
-    // Note: in a headless test environment, Blockly's async event dispatch
-    // (requestAnimationFrame + setTimeout) doesn't fire. The workspace state
-    // and blockToDom output above verify correctness at the Blockly level.
+    expect(xmlStr).toContain('name="NUM1"')
+    expect(xmlStr).toContain('name="NUM2"')
 
     flyoutBlock.dispose()
     newBlock.dispose()
@@ -214,13 +291,39 @@ describe('block input serialization round-trip', () => {
 
     // Without the fix, blockToDom would produce XML without the VALUE input.
     // With the fix, the shadow is recovered (and a warning is logged).
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
     const dom = Blockly.Xml.blockToDom(block)
     const xmlStr = new XMLSerializer().serializeToString(dom)
     expect(xmlStr).toContain('name="VALUE"')
     expect(xmlStr).toContain('shadow')
-    expect(warnSpy).toHaveBeenCalledOnce()
-    warnSpy.mockRestore()
+    expect(console.warn).toHaveBeenCalledOnce()
+
+    block.dispose()
+  })
+
+  it('blockToDom recovery strips IDs when opt_noId is true', () => {
+    const block = createTestBlock(SHADOW_INPUT_STATE)
+    const conn = getConnection(getInput(block, 'VALUE'))
+
+    // Create the pathological state: shadowDom set, no targetBlock
+    const shadow = conn.targetBlock()
+    assert(shadow, 'Expected shadow block')
+    Blockly.Events.disable()
+    try {
+      shadow.dispose(false)
+    } finally {
+      Blockly.Events.enable()
+    }
+
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const dom = Blockly.Xml.blockToDom(block, true)
+    expect(dom).toBeInstanceOf(Element)
+
+    const xmlStr = new XMLSerializer().serializeToString(dom as Element)
+    expect(xmlStr).toContain('name="VALUE"')
+    expect(xmlStr).toContain('shadow')
+    // With opt_noId, no element should have an id attribute
+    expect(xmlStr).not.toMatch(/\bid="/)
 
     block.dispose()
   })

--- a/tests/unit/block_input_serialization.test.ts
+++ b/tests/unit/block_input_serialization.test.ts
@@ -1,0 +1,263 @@
+/**
+ * Copyright 2026 Scratch Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import * as Blockly from 'blockly/core'
+import { afterEach, assert, beforeEach, describe, expect, it, vi } from 'vitest'
+// Import the blockToDom fix
+import '../../src/xml'
+
+/**
+ * Regression tests for block input serialization (bug 878291).
+ *
+ * Block inputs (especially shadow-only inputs like VALUE on
+ * data_setvariableto) must survive the full round-trip:
+ *   toolbox XML -> flyout block -> JSON serialize -> workspace block
+ *   -> BlockCreate event XML -> adapter XML parse
+ *
+ * The bug: inputs with only a shadow block were silently dropped
+ * during one of these serialization steps, resulting in blocks
+ * with `inputs: {}` in the saved project.
+ */
+
+const BLOCK_TYPES = ['test_set_variable', 'test_text_shadow', 'test_reporter']
+
+/**
+ * Returns a block's named input, asserting that it exists.
+ * @param block The block to get the input from.
+ * @param name The input name to look up on the block.
+ * @returns The named input.
+ */
+function getInput(block: Blockly.Block, name: string): Blockly.Input {
+  const input = block.getInput(name)
+  assert(input, `Expected input "${name}" on ${block.type}`)
+  return input
+}
+
+/**
+ * Returns an input's connection, asserting that it exists.
+ * @param input The input to get the connection from.
+ * @returns The input's connection.
+ */
+function getConnection(input: Blockly.Input): Blockly.Connection {
+  assert(input.connection, `Expected connection on input "${input.name}"`)
+  return input.connection
+}
+
+let workspace: Blockly.Workspace
+
+beforeEach(() => {
+  Blockly.defineBlocksWithJsonArray([
+    {
+      type: 'test_set_variable',
+      message0: 'set to %1',
+      args0: [{ type: 'input_value', name: 'VALUE' }],
+      previousStatement: null,
+      nextStatement: null,
+    },
+    {
+      type: 'test_text_shadow',
+      message0: '%1',
+      args0: [{ type: 'field_input', name: 'TEXT' }],
+      output: 'String',
+    },
+    {
+      type: 'test_reporter',
+      message0: 'answer',
+      output: 'String',
+    },
+  ])
+  workspace = new Blockly.Workspace()
+})
+
+afterEach(() => {
+  workspace.dispose()
+  for (const t of BLOCK_TYPES) {
+    delete Blockly.Blocks[t]
+  }
+})
+
+/** Shadow state shared across tests. */
+const SHADOW_INPUT_STATE: Blockly.serialization.blocks.State = {
+  type: 'test_set_variable',
+  inputs: {
+    VALUE: {
+      shadow: {
+        type: 'test_text_shadow',
+        fields: { TEXT: '0' },
+      },
+    },
+  },
+}
+
+/**
+ * Creates a test block from JSON with events disabled.
+ * @param state The JSON state to create the block from.
+ * @returns The created block.
+ */
+function createTestBlock(state: Blockly.serialization.blocks.State): Blockly.Block {
+  Blockly.Events.disable()
+  try {
+    return Blockly.serialization.blocks.append(state, workspace)
+  } finally {
+    Blockly.Events.enable()
+  }
+}
+
+describe('block input serialization round-trip', () => {
+  it('newBlock creates VALUE input on the block', () => {
+    const block = workspace.newBlock('test_set_variable')
+    const input = getInput(block, 'VALUE')
+    expect(getConnection(input)).toBeDefined()
+    block.dispose()
+  })
+
+  it('JSON save() includes shadow-only VALUE input', () => {
+    const block = createTestBlock(SHADOW_INPUT_STATE)
+
+    const conn = getConnection(getInput(block, 'VALUE'))
+    const target = conn.targetBlock()
+    assert(target, 'Expected a shadow block on VALUE')
+    expect(target.isShadow()).toBe(true)
+
+    const saved = Blockly.serialization.blocks.save(block)
+    assert(saved, 'Expected save to return a state object')
+    expect(saved.inputs).toBeDefined()
+    assert(saved.inputs?.VALUE, 'Expected VALUE in saved inputs')
+    expect(saved.inputs.VALUE.shadow).toBeDefined()
+    expect(saved.inputs.VALUE.shadow?.type).toBe('test_text_shadow')
+
+    block.dispose()
+  })
+
+  it('blockToDom includes VALUE shadow in XML output', () => {
+    const block = createTestBlock(SHADOW_INPUT_STATE)
+
+    const dom = Blockly.Xml.blockToDom(block)
+    expect(dom).toBeInstanceOf(Element)
+
+    const xmlStr = new XMLSerializer().serializeToString(dom)
+    expect(xmlStr).toContain('name="VALUE"')
+    expect(xmlStr).toContain('<shadow')
+    expect(xmlStr).toContain('type="test_text_shadow"')
+
+    block.dispose()
+  })
+
+  it('flyout copy path: JSON save -> delete id -> append preserves shadow', () => {
+    const flyoutBlock = createTestBlock({
+      ...SHADOW_INPUT_STATE,
+      id: 'flyout-template',
+    })
+
+    const json = Blockly.serialization.blocks.save(flyoutBlock)
+    assert(json, 'Expected save to return state')
+    delete json.id // CheckableContinuousFlyout deletes the root id
+
+    const newBlock = Blockly.serialization.blocks.append(json, workspace, {
+      recordUndo: true,
+    })
+
+    const conn = getConnection(getInput(newBlock, 'VALUE'))
+    const target = conn.targetBlock()
+    assert(target, 'Expected shadow on copied block')
+    expect(target.isShadow()).toBe(true)
+    expect(conn.getShadowDom()).not.toBeNull()
+    expect(conn.getShadowState()).not.toBeNull()
+
+    const dom = Blockly.Xml.blockToDom(newBlock)
+    const xmlStr = new XMLSerializer().serializeToString(dom)
+    expect(xmlStr).toContain('name="VALUE"')
+    expect(xmlStr).toContain('<shadow')
+
+    // Note: in a headless test environment, Blockly's async event dispatch
+    // (requestAnimationFrame + setTimeout) doesn't fire. The workspace state
+    // and blockToDom output above verify correctness at the Blockly level.
+
+    flyoutBlock.dispose()
+    newBlock.dispose()
+  })
+
+  it('blockToDom recovers shadow when targetBlock() is null (Blockly empty flag bug)', () => {
+    // This tests the specific Blockly bug that causes cursed inputs:
+    // blockToDom has an `empty` flag that is only set to false when a
+    // targetBlock exists. If a connection has shadowDom but no targetBlock,
+    // the shadow IS appended to the <value> container, but `empty` stays
+    // true and the container is not appended to the output.
+    //
+    // The scratch-blocks wrapper around blockToDom detects and recovers
+    // this case.
+    const block = createTestBlock(SHADOW_INPUT_STATE)
+
+    const conn = getConnection(getInput(block, 'VALUE'))
+    expect(conn.targetBlock()).not.toBeNull()
+    expect(conn.getShadowDom()).not.toBeNull()
+
+    // Dispose the shadow block to create the pathological state:
+    // shadowDom set but no targetBlock. After disposing a shadow,
+    // respawnShadow_ is NOT called (because the disconnected block IS
+    // a shadow), so targetBlock() becomes null while shadow state persists.
+    const shadow = conn.targetBlock()
+    assert(shadow, 'Expected shadow block')
+    Blockly.Events.disable()
+    try {
+      shadow.dispose(false)
+    } finally {
+      Blockly.Events.enable()
+    }
+
+    // Verify the pathological state exists
+    const currentTarget = conn.targetBlock()
+    const currentShadowDom = conn.getShadowDom()
+    expect(currentTarget).toBeNull()
+    expect(currentShadowDom).not.toBeNull()
+
+    // Without the fix, blockToDom would produce XML without the VALUE input.
+    // With the fix, the shadow is recovered (and a warning is logged).
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const dom = Blockly.Xml.blockToDom(block)
+    const xmlStr = new XMLSerializer().serializeToString(dom)
+    expect(xmlStr).toContain('name="VALUE"')
+    expect(xmlStr).toContain('shadow')
+    expect(warnSpy).toHaveBeenCalledOnce()
+    warnSpy.mockRestore()
+
+    block.dispose()
+  })
+
+  it('shadow respawns after connecting and disconnecting a reporter', () => {
+    const block = createTestBlock(SHADOW_INPUT_STATE)
+
+    Blockly.Events.disable()
+    let reporter: Blockly.Block
+    try {
+      reporter = workspace.newBlock('test_reporter')
+    } finally {
+      Blockly.Events.enable()
+    }
+
+    const conn = getConnection(getInput(block, 'VALUE'))
+    const reporterOutput = reporter.outputConnection
+    assert(reporterOutput, 'Expected output connection on reporter')
+
+    // Connect reporter (displaces shadow)
+    conn.connect(reporterOutput)
+    expect(conn.targetBlock()).toBe(reporter)
+    expect(conn.getShadowDom()).not.toBeNull()
+
+    // Disconnect reporter (shadow should respawn)
+    reporterOutput.disconnect()
+    const respawned = conn.targetBlock()
+    assert(respawned, 'Expected shadow to respawn after disconnect')
+    expect(respawned.isShadow()).toBe(true)
+    expect(respawned.type).toBe('test_text_shadow')
+
+    const dom = Blockly.Xml.blockToDom(block)
+    const xmlStr = new XMLSerializer().serializeToString(dom)
+    expect(xmlStr).toContain('name="VALUE"')
+    expect(xmlStr).toContain('<shadow')
+
+    reporter.dispose()
+    block.dispose()
+  })
+})


### PR DESCRIPTION
### Resolves

- Forum topics 878291, 878962, and part of 878945 ("cursed inputs" / blank inputs after editing and reloading)
- Replaces `changeObscuredShadowIds` from old scratch-blocks, which was lost during the unfork

### Proposed Changes

**Root cause:** When a block is copied from the flyout, `CheckableContinuousFlyout.serializeBlock` strips the root block's ID but preserves descendant IDs (including shadows). If a previous copy's shadow was disposed (because a reporter was placed in the input), the flyout's original shadow ID becomes available again on the Blockly workspace. The next copy reuses that ID. The VM then has two blocks sharing the same shadow. Deleting one destroys the other's shadow, corrupting the project.

This is the same problem that old scratch-blocks solved with `changeObscuredShadowIds` (in `scratch_blocks_utils.js`), which was lost during the unfork.

Two fixes:

1. **`checkable_continuous_flyout.ts` (primary fix):** `stripIds` recursively removes all IDs from the serialized block tree before deserialization, so every copy (including shadows and nested inputs) gets fully unique IDs. This prevents the shared-shadow problem at the source.

2. **`xml.ts` (defense-in-depth):** Wrapper around `Blockly.Xml.blockToDom` that detects when an input with shadow state was dropped from the XML output due to a Blockly bug (the `empty` flag is only set to false when `targetBlock()` exists) and recovers it. This guards against a separate code path that could produce the same symptom.

**Companion change needed in scratch-editor:** load-time repair in the VM's sb3 deserializer to fix already-corrupted projects (recreates missing shadow blocks using peer lookup), plus a defensive guard in `moveBlock` to prevent crashes on stale shadow references.

### Test Coverage

- 7 unit tests covering: shadow round-trip through JSON and XML, flyout copy with nested inputs (two levels of shadows), the `blockToDom` recovery path (including `opt_noId` ID stripping), and shadow respawn after reporter disconnect
- 1 test that reliably failed before the `blockToDom` wrapper was added

### Manual Testing

- [x] Place two "set variable to" blocks from the palette. Put a reporter in the first one's VALUE slot. Delete the first block. Verify the second block's VALUE shadow is intact (not blank).
- [x] Open a previously-corrupted project (e.g., 1296008268). Verify inputs are restored and dragging reporters in/out doesn't crash (requires the companion scratch-editor change).
- [x] Verify undo/redo of block creation preserves shadow inputs
- [x] Verify duplicate (right-click) preserves shadow inputs
