### PR TITLE
Fix cursed inputs on duplicate/paste

### DIFF
--- a/src/checkable_continuous_flyout.ts
+++ b/src/checkable_continuous_flyout.ts
@@ -5,6 +5,7 @@
 import { ContinuousFlyout, type LabelFlyoutItem } from '@blockly/continuous-toolbox'
 import * as Blockly from 'blockly/core'
 import { CheckboxBubble } from './checkbox_bubble'
+import { stripIds } from './scratch_blocks_utils'
 import { StatusIndicatorLabel } from './status_indicator_label'
 import { STATUS_INDICATOR_LABEL_TYPE } from './status_indicator_label_flyout_inflater'
 
@@ -18,27 +19,6 @@ interface CheckboxIcon {
 
 function isCheckboxIcon(icon: Blockly.IIcon | undefined): icon is Blockly.IIcon & CheckboxIcon {
   return !!icon && typeof (icon as { setChecked?: unknown }).setChecked === 'function'
-}
-
-/**
- * Recursively strip `id` properties from a serialized block state tree
- * so that every block (including shadows and nested inputs) gets a fresh
- * ID when deserialized onto the workspace.
- * @param state A serialized block state object.
- */
-function stripIds(state: Blockly.serialization.blocks.State): void {
-  delete state.id
-  if (state.inputs) {
-    for (const inputName in state.inputs) {
-      const conn = state.inputs[inputName]
-      if (conn.shadow) stripIds(conn.shadow)
-      if (conn.block) stripIds(conn.block)
-    }
-  }
-  if (state.next) {
-    if (state.next.shadow) stripIds(state.next.shadow)
-    if (state.next.block) stripIds(state.next.block)
-  }
 }
 
 export class CheckableContinuousFlyout extends ContinuousFlyout {

--- a/src/scratch_block_paster.ts
+++ b/src/scratch_block_paster.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import * as Blockly from 'blockly/core'
+import { stripIds } from './scratch_blocks_utils'
 import type { ScratchCommentIcon } from './scratch_comment_icon'
 
 /**
@@ -22,6 +23,12 @@ class ScratchBlockPaster extends Blockly.clipboard.BlockPaster {
     workspace: Blockly.WorkspaceSvg,
     coordinate: Blockly.utils.Coordinate,
   ) {
+    // Strip all block IDs so that every block in the pasted tree (including
+    // shadows) gets a fresh ID. Without this, disposed shadows from the
+    // original block can reuse the same ID, causing the VM to think both
+    // blocks share the same shadow. Deleting one then destroys the other's
+    // shadow (forum topic 878291).
+    stripIds(copyData.blockState)
     const block = super.paste(copyData, workspace, coordinate)
     if (block?.type === 'argument_reporter_boolean' || block?.type === 'argument_reporter_string_number') {
       block.setDragStrategy(new Blockly.dragging.BlockDragStrategy(block))

--- a/src/scratch_blocks_utils.ts
+++ b/src/scratch_blocks_utils.ts
@@ -20,6 +20,31 @@
  * @file Utility methods for Scratch Blocks but not Blockly.
  * @author fenichel@google.com (Rachel Fenichel)
  */
+import type * as Blockly from 'blockly/core'
+
+/**
+ * Recursively strip `id` properties from a serialized block state tree
+ * so that every block (including shadows and nested inputs) gets a fresh
+ * ID when deserialized onto the workspace. This prevents two blocks from
+ * sharing the same shadow block in the VM, which would cause deleting
+ * one to destroy the other's shadow.
+ * @param state A serialized block state object.
+ */
+export function stripIds(state: Blockly.serialization.blocks.State): void {
+  delete state.id
+  if (state.inputs) {
+    for (const inputName in state.inputs) {
+      const conn = state.inputs[inputName]
+      if (conn.shadow) stripIds(conn.shadow)
+      if (conn.block) stripIds(conn.block)
+    }
+  }
+  if (state.next) {
+    if (state.next.shadow) stripIds(state.next.shadow)
+    if (state.next.block) stripIds(state.next.block)
+  }
+}
+
 /**
  * Compare strings with natural number sorting.
  * @param str1 First input.

--- a/tests/browser/block_duplicate_shadow.test.ts
+++ b/tests/browser/block_duplicate_shadow.test.ts
@@ -3,27 +3,27 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import * as Blockly from 'blockly/core'
-import { afterEach, assert, beforeEach, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, assert, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { CheckableContinuousFlyout } from '../../src/checkable_continuous_flyout'
+import { registerRecyclableBlockFlyoutInflater } from '../../src/recyclable_block_flyout_inflater'
 import { registerScratchBlockPaster } from '../../src/scratch_block_paster'
 
-// Browser test: duplicating a block with an obscured shadow must produce a
-// copy with unique shadow IDs. Without the stripIds fix in
-// ScratchBlockPaster.paste, the copy reuses the original's shadow IDs,
-// causing the VM to think both blocks share the same shadow. Deleting one
-// then destroys the other's shadow (forum topic 878291).
+// Browser tests for the shared-shadow-ID bug (forum topic 878291).
+// Both the duplicate/paste path and the flyout copy path must produce
+// blocks with unique shadow IDs. Without stripIds, disposed shadows
+// from the original reuse their IDs in the copy, causing the VM to
+// think both blocks share the same shadow.
 
 const BLOCK_TYPES = ['test_value_block', 'test_text_shadow', 'test_reporter']
 
-let container: HTMLElement
-let workspace: Blockly.WorkspaceSvg
+let container: HTMLElement | undefined
+let workspace: Blockly.WorkspaceSvg | undefined
 
 beforeEach(() => {
   container = document.createElement('div')
   container.style.width = '800px'
   container.style.height = '600px'
   document.body.appendChild(container)
-  workspace = Blockly.inject(container, {})
-  registerScratchBlockPaster()
 
   Blockly.defineBlocksWithJsonArray([
     {
@@ -47,9 +47,29 @@ beforeEach(() => {
   ])
 })
 
+// Save the default Blockly implementations so we can restore them after
+// all tests, preventing cross-suite leakage of Scratch-specific overrides.
+const DefaultInflater = Blockly.registry.getClass(Blockly.registry.Type.FLYOUT_INFLATER, 'block')
+
+beforeAll(() => {
+  registerScratchBlockPaster()
+  registerRecyclableBlockFlyoutInflater()
+})
+
+afterAll(() => {
+  // Restore the default block paster
+  Blockly.clipboard.registry.unregister(Blockly.clipboard.BlockPaster.TYPE)
+  Blockly.clipboard.registry.register(Blockly.clipboard.BlockPaster.TYPE, new Blockly.clipboard.BlockPaster())
+  // Restore the default flyout inflater
+  if (DefaultInflater) {
+    Blockly.registry.unregister(Blockly.registry.Type.FLYOUT_INFLATER, 'block')
+    Blockly.registry.register(Blockly.registry.Type.FLYOUT_INFLATER, 'block', DefaultInflater)
+  }
+})
+
 afterEach(() => {
-  workspace.dispose()
-  container.remove()
+  workspace?.dispose()
+  container?.remove()
   for (const t of BLOCK_TYPES) {
     delete Blockly.Blocks[t]
   }
@@ -57,26 +77,34 @@ afterEach(() => {
 
 describe('duplicate block shadow IDs (forum topic 878291)', () => {
   it('duplicated block gets unique shadow IDs, not shared with original', () => {
+    assert(container, 'Expected container from beforeEach')
+    workspace = Blockly.inject(container, {})
+
     // Create the original block with a shadow on VALUE
+    let original: Blockly.BlockSvg
+    let reporter: Blockly.BlockSvg
     Blockly.Events.disable()
-    const original = Blockly.serialization.blocks.append(
-      {
-        type: 'test_value_block',
-        inputs: {
-          VALUE: {
-            shadow: {
-              type: 'test_text_shadow',
-              fields: { TEXT: '0' },
+    try {
+      original = Blockly.serialization.blocks.append(
+        {
+          type: 'test_value_block',
+          inputs: {
+            VALUE: {
+              shadow: {
+                type: 'test_text_shadow',
+                fields: { TEXT: '0' },
+              },
             },
           },
         },
-      },
-      workspace,
-    ) as Blockly.BlockSvg
+        workspace,
+      ) as Blockly.BlockSvg
 
-    // Connect a reporter to obscure the shadow
-    const reporter = workspace.newBlock('test_reporter')
-    Blockly.Events.enable()
+      // Connect a reporter to obscure the shadow
+      reporter = workspace.newBlock('test_reporter')
+    } finally {
+      Blockly.Events.enable()
+    }
 
     const conn = original.getInput('VALUE')?.connection
     assert(conn, 'Expected VALUE connection')
@@ -112,5 +140,72 @@ describe('duplicate block shadow IDs (forum topic 878291)', () => {
     assert(respawned, 'Original shadow should respawn after copy is deleted')
     expect(respawned.isShadow()).toBe(true)
     expect(respawned.type).toBe('test_text_shadow')
+  })
+
+  it('two flyout copies get unique shadow IDs when first copy shadow is obscured', () => {
+    assert(container, 'Expected container from beforeEach')
+    // Inject with CheckableContinuousFlyout (which has the stripIds fix)
+    // and a toolbox that includes a block with a shadow input.
+    workspace = Blockly.inject(container, {
+      toolbox: {
+        kind: 'flyoutToolbox',
+        contents: [
+          {
+            kind: 'block',
+            type: 'test_value_block',
+            inputs: {
+              VALUE: {
+                shadow: {
+                  type: 'test_text_shadow',
+                  fields: { TEXT: '0' },
+                },
+              },
+            },
+          },
+        ],
+      },
+      plugins: {
+        flyoutsVerticalToolbox: CheckableContinuousFlyout,
+      },
+    })
+
+    const flyout = workspace.getFlyout()
+    assert(flyout, 'Expected workspace to have a flyout')
+
+    // Find the template block in the flyout
+    const flyoutBlocks = flyout.getWorkspace().getAllBlocks(false)
+    const template = flyoutBlocks.find((b) => b.type === 'test_value_block')
+    assert(template, 'Expected template block in flyout')
+
+    // First copy from flyout
+    const copy1 = flyout.createBlock(template)
+    const conn1 = copy1.getInput('VALUE')?.connection
+    assert(conn1, 'Expected VALUE connection on first copy')
+    const shadow1 = conn1.targetBlock()
+    assert(shadow1, 'Expected shadow on first copy')
+    expect(shadow1.isShadow()).toBe(true)
+    const shadow1Id = shadow1.id
+
+    // Obscure the first copy's shadow by connecting a reporter
+    let reporter: Blockly.BlockSvg
+    Blockly.Events.disable()
+    try {
+      reporter = workspace.newBlock('test_reporter')
+    } finally {
+      Blockly.Events.enable()
+    }
+    const reporterOutput = reporter.outputConnection
+    assert(reporterOutput, 'Expected reporter output connection')
+    conn1.connect(reporterOutput)
+
+    // Second copy from flyout — its shadow must get a different ID
+    const copy2 = flyout.createBlock(template)
+    const conn2 = copy2.getInput('VALUE')?.connection
+    assert(conn2, 'Expected VALUE connection on second copy')
+    const shadow2 = conn2.targetBlock()
+    assert(shadow2, 'Expected shadow on second copy')
+    expect(shadow2.isShadow()).toBe(true)
+
+    expect(shadow2.id).not.toBe(shadow1Id)
   })
 })

--- a/tests/browser/block_duplicate_shadow.test.ts
+++ b/tests/browser/block_duplicate_shadow.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Copyright 2026 Scratch Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import * as Blockly from 'blockly/core'
+import { afterEach, assert, beforeEach, describe, expect, it } from 'vitest'
+import { registerScratchBlockPaster } from '../../src/scratch_block_paster'
+
+// Browser test: duplicating a block with an obscured shadow must produce a
+// copy with unique shadow IDs. Without the stripIds fix in
+// ScratchBlockPaster.paste, the copy reuses the original's shadow IDs,
+// causing the VM to think both blocks share the same shadow. Deleting one
+// then destroys the other's shadow (forum topic 878291).
+
+const BLOCK_TYPES = ['test_value_block', 'test_text_shadow', 'test_reporter']
+
+let container: HTMLElement
+let workspace: Blockly.WorkspaceSvg
+
+beforeEach(() => {
+  container = document.createElement('div')
+  container.style.width = '800px'
+  container.style.height = '600px'
+  document.body.appendChild(container)
+  workspace = Blockly.inject(container, {})
+  registerScratchBlockPaster()
+
+  Blockly.defineBlocksWithJsonArray([
+    {
+      type: 'test_value_block',
+      message0: 'set to %1',
+      args0: [{ type: 'input_value', name: 'VALUE' }],
+      previousStatement: null,
+      nextStatement: null,
+    },
+    {
+      type: 'test_text_shadow',
+      message0: '%1',
+      args0: [{ type: 'field_input', name: 'TEXT' }],
+      output: 'String',
+    },
+    {
+      type: 'test_reporter',
+      message0: 'answer',
+      output: 'String',
+    },
+  ])
+})
+
+afterEach(() => {
+  workspace.dispose()
+  container.remove()
+  for (const t of BLOCK_TYPES) {
+    delete Blockly.Blocks[t]
+  }
+})
+
+describe('duplicate block shadow IDs (forum topic 878291)', () => {
+  it('duplicated block gets unique shadow IDs, not shared with original', () => {
+    // Create the original block with a shadow on VALUE
+    Blockly.Events.disable()
+    const original = Blockly.serialization.blocks.append(
+      {
+        type: 'test_value_block',
+        inputs: {
+          VALUE: {
+            shadow: {
+              type: 'test_text_shadow',
+              fields: { TEXT: '0' },
+            },
+          },
+        },
+      },
+      workspace,
+    ) as Blockly.BlockSvg
+
+    // Connect a reporter to obscure the shadow
+    const reporter = workspace.newBlock('test_reporter')
+    Blockly.Events.enable()
+
+    const conn = original.getInput('VALUE')?.connection
+    assert(conn, 'Expected VALUE connection')
+    const reporterOutput = reporter.outputConnection
+    assert(reporterOutput, 'Expected reporter output connection')
+    conn.connect(reporterOutput)
+
+    // Capture the original's shadow state before duplication
+    const originalShadowState = conn.getShadowState()
+    assert(originalShadowState, 'Expected shadow state on original after connecting reporter')
+    const originalShadowId = originalShadowState.id
+    assert(originalShadowId, 'Expected shadow state to have an ID')
+
+    // Duplicate via the actual clipboard path (toCopyData + paste)
+    const copyData = original.toCopyData()
+    assert(copyData, 'Expected toCopyData to return data')
+    const copyResult = Blockly.clipboard.paste(copyData, workspace)
+    assert(copyResult, 'Expected paste to return a block')
+    const copy = copyResult as unknown as Blockly.BlockSvg
+
+    // The copy's shadow should have a DIFFERENT ID than the original's
+    const copyConn = copy.getInput('VALUE')?.connection
+    assert(copyConn, 'Expected VALUE connection on copy')
+    const copyShadowState = copyConn.getShadowState()
+    assert(copyShadowState, 'Expected shadow state on copy')
+
+    expect(copyShadowState.id).not.toBe(originalShadowId)
+
+    // Verify: deleting the copy does not affect the original's shadow
+    copy.dispose()
+    reporterOutput.disconnect()
+    const respawned = conn.targetBlock()
+    assert(respawned, 'Original shadow should respawn after copy is deleted')
+    expect(respawned.isShadow()).toBe(true)
+    expect(respawned.type).toBe('test_text_shadow')
+  })
+})


### PR DESCRIPTION
### Resolves

- Yet another facet of the cursed inputs problem

### Proposed Changes

- Factor `stripIds` out of the flyout and into `scratch_blocks_utils.ts`
- Call `stripIds` from `ScratchBlockPaster.paste` as well as from the flyout path

### Reason for Changes

This is another place where we duplicate blocks, leading to duplicate IDs unless we fix it in post:tm:.

### Test Coverage

Added two tests:

- duplicate a block and make sure the IDs don't overlap (this fix)
- drag a block from the flyout/palette and make sure it gets new IDs (additional high-level test for the previous fix)