### PR TITLE
test: cover ScratchFieldAngle wrapper-cleanup invariants

### DIFF
--- a/tests/unit/scratch_field_angle.test.ts
+++ b/tests/unit/scratch_field_angle.test.ts
@@ -7,10 +7,17 @@ import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
 import { registerScratchFieldAngle } from '../../src/fields/scratch_field_angle'
 
 type ScratchFieldAngleForTest = Blockly.FieldNumber & {
+  mouseDownWrapper_?: Blockly.browserEvents.Data
   mouseMoveWrapper?: Blockly.browserEvents.Data
   mouseUpWrapper?: Blockly.browserEvents.Data
   onMouseUp(): void
 }
+
+const makeField = () =>
+  Blockly.fieldRegistry.TEST_ONLY.fromJsonInternal({
+    type: 'field_angle',
+    angle: 90,
+  }) as ScratchFieldAngleForTest
 
 beforeAll(() => {
   registerScratchFieldAngle()
@@ -22,21 +29,80 @@ afterEach(() => {
 
 describe('ScratchFieldAngle', () => {
   it('does not unbind drag listeners again after mouseup', () => {
-    const field = Blockly.fieldRegistry.TEST_ONLY.fromJsonInternal({
-      type: 'field_angle',
-      angle: 90,
-    }) as ScratchFieldAngleForTest
+    const field = makeField()
     const mouseMoveWrapper = [{}] as Blockly.browserEvents.Data
     const mouseUpWrapper = [{}] as Blockly.browserEvents.Data
     field.mouseMoveWrapper = mouseMoveWrapper
     field.mouseUpWrapper = mouseUpWrapper
 
-    const unbind = vi.spyOn(Blockly.browserEvents, 'unbind').mockImplementation(() => {})
+    const unbind = vi.spyOn(Blockly.browserEvents, 'unbind').mockReturnValue(() => {})
 
     field.onMouseUp()
+    expect(field.mouseMoveWrapper).toBeUndefined()
+    expect(field.mouseUpWrapper).toBeUndefined()
+
     field.dispose()
 
     expect(unbind).toHaveBeenCalledTimes(2)
+    expect(unbind).toHaveBeenCalledWith(mouseMoveWrapper)
+    expect(unbind).toHaveBeenCalledWith(mouseUpWrapper)
+  })
+
+  it('does not unbind drag listeners again on a second mouseup', () => {
+    const field = makeField()
+    const mouseMoveWrapper = [{}] as Blockly.browserEvents.Data
+    const mouseUpWrapper = [{}] as Blockly.browserEvents.Data
+    field.mouseMoveWrapper = mouseMoveWrapper
+    field.mouseUpWrapper = mouseUpWrapper
+
+    const unbind = vi.spyOn(Blockly.browserEvents, 'unbind').mockReturnValue(() => {})
+
+    field.onMouseUp()
+    field.onMouseUp()
+
+    expect(unbind).toHaveBeenCalledTimes(2)
+    expect(unbind).toHaveBeenCalledWith(mouseMoveWrapper)
+    expect(unbind).toHaveBeenCalledWith(mouseUpWrapper)
+  })
+
+  it('unbinds all wrappers on dispose during a drag', () => {
+    const field = makeField()
+    const mouseDownWrapper = [{}] as Blockly.browserEvents.Data
+    const mouseMoveWrapper = [{}] as Blockly.browserEvents.Data
+    const mouseUpWrapper = [{}] as Blockly.browserEvents.Data
+    field.mouseDownWrapper_ = mouseDownWrapper
+    field.mouseMoveWrapper = mouseMoveWrapper
+    field.mouseUpWrapper = mouseUpWrapper
+
+    const unbind = vi.spyOn(Blockly.browserEvents, 'unbind').mockReturnValue(() => {})
+
+    field.dispose()
+
+    expect(field.mouseDownWrapper_).toBeUndefined()
+    expect(field.mouseMoveWrapper).toBeUndefined()
+    expect(field.mouseUpWrapper).toBeUndefined()
+    expect(unbind).toHaveBeenCalledTimes(3)
+    expect(unbind).toHaveBeenCalledWith(mouseDownWrapper)
+    expect(unbind).toHaveBeenCalledWith(mouseMoveWrapper)
+    expect(unbind).toHaveBeenCalledWith(mouseUpWrapper)
+  })
+
+  it('does not unbind wrappers again on a second dispose', () => {
+    const field = makeField()
+    const mouseDownWrapper = [{}] as Blockly.browserEvents.Data
+    const mouseMoveWrapper = [{}] as Blockly.browserEvents.Data
+    const mouseUpWrapper = [{}] as Blockly.browserEvents.Data
+    field.mouseDownWrapper_ = mouseDownWrapper
+    field.mouseMoveWrapper = mouseMoveWrapper
+    field.mouseUpWrapper = mouseUpWrapper
+
+    const unbind = vi.spyOn(Blockly.browserEvents, 'unbind').mockReturnValue(() => {})
+
+    field.dispose()
+    field.dispose()
+
+    expect(unbind).toHaveBeenCalledTimes(3)
+    expect(unbind).toHaveBeenCalledWith(mouseDownWrapper)
     expect(unbind).toHaveBeenCalledWith(mouseMoveWrapper)
     expect(unbind).toHaveBeenCalledWith(mouseUpWrapper)
   })


### PR DESCRIPTION
### Resolves

Follow-up to #3568.

### Proposed Changes

In `tests/unit/scratch_field_angle.test.ts`:

- Strengthen the existing `onMouseUp` test with `toBeUndefined` checks on `mouseMoveWrapper` and `mouseUpWrapper`, asserting the wrapper-cleared contract directly rather than inferring it from `unbind` call count.
- Add `does not unbind drag listeners again on a second mouseup`: two `onMouseUp()` calls produce two `unbind` calls, not four.
- Add `unbinds all wrappers on dispose during a drag`: covers `mouseDownWrapper_` cleanup, which the original test never set up.
- Add `does not unbind wrappers again on a second dispose`: two `dispose()` calls produce three `unbind` calls (one per wrapper), not six.
- Replace `mockImplementation(() => {})` with `mockReturnValue(() => {})` at the four spy sites. `Blockly.browserEvents.unbind` returns the unbound listener function, not `void`; the `mockImplementation` form was a pre-existing type mismatch.

### Reason for Changes

The original test covered the onMouseUp-then-dispose path with `mouseMoveWrapper` and `mouseUpWrapper` set. Three gaps remained: `mouseDownWrapper_` was never exercised, `onMouseUp()` and `dispose()` idempotency under repeated calls was untested, and the wrapper-cleared state was asserted only via `unbind` call count.

Each new assertion was verified against the pre-fix source at commit `2c290d27`; all four tests fail under pre-fix code, each on a distinct assertion.

### Test Coverage

`npx vitest run tests/unit/scratch_field_angle.test.ts` passes (4/4); `npm run test:lint` is clean.