### PR TITLE
Fix: clear angle field event wrappers to prevent double-unbind

### DIFF
--- a/src/fields/scratch_field_angle.ts
+++ b/src/fields/scratch_field_angle.ts
@@ -140,12 +140,15 @@ class ScratchFieldAngle extends Blockly.FieldNumber {
     this.gauge = undefined
     if (this.mouseDownWrapper_) {
       Blockly.browserEvents.unbind(this.mouseDownWrapper_)
+      this.mouseDownWrapper_ = undefined
     }
     if (this.mouseUpWrapper) {
       Blockly.browserEvents.unbind(this.mouseUpWrapper)
+      this.mouseUpWrapper = undefined
     }
     if (this.mouseMoveWrapper) {
       Blockly.browserEvents.unbind(this.mouseMoveWrapper)
+      this.mouseMoveWrapper = undefined
     }
   }
 
@@ -298,9 +301,11 @@ class ScratchFieldAngle extends Blockly.FieldNumber {
   onMouseUp() {
     if (this.mouseMoveWrapper) {
       Blockly.browserEvents.unbind(this.mouseMoveWrapper)
+      this.mouseMoveWrapper = undefined
     }
     if (this.mouseUpWrapper) {
       Blockly.browserEvents.unbind(this.mouseUpWrapper)
+      this.mouseUpWrapper = undefined
     }
   }
 

--- a/tests/unit/scratch_field_angle.test.ts
+++ b/tests/unit/scratch_field_angle.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2026 Scratch Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import * as Blockly from 'blockly/core'
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+import { registerScratchFieldAngle } from '../../src/fields/scratch_field_angle'
+
+type ScratchFieldAngleForTest = Blockly.FieldNumber & {
+  mouseMoveWrapper?: Blockly.browserEvents.Data
+  mouseUpWrapper?: Blockly.browserEvents.Data
+  onMouseUp(): void
+}
+
+beforeAll(() => {
+  registerScratchFieldAngle()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('ScratchFieldAngle', () => {
+  it('does not unbind drag listeners again after mouseup', () => {
+    const field = Blockly.fieldRegistry.TEST_ONLY.fromJsonInternal({
+      type: 'field_angle',
+      angle: 90,
+    }) as ScratchFieldAngleForTest
+    const mouseMoveWrapper = [{}] as Blockly.browserEvents.Data
+    const mouseUpWrapper = [{}] as Blockly.browserEvents.Data
+    field.mouseMoveWrapper = mouseMoveWrapper
+    field.mouseUpWrapper = mouseUpWrapper
+
+    const unbind = vi.spyOn(Blockly.browserEvents, 'unbind').mockImplementation(() => {})
+
+    field.onMouseUp()
+    field.dispose()
+
+    expect(unbind).toHaveBeenCalledTimes(2)
+    expect(unbind).toHaveBeenCalledWith(mouseMoveWrapper)
+    expect(unbind).toHaveBeenCalledWith(mouseUpWrapper)
+  })
+})


### PR DESCRIPTION
### Resolves

- scratchfoundation/scratch-editor#537 — "Workspace Update Error" after using the angle picker, which then leaves blocks stuck and duplicated across sprites

### Proposed Changes

- In `src/fields/scratch_field_angle.ts`, null out `mouseDownWrapper_`, `mouseUpWrapper`, and `mouseMoveWrapper` right after `Blockly.browserEvents.unbind`, in both `onMouseUp` and `dispose`

### Reason for Changes

After dragging the angle picker, `onMouseUp` unbinds the move/up wrappers but leaves the references populated. When the field is later disposed (or mouseup fires again), `dispose` sees those references and unbinds them a second time — which blows up inside Blockly and bubbles out as a Workspace Update Error. Blockly then aborts the pending change and the workspace is left in the weird duplicated/stuck state from #537.

Setting the wrapper to `undefined` after unbind is what core Blockly does everywhere else for this pattern, and makes the handlers safe to call twice.

### Test Coverage

- Added `tests/unit/scratch_field_angle.test.ts`: after `onMouseUp`, calling `dispose` must not re-unbind the drag wrappers. Spies on `Blockly.browserEvents.unbind` and asserts it's called twice total, not four times.
- `npm test` and lint pass locally.
