### PR TITLE
fix: preserve stack below when deleting a top stack block

### DIFF
--- a/src/context_menu_items.ts
+++ b/src/context_menu_items.ts
@@ -45,6 +45,7 @@ export function registerDeleteBlock() {
 
 export function deleteBlock(block: Blockly.Block) {
   if (block.workspace.isFlyout) return
+  if (!block.isDeletable() || block.isShadow()) return
 
   const priorGroup = Blockly.Events.getGroup()
   const shouldStartGroup = !priorGroup

--- a/src/context_menu_items.ts
+++ b/src/context_menu_items.ts
@@ -47,7 +47,10 @@ export function deleteBlock(block: Blockly.Block) {
   if (block.workspace.isFlyout) return
 
   const priorGroup = Blockly.Events.getGroup()
-  Blockly.Events.setGroup(true)
+  const shouldStartGroup = !priorGroup
+  if (shouldStartGroup) {
+    Blockly.Events.setGroup(true)
+  }
   try {
     if (!block.outputConnection && !block.previousConnection?.isConnected() && block.nextConnection?.isConnected()) {
       block.nextConnection.disconnect()
@@ -61,7 +64,9 @@ export function deleteBlock(block: Blockly.Block) {
       block.dispose(!block.outputConnection)
     }
   } finally {
-    Blockly.Events.setGroup(priorGroup)
+    if (shouldStartGroup) {
+      Blockly.Events.setGroup(false)
+    }
   }
 }
 

--- a/src/context_menu_items.ts
+++ b/src/context_menu_items.ts
@@ -34,15 +34,35 @@ export function registerDeleteBlock() {
       if (!scope.block) {
         return
       }
-      Blockly.Events.setGroup(true)
-      scope.block.dispose(true, true)
-      Blockly.Events.setGroup(false)
+      deleteBlock(scope.block)
     },
     scopeType: Blockly.ContextMenuRegistry.ScopeType.BLOCK,
     id: 'blockDelete',
     weight: 6,
   }
   Blockly.ContextMenuRegistry.registry.register(deleteOption)
+}
+
+export function deleteBlock(block: Blockly.Block) {
+  if (block.workspace.isFlyout) return
+
+  const priorGroup = Blockly.Events.getGroup()
+  Blockly.Events.setGroup(true)
+  try {
+    if (!block.outputConnection && !block.previousConnection?.isConnected()) {
+      block.nextConnection?.disconnect()
+    }
+    if (block.workspace instanceof Blockly.WorkspaceSvg) {
+      block.workspace.hideChaff()
+    }
+    if (block instanceof Blockly.BlockSvg) {
+      block.dispose(!block.outputConnection, true)
+    } else {
+      block.dispose(!block.outputConnection)
+    }
+  } finally {
+    Blockly.Events.setGroup(priorGroup)
+  }
 }
 
 function getDeletableBlocksInStack(block: Blockly.Block): Blockly.Block[] {

--- a/src/context_menu_items.ts
+++ b/src/context_menu_items.ts
@@ -49,8 +49,8 @@ export function deleteBlock(block: Blockly.Block) {
   const priorGroup = Blockly.Events.getGroup()
   Blockly.Events.setGroup(true)
   try {
-    if (!block.outputConnection && !block.previousConnection?.isConnected()) {
-      block.nextConnection?.disconnect()
+    if (!block.outputConnection && !block.previousConnection?.isConnected() && block.nextConnection?.isConnected()) {
+      block.nextConnection.disconnect()
     }
     if (block.workspace instanceof Blockly.WorkspaceSvg) {
       block.workspace.hideChaff()

--- a/src/index.ts
+++ b/src/index.ts
@@ -189,6 +189,9 @@ if (!blockCommentMenuItem) {
 }
 Blockly.ContextMenuRegistry.registry.unregister('blockDelete')
 contextMenuItems.registerDeleteBlock()
+Blockly.BlockSvg.prototype.checkAndDelete = function () {
+  contextMenuItems.deleteBlock(this)
+}
 contextMenuItems.registerDuplicateBlock()
 contextMenuItems.registerCopyShortcut()
 contextMenuItems.registerCutShortcut()

--- a/tests/unit/context_menu_items.test.ts
+++ b/tests/unit/context_menu_items.test.ts
@@ -190,6 +190,16 @@ describe('registerDeleteBlock', () => {
     expect(second.getParent()).toBeNull()
   })
 
+  it('callback deletes a lone stack block', () => {
+    const block = workspace.newBlock('test_stack_block')
+
+    const item = Blockly.ContextMenuRegistry.registry.getItem('blockDelete')
+    assert(item, 'Expected blockDelete item to be registered')
+    ;(item.callback as (scope: Blockly.ContextMenuRegistry.Scope) => void)({ block: asBlockSvg(block) })
+
+    expect(workspace.getAllBlocks(false)).toEqual([])
+  })
+
   it('checkAndDelete override routes through deleteBlock and preserves next block', () => {
     const first = workspace.newBlock('test_stack_block')
     const second = workspace.newBlock('test_stack_block')
@@ -202,7 +212,7 @@ describe('registerDeleteBlock', () => {
     // Mirror the wiring in src/index.ts so we cover the keyboard-delete path.
     // Tests use plain Workspace (not WorkspaceSvg), so blocks aren't BlockSvg
     // instances — invoke the override via prototype to simulate the call site.
-    const originalCheckAndDelete = Blockly.BlockSvg.prototype.checkAndDelete
+    const originalCheckAndDelete = Reflect.get(Blockly.BlockSvg.prototype, 'checkAndDelete')
     Blockly.BlockSvg.prototype.checkAndDelete = function () {
       deleteBlock(this)
     }

--- a/tests/unit/context_menu_items.test.ts
+++ b/tests/unit/context_menu_items.test.ts
@@ -4,7 +4,7 @@
  */
 import * as Blockly from 'blockly/core'
 import { afterAll, afterEach, assert, beforeAll, beforeEach, describe, expect, it } from 'vitest'
-import { registerDeleteBlock } from '../../src/context_menu_items'
+import { deleteBlock, registerDeleteBlock } from '../../src/context_menu_items'
 
 // Tests for the scratch-specific delete context menu override (registerDeleteBlock).
 // The copy/cut/paste override (registerDuplicateBlock, issue #3470) is tested
@@ -170,5 +170,49 @@ describe('registerDeleteBlock', () => {
       delete Blockly.Blocks.test_value_block
       delete Blockly.Blocks.test_output_block
     }
+  })
+
+  it('callback deletes only a top stack block and preserves its next block', () => {
+    const first = workspace.newBlock('test_stack_block')
+    const second = workspace.newBlock('test_stack_block')
+    const nextConn = first.nextConnection
+    const prevConn = second.previousConnection
+    assert(nextConn, 'Expected next connection')
+    assert(prevConn, 'Expected previous connection')
+    nextConn.connect(prevConn)
+
+    const item = Blockly.ContextMenuRegistry.registry.getItem('blockDelete')
+    assert(item, 'Expected blockDelete item to be registered')
+    const callback = item.callback as (scope: Blockly.ContextMenuRegistry.Scope) => void
+    callback({ block: asBlockSvg(first) })
+
+    expect(workspace.getAllBlocks(false)).toEqual([second])
+    expect(second.getParent()).toBeNull()
+  })
+
+  it('checkAndDelete override routes through deleteBlock and preserves next block', () => {
+    const first = workspace.newBlock('test_stack_block')
+    const second = workspace.newBlock('test_stack_block')
+    const nextConn = first.nextConnection
+    const prevConn = second.previousConnection
+    assert(nextConn, 'Expected next connection')
+    assert(prevConn, 'Expected previous connection')
+    nextConn.connect(prevConn)
+
+    // Mirror the wiring in src/index.ts so we cover the keyboard-delete path.
+    // Tests use plain Workspace (not WorkspaceSvg), so blocks aren't BlockSvg
+    // instances — invoke the override via prototype to simulate the call site.
+    const originalCheckAndDelete = Blockly.BlockSvg.prototype.checkAndDelete
+    Blockly.BlockSvg.prototype.checkAndDelete = function () {
+      deleteBlock(this)
+    }
+    try {
+      Blockly.BlockSvg.prototype.checkAndDelete.call(first)
+    } finally {
+      Blockly.BlockSvg.prototype.checkAndDelete = originalCheckAndDelete
+    }
+
+    expect(workspace.getAllBlocks(false)).toEqual([second])
+    expect(second.getParent()).toBeNull()
   })
 })

--- a/tests/unit/context_menu_items.test.ts
+++ b/tests/unit/context_menu_items.test.ts
@@ -200,6 +200,24 @@ describe('registerDeleteBlock', () => {
     expect(workspace.getAllBlocks(false)).toEqual([])
   })
 
+  it('deleteBlock ignores non-deletable blocks', () => {
+    const block = workspace.newBlock('test_stack_block')
+    block.setDeletable(false)
+
+    deleteBlock(block)
+
+    expect(workspace.getAllBlocks(false)).toEqual([block])
+  })
+
+  it('deleteBlock ignores shadow blocks', () => {
+    const block = workspace.newBlock('test_stack_block')
+    block.setShadow(true)
+
+    deleteBlock(block)
+
+    expect(workspace.getAllBlocks(false)).toEqual([block])
+  })
+
   it('callback reuses an active event group', () => {
     const block = workspace.newBlock('test_stack_block')
     const originalSetGroup = Reflect.get(Blockly.Events, 'setGroup')

--- a/tests/unit/context_menu_items.test.ts
+++ b/tests/unit/context_menu_items.test.ts
@@ -200,6 +200,29 @@ describe('registerDeleteBlock', () => {
     expect(workspace.getAllBlocks(false)).toEqual([])
   })
 
+  it('callback reuses an active event group', () => {
+    const block = workspace.newBlock('test_stack_block')
+    const originalSetGroup = Reflect.get(Blockly.Events, 'setGroup')
+    const setGroupCalls: (boolean | string)[] = []
+
+    Blockly.Events.setGroup('outerGroup')
+    Blockly.Events.setGroup = (state: boolean | string) => {
+      setGroupCalls.push(state)
+      originalSetGroup(state)
+    }
+    try {
+      const item = Blockly.ContextMenuRegistry.registry.getItem('blockDelete')
+      assert(item, 'Expected blockDelete item to be registered')
+      ;(item.callback as (scope: Blockly.ContextMenuRegistry.Scope) => void)({ block: asBlockSvg(block) })
+
+      expect(setGroupCalls).not.toContain(true)
+      expect(Blockly.Events.getGroup()).toBe('outerGroup')
+    } finally {
+      Blockly.Events.setGroup = originalSetGroup
+      Blockly.Events.setGroup(false)
+    }
+  })
+
   it('checkAndDelete override routes through deleteBlock and preserves next block', () => {
     const first = workspace.newBlock('test_stack_block')
     const second = workspace.newBlock('test_stack_block')


### PR DESCRIPTION
### Resolves

- scratchfoundation/scratch-blocks#3655 (reported by @Joeclinton1 / moved by @cwillisf)
  - From @cwillisf: I edited the line above when I created scratchfoundation/scratch-blocks#3655 as a sub-issue of scratchfoundation/scratch-editor#533

Deleting a hat block (or any top-of-stack block) via right-click → Delete Block also deletes every block connected below it. Keyboard Delete/Backspace has the same bug. Expected: only the top block is removed; the stack below stays.

### Proposed Changes

- Extract a shared `deleteBlock` helper in `context_menu_items.ts`. For a top stack block (no `previousConnection` target), disconnect `nextConnection` before `dispose` so the block below is left as a new top block.
- Route `BlockSvg.prototype.checkAndDelete` through the same helper in `index.ts` so keyboard delete matches the context-menu path.

### Reason for Changes

`dispose(healStack=true)` on a top block has nothing to heal to, so the next block gets disposed with it. Explicitly detaching fixes both paths through one helper.

### Test Coverage

Two unit tests in `tests/unit/context_menu_items.test.ts` covering both delete paths. Both fail without the fix.

Manually verified in scratch-editor (right-click + keyboard) that deleting a hat leaves its stack intact, mid-stack delete still heals above↔below, reporter delete is unaffected, and undo restores in one step.