### PR TITLE
ci: run build and test on pull requests

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,13 @@
 name: build-scratch-blocks
 on:
   push: # Runs whenever a commit is pushed to the repository
+  pull_request: # Runs on pull requests (including from forks)
   workflow_dispatch: # Allows you to run this workflow manually from the Actions tab
+
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Resolves

External PRs (e.g. #3571) only ran commitlint and the CLA assistant but never built or tested the code, even after a maintainer approved workflows to run.

### Proposed Changes

- Add `pull_request` trigger to the `deploy.yml` workflow so lint, build, and test run on PRs (including from forks)
- Add a concurrency group with `cancel-in-progress: true` so re-pushes to a PR branch cancel stale runs

### Reason for Changes

The `deploy.yml` workflow only triggered on `push` and `workflow_dispatch`. Since fork pushes don't fire `push` events on the base repo, external contributors got no build or test feedback on their PRs.

### Test Coverage

This PR itself serves as the test: the `build-scratch-blocks` workflow should now appear in the checks for this PR with lint and build-and-test jobs. `semantic-release` will dry-run safely on this non-release branch.