### PR TITLE
fix: prevent stripIds from corrupting original block shadow state

### DIFF
--- a/src/checkable_continuous_flyout.ts
+++ b/src/checkable_continuous_flyout.ts
@@ -50,8 +50,7 @@ export class CheckableContinuousFlyout extends ContinuousFlyout {
     // from a previous copy can reuse the flyout's IDs, causing two workspace
     // blocks to share the same shadow in the VM. Deleting one then destroys
     // the other's shadow (bug 878291).
-    stripIds(json)
-    return json
+    return stripIds(json)
   }
 
   /**

--- a/src/scratch_block_paster.ts
+++ b/src/scratch_block_paster.ts
@@ -28,7 +28,7 @@ class ScratchBlockPaster extends Blockly.clipboard.BlockPaster {
     // original block can reuse the same ID, causing the VM to think both
     // blocks share the same shadow. Deleting one then destroys the other's
     // shadow (forum topic 878291).
-    stripIds(copyData.blockState)
+    copyData = { ...copyData, blockState: stripIds(copyData.blockState) }
     const block = super.paste(copyData, workspace, coordinate)
     if (block?.type === 'argument_reporter_boolean' || block?.type === 'argument_reporter_string_number') {
       block.setDragStrategy(new Blockly.dragging.BlockDragStrategy(block))

--- a/src/scratch_blocks_utils.ts
+++ b/src/scratch_blocks_utils.ts
@@ -23,26 +23,38 @@
 import type * as Blockly from 'blockly/core'
 
 /**
- * Recursively strip `id` properties from a serialized block state tree
- * so that every block (including shadows and nested inputs) gets a fresh
- * ID when deserialized onto the workspace. This prevents two blocks from
- * sharing the same shadow block in the VM, which would cause deleting
- * one to destroy the other's shadow.
+ * Return a new serialized block state object with `id` properties removed
+ * from this block and recursively from nested `inputs`/`next` block and
+ * shadow states so they get fresh IDs when deserialized onto the workspace.
+ * The input state is NOT modified. Blockly's serialization shares shadow
+ * state objects by reference with the live workspace, so mutating the
+ * serialized tree in place would corrupt the original block's internal
+ * shadow state.
  * @param state A serialized block state object.
+ * @returns A new state object with `id` properties removed from serialized
+ *     block/shadow subtrees.
  */
-export function stripIds(state: Blockly.serialization.blocks.State): void {
-  delete state.id
-  if (state.inputs) {
-    for (const inputName in state.inputs) {
-      const conn = state.inputs[inputName]
-      if (conn.shadow) stripIds(conn.shadow)
-      if (conn.block) stripIds(conn.block)
+export function stripIds(state: Blockly.serialization.blocks.State): Blockly.serialization.blocks.State {
+  const copy: Blockly.serialization.blocks.State = { ...state }
+  delete copy.id
+  if (copy.inputs) {
+    const inputs: typeof copy.inputs = {}
+    for (const inputName in copy.inputs) {
+      const conn = copy.inputs[inputName]
+      inputs[inputName] = {
+        ...(conn.shadow && { shadow: stripIds(conn.shadow) }),
+        ...(conn.block && { block: stripIds(conn.block) }),
+      }
+    }
+    copy.inputs = inputs
+  }
+  if (copy.next) {
+    copy.next = {
+      ...(copy.next.shadow && { shadow: stripIds(copy.next.shadow) }),
+      ...(copy.next.block && { block: stripIds(copy.next.block) }),
     }
   }
-  if (state.next) {
-    if (state.next.shadow) stripIds(state.next.shadow)
-    if (state.next.block) stripIds(state.next.block)
-  }
+  return copy
 }
 
 /**

--- a/tests/unit/scratch_blocks_utils.test.ts
+++ b/tests/unit/scratch_blocks_utils.test.ts
@@ -2,8 +2,9 @@
  * Copyright 2026 Scratch Foundation
  * SPDX-License-Identifier: Apache-2.0
  */
-import { describe, expect, it } from 'vitest'
-import { compareStrings } from '../../src/scratch_blocks_utils'
+import * as Blockly from 'blockly/core'
+import { afterEach, assert, beforeEach, describe, expect, it } from 'vitest'
+import { compareStrings, stripIds } from '../../src/scratch_blocks_utils'
 
 describe('compareStrings', () => {
   describe('numeric sorting', () => {
@@ -51,5 +52,175 @@ describe('compareStrings', () => {
       // Just ensure it does not throw
       expect(() => compareStrings('a-b', 'a_b')).not.toThrow()
     })
+  })
+})
+
+describe('stripIds', () => {
+  it('removes id from the top-level block', () => {
+    const state = { type: 'motion_movesteps', id: 'abc' }
+    const result = stripIds(state)
+    expect(result.id).toBeUndefined()
+    expect(result.type).toBe('motion_movesteps')
+  })
+
+  it('does not mutate the input state', () => {
+    const state = { type: 'motion_movesteps', id: 'abc' }
+    stripIds(state)
+    expect(state.id).toBe('abc')
+  })
+
+  it('removes ids from shadow blocks in inputs without mutating originals', () => {
+    const shadow = { type: 'math_number', id: 'shadow_1', fields: { NUM: 0 } }
+    const state = {
+      type: 'motion_setx',
+      id: 'block_1',
+      inputs: { X: { shadow } },
+    }
+
+    const result = stripIds(state)
+
+    expect(result.id).toBeUndefined()
+    expect(result.inputs?.X.shadow?.id).toBeUndefined()
+    expect(result.inputs?.X.shadow?.type).toBe('math_number')
+    // Original must be untouched
+    expect(shadow.id).toBe('shadow_1')
+    expect(state.id).toBe('block_1')
+  })
+
+  it('removes ids from block children in inputs', () => {
+    const child = { type: 'motion_xposition', id: 'child_1' }
+    const shadow = { type: 'math_number', id: 'shadow_1' }
+    const state = {
+      type: 'motion_setx',
+      id: 'block_1',
+      inputs: { X: { shadow, block: child } },
+    }
+
+    const result = stripIds(state)
+
+    expect(result.inputs?.X.shadow?.id).toBeUndefined()
+    expect(result.inputs?.X.block?.id).toBeUndefined()
+    // Originals untouched
+    expect(shadow.id).toBe('shadow_1')
+    expect(child.id).toBe('child_1')
+  })
+
+  it('removes ids from next connections without mutating originals', () => {
+    const nextBlock = { type: 'motion_movesteps', id: 'next_1' }
+    const state = {
+      type: 'motion_movesteps',
+      id: 'block_1',
+      next: { block: nextBlock },
+    }
+
+    const result = stripIds(state)
+
+    expect(result.next?.block?.id).toBeUndefined()
+    expect(nextBlock.id).toBe('next_1')
+  })
+
+  it('handles deeply nested inputs', () => {
+    const innerShadow = { type: 'math_number', id: 'inner_shadow' }
+    const innerBlock = {
+      type: 'operator_add',
+      id: 'inner',
+      inputs: { NUM1: { shadow: innerShadow } },
+    }
+    const state = {
+      type: 'motion_setx',
+      id: 'outer',
+      inputs: { X: { block: innerBlock } },
+    }
+
+    const result = stripIds(state)
+
+    expect(result.inputs?.X.block?.inputs?.NUM1.shadow?.id).toBeUndefined()
+    expect(innerShadow.id).toBe('inner_shadow')
+  })
+})
+
+describe('stripIds with live Blockly workspace', () => {
+  let workspace: Blockly.Workspace
+
+  beforeEach(() => {
+    Blockly.defineBlocksWithJsonArray([
+      {
+        type: 'test_value_input',
+        message0: 'value %1',
+        args0: [{ type: 'input_value', name: 'X' }],
+        previousStatement: null,
+        nextStatement: null,
+      },
+      {
+        type: 'test_reporter',
+        message0: 'reporter',
+        output: null,
+      },
+      {
+        type: 'test_shadow',
+        message0: '%1',
+        args0: [{ type: 'field_number', name: 'NUM', value: 0 }],
+        output: null,
+      },
+    ])
+    workspace = new Blockly.Workspace()
+  })
+
+  afterEach(() => {
+    workspace.dispose()
+    for (const type of ['test_value_input', 'test_reporter', 'test_shadow']) {
+      delete Blockly.Blocks[type]
+    }
+  })
+
+  it('does not corrupt the original block shadow state when stripping a serialized copy', () => {
+    // Simulate the duplication bug: create a block with a shadow input,
+    // cover the shadow with a reporter, serialize with saveIds:false
+    // (same as toCopyData), then call stripIds on the result.
+    // The original block's connection.shadowState must be untouched.
+
+    // Create a block with a shadow in its input
+    const parent = workspace.newBlock('test_value_input')
+    const input = parent.getInput('X')
+    assert(input?.connection, 'test_value_input should have an X input with a connection')
+    const inputConn = input.connection
+    inputConn.setShadowState({ type: 'test_shadow', id: 'original_shadow_id' })
+
+    // Cover the shadow with a non-shadow reporter
+    const reporter = workspace.newBlock('test_reporter')
+    assert(reporter.outputConnection, 'test_reporter should have an output connection')
+    inputConn.connect(reporter.outputConnection)
+
+    // The shadow is now covered; getShadowState() returns the stored state
+    const shadowStateBefore = inputConn.getShadowState()
+    assert(shadowStateBefore, 'shadow state should exist while covered')
+    expect(shadowStateBefore.id).toBe('original_shadow_id')
+
+    // Serialize the parent (same path as toCopyData with saveIds:false).
+    // saveConnection returns shadowState by reference for covered shadows.
+    const serialized = Blockly.serialization.blocks.save(parent, { saveIds: false })
+    assert(serialized, 'serialization should succeed')
+
+    // The serialized shadow should carry the original id (it's a shared reference)
+    assert(serialized.inputs, 'serialized state should have inputs')
+    const serializedConn = serialized.inputs.X
+    assert(serializedConn, 'serialized state should have X connection')
+    assert(serializedConn.shadow, 'serialized X connection should include the shadow')
+    expect(serializedConn.shadow.id).toBe('original_shadow_id')
+
+    // This is what ScratchBlockPaster.paste does before deserializing the copy
+    const stripped = stripIds(serialized)
+
+    // The stripped copy should have the shadow id removed
+    assert(stripped.inputs, 'stripped state should have inputs')
+    const strippedConn = stripped.inputs.X
+    assert(strippedConn, 'stripped state should have X connection')
+    assert(strippedConn.shadow, 'stripped X connection should include the shadow')
+    expect(strippedConn.shadow.id).toBeUndefined()
+
+    // The original block's shadow state must still have its id
+    const shadowStateAfter = inputConn.getShadowState()
+    assert(shadowStateAfter, 'shadow state should still exist')
+    expect(shadowStateAfter.id).toBe('original_shadow_id')
   })
 })


### PR DESCRIPTION
### Resolves

- Duplicate-block data loss reported by @Joeclinton1 on scratchfoundation/scratch-editor#533 (2026-04-23), diagnosed by @nimeratus
- Incomplete coverage of the shared shadow ID fix from #3560 + #3563

### Proposed Changes

- Change `stripIds` from an in-place mutation to a pure function that returns a new state tree
- Update both call sites (`ScratchBlockPaster.paste`, `CheckableContinuousFlyout.serializeBlock`) to use the return value

### Reason for Changes

Blockly's `saveConnection` returns shadow state objects by reference from the live workspace when a shadow is covered by a non-shadow block. `stripIds` mutated this shared reference in place, deleting the shadow's id from the original block's internal `connection.shadowState`. (I had previously been operating as if `stripIds` was running on a copy that we could mutate, but... not so much.)

When the user later uncovered the shadow, `respawnShadow_` created a replacement with a new random id instead of reusing the existing one. The VM received a create event for this new shadow with `topLevel: true` and added it to `_scripts`. On sprite switch, `toXML` serialized the orphaned top-level shadow as a root `<shadow>` element.

Blockly cannot load a top-level shadow, so `clearWorkspaceAndLoadFromXml` threw "Workspace Update Error", preventing all subsequent scripts from rendering.

### Test Coverage

- 6 unit tests: `stripIds` returns a copy and does not mutate the input, covering top-level blocks, shadow inputs, block children, next connections, and deeply nested inputs
- 1 behavioral test: serializing a block with a covered shadow and calling `stripIds` does not corrupt
`connection.shadowState` (headless Blockly workspace with real connections)

### Manual Testing

- End-to-end browser verification: without this fix, orphaned top-level shadow appears in VM `_scripts` after duplicate + uncover + sprite switch; with the fix, shadow id is preserved and zero top-level shadows appear
- Repeat @Joeclinton1's repro steps in production build and confirm no "Workspace Update Error"
